### PR TITLE
EDS Language

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.5 (pending)
+
+- Add a new `eds` language to better fit French clinical documents and improve speed.
+
 ## v0.4.4
 
 - Add `measures` pipeline

--- a/demo/app.py
+++ b/demo/app.py
@@ -39,7 +39,7 @@ CODE = """
 import spacy
 
 # Declare the pipeline
-nlp = spacy.blank("fr")
+nlp = spacy.blank("eds")
 
 # General-purpose components
 nlp.add_pipe("eds.normalizer")
@@ -76,7 +76,7 @@ def load_model(
     pipes = []
 
     # Declare the pipeline
-    nlp = spacy.blank("fr")
+    nlp = spacy.blank("eds")
     nlp.add_pipe("eds.normalizer")
     nlp.add_pipe("eds.sentences")
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -7,13 +7,13 @@ the `fr` tokenizer. The main differences lie in the tokenization process.
 
 A comparison of the two tokenization methods is demonstrated below:
 
-| Example               | FrenchLanguage             | EDSLanguage                       |
-| --------------------- | -------------------------- | --------------------------------- |
-| `ACR 5`               | [`ACR5`]                   | [`ACR`, `5`]                      |
-| `26.5`                | [`26.5`]                   | [`26`, `.`, `5`]                  |
-| `26.5/`               | [`26.5/`]                  | [`26`, `.`, `5`, `/`]             |
-| `\n    \n CONCLUSION` | [`\n    \n`, `CONCLUSION]` | [`\n`, `   `, `\n`, `CONCLUSION`] |
-| `l'artère`            | [`l'`, `artère`]           | [`l'`, `artère`] (same)           |
+| Example               | FrenchLanguage             | EDSLanguage                |
+| --------------------- | -------------------------- | -------------------------- |
+| `ACR 5`               | [`ACR5`]                   | [`ACR`, `5`]               |
+| `26.5`                | [`26.5`]                   | [`26`, `.`, `5`]           |
+| `26.5/`               | [`26.5/`]                  | [`26`, `.`, `5`, `/`]      |
+| `\n \n CONCLUSION`    | [`\n \n`, `CONCLUSION]`    | [`\n`, `\n`, `CONCLUSION`] |
+| `l'artère`            | [`l'`, `artère`]           | [`l'`, `artère`] (same)    |
 
 To instantiate one of the two languages, you can call the `spacy.blank` method.
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,8 +1,8 @@
 # Languages
 
 
-In addition to the standard spacy FrenchLanguage (`fr`), EDS-NLP offers a new language better fit
-for French clinical documents: EDSLanguage (`eds`). Additionally, the EDSLanguage document creation should be around 5-6 times faster than
+In addition to the standard spaCy `FrenchLanguage` (`fr`), EDS-NLP offers a new language better fit
+for French clinical documents: `EDSLanguage` (`eds`). Additionally, the `EDSLanguage` document creation should be around 5-6 times faster than
 the `fr` tokenizer. The main differences lie in the tokenization process.
 
 A comparison of the two tokenization methods is demonstrated below:

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,34 @@
+# Languages
+
+
+In addition to the standard spacy FrenchLanguage (`fr`), EDS-NLP offers a new language better fit
+for French clinical documents: EDSLanguage (`eds`). Additionally, the EDSLanguage document creation should be around 5-6 times faster than
+the `fr` tokenizer. The main differences lie in the tokenization process.
+
+A comparison of the two tokenization methods is demonstrated below:
+
+| Example               | FrenchLanguage             | EDSLanguage                       |
+| --------------------- | -------------------------- | --------------------------------- |
+| `ACR 5`               | [`ACR5`]                   | [`ACR`, `5`]                      |
+| `26.5`                | [`26.5`]                   | [`26`, `.`, `5`]                  |
+| `26.5/`               | [`26.5/`]                  | [`26`, `.`, `5`, `/`]             |
+| `\n    \n CONCLUSION` | [`\n    \n`, `CONCLUSION]` | [`\n`, `   `, `\n`, `CONCLUSION`] |
+| `l'artère`            | [`l'`, `artère`]           | [`l'`, `artère`] (same)           |
+
+To instantiate one of the two languages, you can call the `spacy.blank` method.
+
+=== "EDSLanguage"
+
+    ```python
+    import spacy
+
+    nlp = spacy.blank("eds")
+    ```
+
+=== "FrenchLanguage"
+
+    ```python
+    import spacy
+
+    nlp = spacy.blank("fr")
+    ```

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -5,6 +5,7 @@ EDS-NLP
 from pathlib import Path
 
 from . import extensions
+from .language import *
 
 __version__ = "0.4.4"
 

--- a/edsnlp/language.py
+++ b/edsnlp/language.py
@@ -1,0 +1,119 @@
+import regex
+import spacy
+from spacy import Vocab
+from spacy.lang.fr import French, FrenchDefaults
+from spacy.lang.fr.lex_attrs import LEX_ATTRS
+from spacy.lang.fr.stop_words import STOP_WORDS
+from spacy.lang.fr.syntax_iterators import SYNTAX_ITERATORS
+from spacy.tokens import Doc
+from spacy.util import DummyTokenizer
+
+
+class EDSDefaults(FrenchDefaults):
+    """
+    Defaults for the EDSLanguage class
+    Mostly identical to the FrenchDefaults, but
+    without tokenization info
+    """
+
+    tokenizer_exceptions = {}
+    infixes = []
+    lex_attr_getters = LEX_ATTRS
+    syntax_iterators = SYNTAX_ITERATORS
+    stop_words = STOP_WORDS
+    config = FrenchDefaults.config.merge(
+        {
+            "nlp": {"tokenizer": {"@tokenizers": "eds.tokenizer"}},
+        }
+    )
+
+
+@spacy.registry.languages("eds")
+class EDSLanguage(French):
+    """
+    French clinical language.
+    It is shipped with the `EDSTokenizer` tokenizer that better handles
+    tokenization for French clinical documents
+    """
+
+    lang = "eds"
+    Defaults = EDSDefaults
+    default_config = Defaults
+
+
+class EDSTokenizer(DummyTokenizer):
+    def __init__(self, vocab: Vocab) -> None:
+        """
+        Tokenizer class for French clinical documents.
+        It better handles tokenization around:
+        - numbers (ACR5 -> [ACR, 5] instead of [ACR5]
+        - newlines (\n \n  \n) -> [\n, \n, \n] instead of [\n \n  \n]
+        and should be around 5-6 times faster than its standard French counterpart.
+
+        Parameters
+        ----------
+        vocab: Vocab
+            The spacy vocabulary
+        """
+        self.vocab = vocab
+        punct = "[:punct:]" + "\"'ˊ＂〃ײ᳓″״‶˶ʺ“”˝"
+        num_like = r"[\d]+"  # (?:[:.,]\d+)*"
+        default = rf"[^\d{punct}'\n ]+(?:['ˊ](?=[[:alpha:]]))?"
+        self.word_regex = regex.compile(
+            rf"({num_like}|[{punct}]|\n|[ ]+|{default})([ ])?"
+        )
+
+    def __call__(self, text: str) -> Doc:
+        """
+        Tokenizes the text using the EDSTokenizer
+
+        Parameters
+        ----------
+        text: str
+
+        Returns
+        -------
+        Doc
+
+        """
+        last = 0
+        words = []
+        whitespaces = []
+        for match in self.word_regex.finditer(text):
+            begin, end = match.start(), match.end()
+            if last != begin:
+                print(
+                    "Error",
+                    "last",
+                    last,
+                    "begin",
+                    begin,
+                    text[last - 10 : last]
+                    + "|"
+                    + text[last:begin]
+                    + "|"
+                    + text[begin : begin + 10],
+                )
+            last = end
+            words.append(match.group(1))
+            whitespaces.append(bool(match.group(2)))
+        return Doc(self.vocab, words=words, spaces=whitespaces)
+
+
+@spacy.registry.tokenizers("eds.tokenizer")
+def create_eds_tokenizer():
+    """
+    Creates a factory that returns new EDSTokenizer instances
+
+    Returns
+    -------
+    EDSTokenizer
+    """
+
+    def eds_tokenizer_factory(nlp):
+        return EDSTokenizer(nlp.vocab)
+
+    return eds_tokenizer_factory
+
+
+__all__ = ["EDSLanguage"]

--- a/edsnlp/language.py
+++ b/edsnlp/language.py
@@ -1,5 +1,6 @@
 import regex
 import spacy
+from loguru import logger
 from spacy import Vocab
 from spacy.lang.fr import French, FrenchDefaults
 from spacy.lang.fr.lex_attrs import LEX_ATTRS
@@ -82,13 +83,10 @@ class EDSTokenizer(DummyTokenizer):
         for match in self.word_regex.finditer(text):
             begin, end = match.start(), match.end()
             if last != begin:
-                print(
-                    "Error",
-                    "last",
-                    last,
-                    "begin",
-                    begin,
-                    text[last - 10 : last]
+                logger.warning(
+                    "Missed some characters during"
+                    + f" tokenization between {last} and {begin}: "
+                    + text[last - 10 : last]
                     + "|"
                     + text[last:begin]
                     + "|"

--- a/edsnlp/language.py
+++ b/edsnlp/language.py
@@ -47,8 +47,8 @@ class EDSTokenizer(DummyTokenizer):
         """
         Tokenizer class for French clinical documents.
         It better handles tokenization around:
-        - numbers (ACR5 -> [ACR, 5] instead of [ACR5]
-        - newlines (\n \n  \n) -> [\n, \n, \n] instead of [\n \n  \n]
+        - numbers: "ACR5" -> ["ACR", "5"] instead of ["ACR5"]
+        - newlines: "\n \n \n" -> ["\n", "\n", "\n"] instead of ["\n \n \n"]
         and should be around 5-6 times faster than its standard French counterpart.
 
         Parameters
@@ -58,7 +58,7 @@ class EDSTokenizer(DummyTokenizer):
         """
         self.vocab = vocab
         punct = "[:punct:]" + "\"'ˊ＂〃ײ᳓″״‶˶ʺ“”˝"
-        num_like = r"[\d]+"  # (?:[:.,]\d+)*"
+        num_like = r"[\d]+"
         default = rf"[^\d{punct}'\n ]+(?:['ˊ](?=[[:alpha:]]))?"
         self.word_regex = regex.compile(
             rf"({num_like}|[{punct}]|\n|[ ]+|{default})([ ])?"

--- a/edsnlp/pipelines/misc/dates/patterns/__init__.py
+++ b/edsnlp/pipelines/misc/dates/patterns/__init__.py
@@ -28,7 +28,7 @@ raw_delimiter_pattern = make_pattern(raw_delimiters)
 raw_delimiter_with_spaces_pattern = make_pattern(raw_delimiters + [r"[^\S\r\n]+"])
 delimiter_pattern = make_pattern(delimiters)
 
-ante_num_pattern = f"(?<!{raw_delimiter_pattern})"
+ante_num_pattern = f"(?<!.(?:{raw_delimiter_pattern})|[0-9][.,])"
 post_num_pattern = f"(?!{raw_delimiter_pattern})"
 
 full_year_pattern = ante_num_pattern + fy_pattern + post_num_pattern
@@ -102,7 +102,7 @@ since_pattern = [
 
 false_positive_pattern = make_pattern(
     [
-        r"(\d+" + delimiter_pattern + r"){3,}\d+",
+        r"(\d+" + delimiter_pattern + r"){3,}\d+(?!:\d\d)\b",
         r"\d\/\d",
     ]
 )

--- a/edsnlp/pipelines/misc/sections/sections.py
+++ b/edsnlp/pipelines/misc/sections/sections.py
@@ -74,6 +74,7 @@ class Sections(GenericMatcher):
 
         if sections is None:
             sections = patterns.sections
+        sections = dict(sections)
 
         self.add_patterns = add_patterns
         if add_patterns:

--- a/edsnlp/processing/parallel.py
+++ b/edsnlp/processing/parallel.py
@@ -8,7 +8,7 @@ from spacy import Language
 from .helpers import check_spacy_version_for_context
 from .simple import ExtensionSchema, _flatten, _pipe_generator
 
-nlp = spacy.blank("fr")
+nlp = spacy.blank("eds")
 
 
 def _define_nlp(new_nlp: Language):

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 
 from .helpers import check_spacy_version_for_context
 
-nlp = spacy.blank("fr")
+nlp = spacy.blank("eds")
 
 ExtensionSchema = Union[
     str,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - pipelines/ner/index.md
       - pipelines/ner/score.md
       - pipelines/ner/covid.md
+  - languages.md
   - Connectors:
     - utilities/connectors/index.md
     - utilities/connectors/brat.md

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -8,7 +8,7 @@ import edsnlp
 
 app = FastAPI(title="EDS-NLP", version=edsnlp.__version__)
 
-nlp = spacy.blank("fr")
+nlp = spacy.blank("eds")
 
 nlp.add_pipe("eds.sentences")
 

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,6 @@ setup(
     },
     entry_points={
         "spacy_factories": factories,
+        "spacy_languages": ["eds = edsnlp.language:EDSLanguage"],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,14 @@ from pytest import fixture
 import edsnlp.components  # noqa
 
 
+@fixture(scope="session", params=["eds", "fr"])
+def lang(request):
+    return request.param
+
+
 @fixture(scope="session")
-def nlp():
-    model = spacy.blank("fr")
+def nlp(lang):
+    model = spacy.blank(lang)
 
     model.add_pipe("eds.normalizer")
 
@@ -61,8 +66,8 @@ def nlp():
 
 
 @fixture
-def blank_nlp():
-    model = spacy.blank("fr")
+def blank_nlp(lang):
+    model = spacy.blank(lang)
     model.add_pipe("eds.sentences")
     return model
 

--- a/tests/pipelines/misc/test_measure.py
+++ b/tests/pipelines/misc/test_measure.py
@@ -1,4 +1,3 @@
-import spacy
 from pytest import fixture, raises
 from spacy.language import Language
 
@@ -10,13 +9,6 @@ text = (
     "Une autre tumeur plus petite fait 2 par 1mm.\n"
     "Les trois éléments font 8, 13 et 15dm."
 )
-
-
-@fixture
-def blank_nlp():
-    model = spacy.blank("fr")
-    model.add_pipe("eds.sentences")
-    return model
 
 
 @fixture

--- a/tests/pipelines/misc/test_reason.py
+++ b/tests/pipelines/misc/test_reason.py
@@ -10,8 +10,8 @@ Antécédents médicaux :
 Premier épisode d'asthme en mai 2018."""
 
 
-def test_reason():
-    nlp = spacy.blank("fr")
+def test_reason(lang):
+    nlp = spacy.blank(lang)
     # Extraction d'entités nommées
     nlp.add_pipe(
         "matcher",

--- a/tests/pipelines/qualifiers/conftest.py
+++ b/tests/pipelines/qualifiers/conftest.py
@@ -2,7 +2,7 @@ from pytest import fixture
 
 
 @fixture(params=[True, False])
-def blank_nlp(blank_nlp, request):
+def blank_nlp(blank_nlp, request, lang):
     if request.param:
         blank_nlp.add_pipe("normalizer")
     return blank_nlp

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -61,9 +61,9 @@ def note(module: DataFrameModules):
 
 
 @pytest.fixture
-def model():
+def model(lang):
     # Creates the spaCy instance
-    nlp = spacy.blank("fr")
+    nlp = spacy.blank(lang)
 
     # Normalisation of accents, case and other special characters
     nlp.add_pipe("eds.normalizer")

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,0 +1,43 @@
+import pytest
+import spacy
+from spacy.lang.fr.lex_attrs import like_num
+
+
+def test_eds_tokenizer_handles_long_text():
+    text = """Témoin interne : + ; témoin externe : +
+- Récepteurs aux œstrogènes : tous les élements sont marqués (3+).
+- Récepteurs à la progestérone : 40% sont marqués (intensité 2+).
+- Anti-Cerb B2: 0% des cellules carcinomateuses présentent
+un marquage membranaire complet.
+CONCLUSION`: ========
+-Carcinome mammaire infiltrant du quadrant inféro-externe,
+de 25 mm size de grade II de
+malignité selon Elston et Ellis (3+2+1), sans composante
+Score ACR5 de chaque coté`'.
+On se donne rendez-vous pour le 23/11/1967.
+"""
+    nlp = spacy.blank("eds")
+    tokens = nlp(text)
+    assert (
+        [t.text_with_ws for t in tokens]
+        == """Témoin |interne |: |+ |; |témoin |externe |: |+|
+|- |Récepteurs |aux |œstrogènes |: |tous |les |élements |sont |marqués |(|3|+|)|.|
+|- |Récepteurs |à |la |progestérone |: |40|% |sont |marqués |(|intensité |2|+|)|.|
+|- |Anti|-|Cerb |B|2|: |0|% |des |cellules |carcinomateuses |présentent|
+|un |marquage |membranaire |complet|.|
+|CONCLUSION|`|: |=|=|=|=|=|=|=|=|
+|-|Carcinome |mammaire |infiltrant |du |quadrant |inféro|-|externe|,|
+|de |25 |mm |size |de |grade |II |de|
+|malignité |selon |Elston |et |Ellis |(|3|+|2|+|1|)|, |sans |composante|
+|Score |ACR|5 |de |chaque |coté|`|'|.|
+|On |se |donne |rendez|-|vous |pour |le |23|/|11|/|1967|.|
+""".split(
+            "|"
+        )
+    )
+
+
+@pytest.mark.parametrize("word", ["onze", "onzième"])
+def test_eds_lex_attrs_capitals(word):
+    assert like_num(word)
+    assert like_num(word.upper())


### PR DESCRIPTION
## Description

This PR introduces a new Language class better fit for French clinical documents. 
It is shipped with the `EDSTokenizer` tokenizer that handles specific tokenization cases for:
  - numbers: `ACR5` -> `[ACR, 5]` instead of `[ACR5]`
  - newlines: `\n \n  \n` -> `[\n, \n, \n]` instead of `[\n \n  \n]`
Moreover, this tokenizer should be around 5-6 times faster than its standard French counterpart.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).