### PR TITLE
fix: ensures the package is installed into the same Python you'll be running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ If it's your first time with spaCy, we recommend you familiarise yourself with s
 ### Installation
 
 You can install EDS-NLP via `pip`:
-
+ 
 ```shell
-python -m pip install edsnlp
+python<version> -m pip install edsnlp
 ```
 
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-python -m pip install edsnlp==0.4.0
+python<version> -m pip install edsnlp==0.4.0
 ```
 
 ### A first pipeline

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ If it's your first time with spaCy, we recommend you familiarise yourself with s
 You can install EDS-NLP via `pip`:
 
 ```shell
-pip install edsnlp
+python -m pip install edsnlp
 ```
 
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.4.0
+python -m pip install edsnlp==0.4.0
 ```
 
 ### A first pipeline


### PR DESCRIPTION
If you're in a venv you don't need this (it is likely that some people will not think to create one ..).

It seems appropriate to recall as a best practice that if you install external packages you should always do it in a venv to avoid confusion.