### PR TITLE
Speed up regex matching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v0.4.3 (pending)
+## v0.4.4 (pending)
 
 - Improve the speed of char replacement pipelines (accents and quotes)
+- Improve the speed of the regex matcher
 
 ## v0.4.3
 

--- a/edsnlp/matchers/regex.py
+++ b/edsnlp/matchers/regex.py
@@ -1,5 +1,6 @@
 import re
 from bisect import bisect_left
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from loguru import logger
@@ -8,6 +9,7 @@ from spacy.tokens import Doc, Span, Token
 from .utils import Patterns, alignment, get_text, offset
 
 
+@lru_cache(32)
 def get_first_included(doclike: Union[Doc, Span]) -> Token:
     for token in doclike:
         if not token._.excluded:


### PR DESCRIPTION
## Description

This PR improves the speed of the regex matcher used in multiple pipelines when the `ignore_excluded` argument is set to True by caching the `get_first_included` function.  

Benchmark on 10000 clinical docs with 70 regexes

| Pipelines | Time |
| :--------- | ----: |
| RegexMatcher (before) | 110s |
| RegexMatcher (this PR) |  40s |

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
