### PR TITLE
Fix dateparser/regex issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.4.1
+pip install edsnlp==0.4.2
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.4.2 (pending)
+## v0.4.2
 
 - Fix issue with `dateparser` library (see scrapinghub/dateparser#1045)
 - Fix `attr` issue in the `advanced-regex` pipelin

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.2 (pending)
+
+- Fix issue with `dateparser` library (see scrapinghub/dateparser#1045)
+
 ## v0.4.1
 
 - Added support to Koalas DataFrames in the `edsnlp.processing` pipe.

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ## v0.4.2 (pending)
 
 - Fix issue with `dateparser` library (see scrapinghub/dateparser#1045)
+- Fix `attr` issue in the `advanced-regex` pipelin
+- Add documentation for `eds.covid`
+- Update the demo with an explanation for the regex
 
 ## v0.4.1
 

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,2 @@
-edsnlp==0.4.0
+edsnlp==0.4.2
 streamlit

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Installed
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.4.1
+pip install edsnlp==0.4.2
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -6,6 +6,6 @@ from pathlib import Path
 
 from . import extensions
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 BASE_DIR = Path(__file__).parent

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ decorator
 loguru
 numpy
 pandas>=1.1
+regex<=2022.3.2  # due to dateparser bug issue 1045
 scikit-learn>=1.0.0
 spacy>=3.1<4.0.0
 tqdm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Update requirements to fix bug introduced by a version bump in regex. Related to scrapinghub/dateparser#1045

The `regex` module is constrained to avoid `v2022.3.15` and up.

Bump version to fix the issue immediately.

<!--- Describe the changes. -->

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
