### PR TITLE
Cap Jinja2 version to fix documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.4.3 (pending)
 
+- Cap Jinja2 version to fix mkdocs
 - Adding the possibility to add context in the processing module
 - Improve the speed of char replacement pipelines (accents and quotes)
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,4 @@
+Jinja2>=2.10.2<=3.0.3
 mike
 mkdocs-autorefs==0.3.1
 mkdocs-bibtex


### PR DESCRIPTION
## Description

Jinja2 v3.1.0 has a breaking change and mkdocs has no cap on its Jinja2 dependency.
This PR fixes the issue in the meantime.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
