### PR TITLE
Add Github CI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,25 @@
+name: Documentation
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  Documentation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-docs.txt
+    - name: Set up Git
+      run: |
+        git config user.name ${{ github.actor }}
+        git config user.email ${{ github.actor }}@users.noreply.github.com
+    - name: Build documentation
+      run: |
+        git fetch origin gh-pages
+        mike deploy --push master

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,6 @@
 name: Documentation
 
 on:
-  pull_request:
   push:
     branches: [master]
 
@@ -22,4 +21,4 @@ jobs:
     - name: Build documentation
       run: |
         git fetch origin gh-pages
-        mike deploy --push master
+        mike deploy --push --update-aliases master

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,4 +21,5 @@ jobs:
     - name: Build documentation
       run: |
         git fetch origin gh-pages
-        mike deploy --push --update-aliases master
+        mike delete master
+        mike deploy --push master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,36 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  PyPI:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,3 +34,21 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+
+  Documentation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-docs.txt
+    - name: Set up Git
+      run: |
+        git config user.name ${{ github.actor }}
+        git config user.email ${{ github.actor }}@users.noreply.github.com
+    - name: Build documentation
+      run: |
+        git fetch origin gh-pages
+        mike deploy --push --no-redirect --update-aliases $GITHUB_REF_NAME latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,3 +14,17 @@ jobs:
     - uses: pre-commit/action@v2.0.3
       with:
         extra_args: --all-files
+
+  Pytest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        scripts/install.sh
+        pip install pyspark
+    - name: Test with Pytest
+      run: |
+        python -m pytest --cov edsnlp --junitxml=report.xml --html=report.html --self-contained-html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: Tests and Linting
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  Linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,3 +12,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args: --all-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,3 +28,12 @@ jobs:
     - name: Test with Pytest
       run: |
         python -m pytest --cov edsnlp --junitxml=report.xml --html=report.html --self-contained-html
+
+  Installation:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Install library
+      run: |
+        pip install .

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,16 @@ setup(
     version=get_version("edsnlp/__init__.py"),
     author="Data Science - DSI APHP",
     author_email="basile.dura-ext@aphp.fr",
-    description="NLP tools for human consumption at AP-HP",
+    description=(
+        "A set of spaCy components to extract information "
+        "from clinical notes written in French."
+    ),
+    url="https://github.com/aphp/edsnlp",
+    project_urls={
+        "Documentation": "https://aphp.github.io/edsnlp",
+        "Demo": "https://aphp.github.io/edsnlp/demo",
+        "Bug Tracker": "https://github.com/aphp/edsnlp/issues",
+    },
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.6",


### PR DESCRIPTION
Port Gitlab-CI workflows to Github actions.

Tests:
- [x] Linting (using pre-commit)
- [x] Testing with Pytest
- [x] Installation

Documentation:
- [x] Recreate the `master` documentation on every push
- [x] Create a new documentation on stable release/tag creation, `latest` points to the latest stable release

Packaging:
- [x] Upload to PyPI