### PR TITLE
Measures pipeline

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.4.4 (pending)
 
+- Add `measures` pipeline
 - Cap Jinja2 version to fix mkdocs
 - Adding the possibility to add context in the processing module
 - Improve the speed of char replacement pipelines (accents and quotes)

--- a/docs/pipelines/misc/measures.md
+++ b/docs/pipelines/misc/measures.md
@@ -166,7 +166,7 @@ The pipeline can be configured using the following parameters :
 
 | Parameter         | Explanation                                      | Default                           |
 | ----------------- | ------------------------------------------------ | --------------------------------- |
-| `measures`        | The names of the measures to extract, registered in `spacy.misc.registry`          | `["eds.measures.size", "eds.measures.weight", "eds.measures.angle"]` |
+| `measures`        | The names of the measures to extract, registered in `spacy.registry.misc`          | `["eds.measures.size", "eds.measures.weight", "eds.measures.angle"]` |
 | `ignore_excluded` | Whether to ignore excluded tokens for matching           | `False`   |
 | `attr`            | spaCy attribute to match on, eg `NORM` or `TEXT` | `"NORM"`                          |
 

--- a/docs/pipelines/misc/measures.md
+++ b/docs/pipelines/misc/measures.md
@@ -138,14 +138,14 @@ class CustomSize(SimpleMeasure):
         """
         Class method to create an instance from the match groups
 
-        int_part: str
-            The integer part of the match (eg 12 in 12 metres 50 or 12.50metres)
-        dec_part: str
-            The decimal part of the match (eg 50 in 12 metres 50 or 12.50metres)
-        unit: str
-            The normalized variant of the unit (eg "m" for 12 metre 50)
-        infix: bool
-            Whether the unit was in the before (True) or after (False) the decimal part
+        int_part : str
+            The integer part of the match (eg `12` in `12 metres 50` or `12.50metres`)
+        dec_part : str
+            The decimal part of the match (eg `50` in `12 metres 50` or `12.50metres`)
+        unit : str
+            The normalized variant of the unit (eg `m` for `12 metre 50`)
+        infix : bool
+            Whether the unit was in the before (`True`) or after (`False`) the decimal part
         """
         result = float("{}.{}".format(int_part, dec_part))
         return cls(result, unit)

--- a/docs/pipelines/misc/measures.md
+++ b/docs/pipelines/misc/measures.md
@@ -1,0 +1,175 @@
+# Measures
+
+The `eds.measures` pipeline's role is to detect and normalise numerical measures within a medical document.
+We use simple regular expressions to extract and normalize measures, and use `Measure` classes to store them.
+
+!!! warning
+
+    The ``measures`` pipeline is still in active development and has not been rigorously validated.
+    If you come across a measure expression that goes undetected, please file an issue !
+
+## Scope
+
+The `eds.measures` pipeline can extract simple (eg `3cm`) and composite (eg `3 x 2cm`) measures.
+It can detect elliptic enumerations (eg `32, 33 et 34kg`) of measures of the same type and split the measures accordingly.
+
+The normalized value can then be accessed via the `span._.value` attribute and converted on the fly to a desired unit.
+
+The current pipeline supports the following measures:
+
+| Measure name         | Example           | Units                       | Allows composite measures |
+| -------------------- | ----------------- | --------------------------- | ------------------------- |
+| `eds.measures.size`   | `12m50`, `12.50m` | `mm`, `cm`, `dm`, `m`       | YES                       |
+| `eds.measures.weight` | `12kg`, `1g300`   | `mg`, `cg`, `dg`, `g`, `kg` | NO                        |
+| `eds.measures.angle`  | `8h`, `8h30`      | `h`                         | NO                        |
+
+
+## Usage
+
+```python
+import spacy
+
+nlp = spacy.blank("fr")
+nlp.add_pipe(
+    "eds.measures", config=dict(measures=["eds.measures.size", "eds.measures.weight"])
+)
+
+text = (
+    "Le patient est admis hier, fait 1m78 pour 76kg. "
+    "Les deux nodules bénins sont larges de 1,2 et 2.4mm."
+    "La tumeur fait 1 x 2cm."
+)
+
+doc = nlp(text)
+
+measures = doc.spans["measures"]
+# Out: [1m78, 76kg, 1,2, 2.4mm, 1 x 2cm]
+
+measures[0]
+# Out: "1m78"
+
+str(measures[0]._.value)
+# Out: "1.78m"
+
+measures[0]._.value.cm
+# Out: 178.0
+
+measures[-3]
+# Out: "1,2"
+
+str(measures[-3]._.value)
+# Out: "1.2mm"
+
+str(measures[-3]._.value.mm)
+# Out: 1.2
+
+str(measures[-1])
+# Out: 1 x 2cm
+
+str(measures[-1]._.value)
+# Out: 1.0cm x 2.0cm
+
+str(measures[-1]._.value.mm)
+# Out: (10.0, 20.0)
+
+# All measures, simple or composite, support iterable operations
+str(max(measures[-1]._.value))
+# Out: 2.0cm
+
+str(max(measures[0]._.value))
+# Out: 1.78m
+```
+
+## Custom measure
+
+You can declare a custom measure using the following code
+
+```python
+import spacy
+from edsnlp.pipelines.misc.measures import (
+    CompositeMeasure,
+    SimpleMeasure,
+    make_multi_getter,
+    make_simple_getter,
+)
+
+
+class CustomCompositeSize(CompositeMeasure):
+    mm = property(make_multi_getter("mm"))
+    cm = property(make_multi_getter("cm"))
+    dm = property(make_multi_getter("dm"))
+    m = property(make_multi_getter("m"))
+
+
+@spacy.registry.misc("eds.measures.custom_size")
+class CustomSize(SimpleMeasure):
+    # Leave to None if your custom size cannot be composed with others
+    COMPOSITE = CustomCompositeSize
+
+    # Optional integer number regex
+    INTEGER = r"(?:[0-9]+)"
+
+    # Optional conjunction regex to detect enumeration like "1, 2 et 3cm"
+    CONJUNCTIONS = "et|ou"
+
+    # Optional composer regex to detect composite measures like "1 par 2cm"
+    COMPOSERS = r"[x*]|par"
+
+    UNITS = {
+        # Map of the recognized units
+        "cm": {
+            # Regex to match prefixes of non abbreviated lexical forms
+            "prefix": "centim",
+            # Regex to match abbreviated lexical forms
+            "abbr": "cm",
+            # Scaling value to apply when converting values
+            # Only the ratio between different units matter
+            "value": 10,
+        },
+        "mm": {
+            "prefix": "mill?im",
+            "abbr": "mm",
+            "value": 1,
+        },
+    }
+
+    @classmethod
+    def parse(cls, int_part, dec_part, unit, infix=False):
+        """
+        Class method to create an instance from the match groups
+
+        int_part: str
+            The integer part of the match (eg 12 in 12 metres 50 or 12.50metres)
+        dec_part: str
+            The decimal part of the match (eg 50 in 12 metres 50 or 12.50metres)
+        unit: str
+            The normalized variant of the unit (eg "m" for 12 metre 50)
+        infix: bool
+            Whether the unit was in the before (True) or after (False) the decimal part
+        """
+        result = float("{}.{}".format(int_part, dec_part))
+        return cls(result, unit)
+
+    # Properties to access the numerical value of the measure
+    cm = property(make_simple_getter("cm"))
+    mm = property(make_simple_getter("mm"))
+```
+
+## Declared extensions
+
+The `eds.measures` pipeline declares a single [spaCy extension](https://spacy.io/usage/processing-pipelines#custom-components-attributes) on the `Span` object,
+the `value` attribute that is a `Measure` instance.
+
+## Configuration
+
+The pipeline can be configured using the following parameters :
+
+| Parameter         | Explanation                                      | Default                           |
+| ----------------- | ------------------------------------------------ | --------------------------------- |
+| `measures`        | The names of the measures to extract, registered in `spacy.misc.registry`          | `["eds.measures.size", "eds.measures.weight", "eds.measures.angle"]` |
+| `ignore_excluded` | Whether to ignore excluded tokens for matching           | `False`   |
+| `attr`            | spaCy attribute to match on, eg `NORM` or `TEXT` | `"NORM"`                          |
+
+## Authors and citation
+
+The `eds.measures` pipeline was developed by AP-HP's Data Science team.

--- a/edsnlp/matchers/regex.py
+++ b/edsnlp/matchers/regex.py
@@ -1,11 +1,11 @@
-import re
 from bisect import bisect_left
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import regex
 from loguru import logger
 from spacy.tokens import Doc, Span, Token
+
+from edsnlp.utils.regex import compile_regex, re
 
 from .utils import Patterns, alignment, get_text, offset
 
@@ -16,28 +16,6 @@ def get_first_included(doclike: Union[Doc, Span]) -> Token:
         if not token._.excluded:
             return token
     raise IndexError("The provided Span does not include any token")
-
-
-def compile_regex(reg):
-    """
-    This function tries to compile `reg`  using the `re` module, and
-    fallbacks to the `regex` module that is more permissive.
-
-    Parameters
-    ----------
-    reg: str
-
-    Returns
-    -------
-    Union[re.Pattern, regex.Pattern]
-    """
-    try:
-        return re.compile(reg)
-    except re.error:
-        try:
-            return regex.compile(reg)
-        except regex.error:
-            raise Exception("Could not compile: {}".format(repr(reg)))
 
 
 def create_span(

--- a/edsnlp/pipelines/factories.py
+++ b/edsnlp/pipelines/factories.py
@@ -11,6 +11,7 @@ from .core.normalizer.quotes.factory import create_component as quotes
 from .core.sentences.factory import create_component as sentences
 from .misc.consultation_dates.factory import create_component as consultation_dates
 from .misc.dates.factory import create_component as dates
+from .misc.measures.factory import create_component as measures
 from .misc.reason.factory import create_component as reason
 from .misc.sections.factory import create_component as sections
 from .ner.covid.factory import create_component as covid

--- a/edsnlp/pipelines/misc/measures/__init__.py
+++ b/edsnlp/pipelines/misc/measures/__init__.py
@@ -1,0 +1,4 @@
+from edsnlp.pipelines.misc.measures.measures import Measures
+from edsnlp.pipelines.misc.measures.patterns import *
+
+from . import factory

--- a/edsnlp/pipelines/misc/measures/factory.py
+++ b/edsnlp/pipelines/misc/measures/factory.py
@@ -1,0 +1,29 @@
+from typing import Dict, List, Union
+
+from spacy.language import Language
+
+from edsnlp.pipelines.misc.measures import Measures
+from edsnlp.utils.deprecation import deprecated_factory
+
+DEFAULT_CONFIG = dict(
+    attr="NORM",
+    ignore_excluded=False,
+    measures=["eds.measures.size", "eds.measures.weight", "eds.measures.angle"],
+)
+
+
+@deprecated_factory("measures", "eds.measures", default_config=DEFAULT_CONFIG)
+@Language.factory("eds.measures", default_config=DEFAULT_CONFIG)
+def create_component(
+    nlp: Language,
+    name: str,
+    measures: Union[str, List[str], Dict[str, Dict]],
+    attr: str,
+    ignore_excluded: bool,
+):
+    return Measures(
+        nlp,
+        measures=measures,
+        attr=attr,
+        ignore_excluded=ignore_excluded,
+    )

--- a/edsnlp/pipelines/misc/measures/factory.py
+++ b/edsnlp/pipelines/misc/measures/factory.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Union
 from spacy.language import Language
 
 from edsnlp.pipelines.misc.measures import Measures
-from edsnlp.utils.deprecation import deprecated_factory
 
 DEFAULT_CONFIG = dict(
     attr="NORM",

--- a/edsnlp/pipelines/misc/measures/factory.py
+++ b/edsnlp/pipelines/misc/measures/factory.py
@@ -12,7 +12,6 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("measures", "eds.measures", default_config=DEFAULT_CONFIG)
 @Language.factory("eds.measures", default_config=DEFAULT_CONFIG)
 def create_component(
     nlp: Language,

--- a/edsnlp/pipelines/misc/measures/measures.py
+++ b/edsnlp/pipelines/misc/measures/measures.py
@@ -1,0 +1,380 @@
+import abc
+from typing import Callable, Dict, Iterable, List, Tuple, Union
+
+import regex
+import spacy
+from spacy.language import Language
+from spacy.tokens import Doc, Span
+
+from edsnlp.matchers.regex import RegexMatcher
+from edsnlp.pipelines.base import BaseComponent
+from edsnlp.utils.filter import filter_spans
+
+
+def disj_capture(regexes, capture=True):
+    return "|".join(
+        ("(?P<{key}>{forms})" if capture else "{forms}").format(
+            key=key, forms="|".join(forms)
+        )
+        for key, forms in regexes.items()
+    )
+
+
+def rightmost_largest_sort_key(span):
+    return span.end, (len(span))
+
+
+def make_patterns(measure: "Measure") -> Dict[str, Union[List[str], str]]:
+    """
+    Build recognition and extraction patterns for a given Measure class
+
+    Parameters
+    ----------
+    measure: Measure class
+        The measure to build recognition and extraction patterns for
+
+    Returns
+    -------
+    {
+        "trigger": List[str],
+        "extraction": str,
+    }
+
+    """
+    unit_prefix_reg = disj_capture(
+        {key: [entry["prefix"]] for key, entry in measure.UNITS.items()},
+        capture=True,
+    )
+    unit_abbreviation_reg = disj_capture(
+        {key: [entry["abbr"]] for key, entry in measure.UNITS.items()},
+        capture=True,
+    )
+    unit_reg = rf"(?:(?:{unit_prefix_reg})[a-z]*|(?:{unit_abbreviation_reg})(?![a-z]))"
+
+    number_reg = rf"(?:{measure.INTEGER}(?:[,.]{measure.INTEGER})?)"
+    infix_measure_reg = rf"(?:{measure.INTEGER}{unit_reg}{measure.INTEGER})"
+
+    # Simple measure
+    simple_measure_reg = rf"{number_reg}\s*{unit_reg}"
+    trigger = [
+        simple_measure_reg,
+        infix_measure_reg,
+        # Factorized measures separated by a conjunction
+        rf"{number_reg}(?=(?:\s*[,]\s*{number_reg})*\s*"
+        rf"(?:{measure.CONJUNCTIONS})\s*{number_reg}\s*{unit_reg})",
+    ]
+    if measure.COMPOSITE:
+        # Factorized composite measures (3 x 2cm)
+        trigger.append(
+            rf"(?<![a-z]){number_reg}"
+            rf"(?:\s*(?:{measure.COMPOSERS})\s*{number_reg})*\s*{unit_reg}"
+        )
+        # Expanded composite measures (3cm x 2cm)
+        trigger.append(
+            rf"(?<![a-z])(?:{infix_measure_reg}|{simple_measure_reg})"
+            rf"(\s*(?:{measure.COMPOSERS})\s*"
+            rf"(?:{infix_measure_reg}|{simple_measure_reg}))*"
+        )
+
+    unit_reg_capture = (
+        rf"(?:(?:{unit_prefix_reg})[a-z]*|(?:{unit_abbreviation_reg})(?![a-z]))"
+    )
+
+    return {
+        "trigger": trigger,
+        "extraction": rf"(?P<int_part>{measure.INTEGER})\s*(?:[,.]|"
+        rf"{unit_reg_capture})?\s*(?P<dec_part>{measure.INTEGER})?",
+    }
+
+
+def make_simple_getter(name):
+    def getter(self):
+        """
+        Get a scaled numerical value of a measure
+
+        Parameters
+        ----------
+        self
+
+        Returns
+        -------
+        float
+        """
+        return self.value * self._get_scale_to(name)
+
+    return getter
+
+
+def make_multi_getter(name: str) -> Callable[["CompositeMeasure"], Tuple[float]]:
+    def getter(self) -> Tuple[float]:
+        """
+        Get a scaled numerical values of a multi-measure
+
+        Parameters
+        ----------
+        self
+
+        Returns
+        -------
+        float
+        """
+        return tuple(getattr(measure, name) for measure in self.measures)
+
+    return getter
+
+
+class Measure(abc.ABC):
+    INTEGER = r"(?:[0-9]+)"
+    CONJUNCTIONS = "et|ou"
+    COMPOSERS = r"[x*]|par"
+
+    UNITS = {}
+    COMPOSITE = None
+
+    @abc.abstractmethod
+    def __iter__(self) -> Iterable["SimpleMeasure"]:
+        """
+        Iter over items of the measure (only one for SimpleMeasure)
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        Iterable["SimpleMeasure"]
+        """
+
+    @abc.abstractmethod
+    def __getitem__(self, item) -> "SimpleMeasure":
+        """
+        Access items of the measure (only one for SimpleMeasure)
+
+        Parameters
+        ----------
+        item: int
+
+        Returns
+        -------
+        SimpleMeasure
+        """
+
+
+class SimpleMeasure(Measure):
+    def __init__(self, value, unit):
+        """
+        The SimpleMeasure class contains the value and unit
+        for a single non-composite measure
+
+        Parameters
+        ----------
+        value: float
+        unit: str
+        """
+        super().__init__()
+        self.value = value
+        self.unit = unit
+
+    @classmethod
+    @abc.abstractmethod
+    def parse(self, int_part, dec_part, unit, infix) -> "SimpleMeasure":
+        """
+        Class method to create an instance from the match groups
+
+        int_part: str
+            The integer part of the match (eg 12 in 12 metres 50 or 12.50metres)
+        dec_part: str
+            The decimal part of the match (eg 50 in 12 metres 50 or 12.50metres)
+        unit: str
+            The normalized variant of the unit (eg "m" for 12 metre 50)
+        infix: bool
+            Whether the unit was in the before (True) or after (False) the decimal part
+        """
+
+    def _get_scale_to(self, unit):
+        return self.UNITS[self.unit]["value"] / self.UNITS[unit]["value"]
+
+    def __iter__(self):
+        return iter((self,))
+
+    def __getitem__(self, item):
+        assert isinstance(item, int)
+        return [self][item]
+
+    def __str__(self):
+        return f"{self.value}{self.unit}"
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.value}, {repr(self.unit)})"
+
+    def __eq__(self, other: "SimpleMeasure"):
+        return getattr(self, other.unit) == other.value
+
+    def __lt__(self, other: "SimpleMeasure"):
+        return getattr(self, other.unit) < other.value
+
+    def __le__(self, other: "SimpleMeasure"):
+        return getattr(self, other.unit) <= other.value
+
+
+class CompositeMeasure(Measure):
+    """
+    The CompositeMeasure class contains a sequence
+    of multiple SimpleMeasure instances
+
+    Parameters
+    ----------
+    measures: List[SimpleMeasure]
+    """
+
+    def __init__(self, measures):
+        super().__init__()
+        self.measures = list(measures)
+
+    def __iter__(self):
+        return iter(self.measures)
+
+    def __getitem__(self, item):
+        assert isinstance(item, int)
+        res = self.measures[item]
+        return res
+
+    def __str__(self):
+        return " x ".join(map(str, self.measures))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({repr(self.measures)})"
+
+
+class Measures(BaseComponent):
+    """
+    Matcher component to extract measures.
+    A measures is most often composed of a number and a unit like
+    > 1,26 cm
+    The unit can also be positioned in place of the decimal dot/comma
+    > 1 cm 26
+    Some measures can be composite
+    > 1,26 cm x 2,34 mm
+    And sometimes they are factorized
+    > Les trois kystes mesurent 1, 2 et 3cm.
+
+    The recognized measures are stored in the "measures" SpanGroup.
+    Each span has a `Measure` object stored in the "value" extension attribute.
+
+    Parameters
+    ----------
+    nlp : Language
+        The SpaCy object.
+    measures : List[str]
+        The registry names of the measures to extract
+    attr : str
+        Whether to match on the text ('TEXT') or on the normalized text ('NORM')
+    ignore_excluded: bool
+        Whether to exclude pollution patterns when matching in the text
+    """
+
+    def __init__(
+        self,
+        nlp: Language,
+        measures: List[str],
+        attr: str,
+        ignore_excluded: bool,
+    ):
+
+        self.regex_matcher = RegexMatcher(
+            attr=attr,
+            ignore_excluded=ignore_excluded,
+        )
+
+        self.extraction_regexes = {}
+        self.measures: Dict[str, Measure] = {}
+        for name in measures:
+            cls: Measure = spacy.registry.misc.get(name)
+            self.measures[name] = cls
+            regexes = make_patterns(cls)
+            self.regex_matcher.add(name, regexes["trigger"])
+            self.extraction_regexes[name] = regexes["extraction"]
+
+        self.set_extensions()
+
+    @staticmethod
+    def set_extensions() -> None:
+        super(Measures, Measures).set_extensions()
+        if not Span.has_extension("value"):
+            Span.set_extension("value", default=None)
+
+    def __call__(self, doc: Doc) -> Doc:
+        """
+        Adds measures to document's "measures" SpanGroup.
+
+        Parameters
+        ----------
+        doc:
+            spaCy Doc object
+
+        Returns
+        -------
+        doc:
+            spaCy Doc object, annotated for extracted terms.
+        """
+
+        matches = dict(self.regex_matcher(doc, as_spans=True, return_groupdict=True))
+
+        # Filter spans by rightmost, largest spans first to handle cases like 1 m 50 kg
+        # while keeping the corresponding groupdicts
+        matches = {
+            match: matches[match]
+            for match in filter_spans(matches, sort_key=rightmost_largest_sort_key)
+        }
+
+        measures = []
+        for match, groupdict in matches.items():
+            measure_name = match.label_
+            extraction_regex = self.extraction_regexes[measure_name]
+
+            parsed_values = []
+
+            shared_unit_part = next(
+                (key for key, val in groupdict.items() if val is not None), None
+            )
+            for sub_match in regex.finditer(extraction_regex, match.text):
+                sub_groupdict = dict(sub_match.groupdict())
+
+                # Integer part of the match
+                int_part = sub_groupdict.pop("int_part")
+
+                # Decimal part of the match, if any
+                dec_part = sub_groupdict.pop("dec_part") or 0
+
+                # If the unit was not postfix (in cases like 1cm, or 1 et 2cm)
+                # the unit must be infix: we extract it now using non empty groupdict
+                # entries
+                infix_unit_part = next(
+                    (key for key, val in sub_groupdict.items() if val is not None),
+                    None,
+                )
+                unit_part = infix_unit_part or shared_unit_part
+
+                # Create one SimpleMeasure per submatch inside each match...
+                parsed_values.append(
+                    self.measures[measure_name].parse(
+                        int_part=int_part,
+                        dec_part=dec_part,
+                        unit=unit_part,
+                        infix=infix_unit_part is not None,
+                    )
+                )
+
+            # ... and compose theses measures together if there are more than one
+            measure = Span(doc, start=match.start, end=match.end, label=measure_name)
+            measure._.value = (
+                parsed_values[0]
+                if len(parsed_values) == 1
+                else self.measures[measure_name].COMPOSITE(parsed_values)
+                if self.measures[measure_name].COMPOSITE is not None
+                else parsed_values[-1]
+            )
+            measures.append(match)
+
+        doc.spans["measures"] = sorted(measures)
+
+        return doc

--- a/edsnlp/pipelines/misc/measures/measures.py
+++ b/edsnlp/pipelines/misc/measures/measures.py
@@ -340,10 +340,10 @@ class Measures(BaseComponent):
                 sub_groupdict = dict(sub_match.groupdict())
 
                 # Integer part of the match
-                int_part = sub_groupdict.pop("int_part")
+                int_part = sub_groupdict.pop("int_part", 0)
 
                 # Decimal part of the match, if any
-                dec_part = sub_groupdict.pop("dec_part") or 0
+                dec_part = sub_groupdict.pop("dec_part", 0) or 0
 
                 # If the unit was not postfix (in cases like 1cm, or 1 et 2cm)
                 # the unit must be infix: we extract it now using non empty groupdict

--- a/edsnlp/pipelines/misc/measures/patterns.py
+++ b/edsnlp/pipelines/misc/measures/patterns.py
@@ -1,0 +1,107 @@
+import spacy
+
+from edsnlp.pipelines.misc.measures.measures import (
+    CompositeMeasure,
+    SimpleMeasure,
+    make_multi_getter,
+    make_simple_getter,
+)
+
+
+class CompositeSize(CompositeMeasure):
+    """
+    Composite size measure. Supports the following units:
+    - mm
+    - cm
+    - dm
+    - m
+    """
+
+    mm = property(make_multi_getter("mm"))
+    cm = property(make_multi_getter("cm"))
+    dm = property(make_multi_getter("dm"))
+    m = property(make_multi_getter("m"))
+
+
+@spacy.registry.misc("eds.measures.size")
+class Size(SimpleMeasure):
+    """
+    Size measure. Supports the following units:
+    - mm
+    - cm
+    - dm
+    - m
+    """
+
+    COMPOSITE = CompositeSize
+    UNITS = {
+        "mm": {"prefix": "mill?im", "abbr": "mm", "value": 1},
+        "cm": {"prefix": "centim", "abbr": "cm", "value": 10},
+        "dm": {"prefix": "decim", "abbr": "dm", "value": 100},
+        "m": {"prefix": "metre", "abbr": "m", "value": 1000},
+    }
+
+    @classmethod
+    def parse(cls, int_part, dec_part, unit, infix=False):
+        result = float("{}.{}".format(int_part, dec_part))
+        return cls(result, unit)
+
+    mm = property(make_simple_getter("mm"))
+    cm = property(make_simple_getter("cm"))
+    dm = property(make_simple_getter("dm"))
+    m = property(make_simple_getter("m"))
+
+
+@spacy.registry.misc("eds.measures.weight")
+class Weight(SimpleMeasure):
+    """
+    Weight measure. Supports the following units:
+    - mg
+    - cg
+    - dg
+    - g
+    - kg
+    """
+
+    COMPOSITE = None
+    UNITS = {
+        "mg": {"prefix": "mill?ig", "abbr": "mg", "value": 1},
+        "cg": {"prefix": "centig", "abbr": "cg", "value": 10},
+        "dg": {"prefix": "decig", "abbr": "dg", "value": 100},
+        "g": {"prefix": "gram", "abbr": "g", "value": 1000},
+        "kg": {"prefix": "kilo", "abbr": "kg", "value": 1000000},
+    }
+
+    @classmethod
+    def parse(cls, int_part, dec_part, unit, infix=False):
+        result = float("{}.{}".format(int_part, dec_part))
+        return cls(result, unit)
+
+    mg = property(make_simple_getter("mg"))
+    cg = property(make_simple_getter("cg"))
+    dg = property(make_simple_getter("dg"))
+    g = property(make_simple_getter("g"))
+    kg = property(make_simple_getter("kg"))
+
+
+@spacy.registry.misc("eds.measures.angle")
+class Angle(SimpleMeasure):
+    """
+    Angle measure. Supports the following units:
+    - h
+    """
+
+    COMPOSITE = None
+    UNITS = {
+        "h": {"prefix": "heur", "abbr": "h", "value": 1},
+    }
+
+    @classmethod
+    def parse(cls, int_part, dec_part, unit, infix=False):
+        if infix:
+            result = float(int_part) + int(dec_part) / 60.0
+            return cls(result, unit)
+        result = float("{}.{}".format(int_part, dec_part))
+        return cls(result, unit)
+
+    h = property(make_simple_getter("h"))

--- a/edsnlp/utils/filter.py
+++ b/edsnlp/utils/filter.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
 from spacy.tokens import Span
 
 
-def get_sort_key(span: Span) -> Tuple[int, int]:
+def default_sort_key(span: Span) -> Tuple[int, int]:
     """
     Returns the sort key for filtering spans.
 
@@ -24,6 +24,7 @@ def filter_spans(
     spans: Iterable[Union["Span", Tuple["Span", Any]]],
     label_to_remove: Optional[str] = None,
     return_discarded: bool = False,
+    sort_key=default_sort_key,
 ) -> Union[List["Span"], Tuple[List["Span"], List["Span"]]]:
     """
     Re-definition of spacy's filtering function, that returns discarded spans
@@ -61,6 +62,10 @@ def filter_spans(
         Whether to return discarded spans.
     label_to_remove : str, optional
         Label to remove. If set, results can contain overlapping spans.
+    sort_key: Callable[Span, Any], optional
+        Key to sorting spans before applying overlap conflict resolution.
+        A span with a higher key will have precedence over another span.
+        By default, the largest, leftmost spans are selected first.
 
     Returns
     -------
@@ -69,7 +74,7 @@ def filter_spans(
     discarded : List[Span], optional
         Discarded spans
     """
-    sorted_spans = sorted(spans, key=get_sort_key, reverse=True)
+    sorted_spans = sorted(spans, key=sort_key, reverse=True)
     result = []
     discarded = []
     seen_tokens = set()

--- a/edsnlp/utils/filter.py
+++ b/edsnlp/utils/filter.py
@@ -24,7 +24,7 @@ def filter_spans(
     spans: Iterable[Union["Span", Tuple["Span", Any]]],
     label_to_remove: Optional[str] = None,
     return_discarded: bool = False,
-    sort_key=default_sort_key,
+    sort_key: Callable[Span, Any] = default_sort_key,
 ) -> Union[List["Span"], Tuple[List["Span"], List["Span"]]]:
     """
     Re-definition of spacy's filtering function, that returns discarded spans
@@ -62,7 +62,7 @@ def filter_spans(
         Whether to return discarded spans.
     label_to_remove : str, optional
         Label to remove. If set, results can contain overlapping spans.
-    sort_key: Callable[Span, Any], optional
+    sort_key : Callable[Span, Any], optional
         Key to sorting spans before applying overlap conflict resolution.
         A span with a higher key will have precedence over another span.
         By default, the largest, leftmost spans are selected first.

--- a/edsnlp/utils/filter.py
+++ b/edsnlp/utils/filter.py
@@ -24,7 +24,7 @@ def filter_spans(
     spans: Iterable[Union["Span", Tuple["Span", Any]]],
     label_to_remove: Optional[str] = None,
     return_discarded: bool = False,
-    sort_key: Callable[Span, Any] = default_sort_key,
+    sort_key: Callable[[Span], Any] = default_sort_key,
 ) -> Union[List["Span"], Tuple[List["Span"], List["Span"]]]:
     """
     Re-definition of spacy's filtering function, that returns discarded spans

--- a/edsnlp/utils/regex.py
+++ b/edsnlp/utils/regex.py
@@ -1,4 +1,7 @@
+import re
 from typing import List, Optional
+
+import regex
 
 
 def make_pattern(
@@ -38,3 +41,25 @@ def make_pattern(
         pattern = r"\b" + pattern + r"\b"
 
     return pattern
+
+
+def compile_regex(reg):
+    """
+    This function tries to compile `reg`  using the `re` module, and
+    fallbacks to the `regex` module that is more permissive.
+
+    Parameters
+    ----------
+    reg: str
+
+    Returns
+    -------
+    Union[re.Pattern, regex.Pattern]
+    """
+    try:
+        return re.compile(reg)
+    except re.error:
+        try:
+            return regex.compile(reg)
+        except regex.error:
+            raise Exception("Could not compile: {}".format(repr(reg)))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - Miscellaneous:
       - pipelines/misc/index.md
       - pipelines/misc/dates.md
+      - pipelines/misc/measures.md
       - pipelines/misc/consultation-dates.md
       - pipelines/misc/sections.md
       - pipelines/misc/reason.md

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ factories = [
     "reason = edsnlp.components:reason",
     "sections = edsnlp.components:sections",
     "context = edsnlp.components:context",
+    "measures = edsnlp.components:measures",
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ def nlp():
     model.add_pipe("eds.reported_speech")
 
     model.add_pipe("eds.dates")
+    model.add_pipe("eds.measures")
 
     return model
 

--- a/tests/pipelines/misc/test_measure.py
+++ b/tests/pipelines/misc/test_measure.py
@@ -1,0 +1,166 @@
+import spacy
+from pytest import fixture, raises
+from spacy.language import Language
+
+from edsnlp.pipelines.misc.measures import Measures
+from edsnlp.pipelines.misc.measures.factory import DEFAULT_CONFIG
+
+text = (
+    "Le patient fait 1 m 50 kg. La tumeur située à 8h fait 2cm x 3cm. \n"
+    "Une autre tumeur plus petite fait 2 par 1mm.\n"
+    "Les trois éléments font 8, 13 et 15dm."
+)
+
+
+@fixture
+def blank_nlp():
+    model = spacy.blank("fr")
+    model.add_pipe("eds.sentences")
+    return model
+
+
+@fixture
+def measure(blank_nlp: Language):
+    return Measures(
+        blank_nlp,
+        **DEFAULT_CONFIG,
+    )
+
+
+def test_default_factory(blank_nlp: Language):
+    blank_nlp.add_pipe("matcher", config=dict(terms={"patient": "patient"}))
+    blank_nlp.add_pipe(
+        "eds.measures",
+        config=dict(
+            measures=["eds.measures.size", "eds.measures.weight", "eds.measures.angle"]
+        ),
+    )
+
+    doc = blank_nlp(text)
+
+    assert len(doc.ents) == 1
+
+    assert len(doc.spans["measures"]) == 8
+
+
+def test_measures_component(blank_nlp: Language, measure: Measures):
+    doc = blank_nlp(text)
+
+    with raises(KeyError):
+        doc.spans["measures"]
+
+    doc = measure(doc)
+
+    m1, m2, m3, m4, m5, m6, m7, m8 = doc.spans["measures"]
+
+    assert str(m1._.value) == "1.0m"
+    assert str(m2._.value) == "50.0kg"
+    assert str(m3._.value) == "8.0h"
+    assert str(m4._.value) == "2.0cm x 3.0cm"
+    assert str(m5._.value) == "2.0mm x 1.0mm"
+    assert str(m6._.value) == "8.0dm"
+    assert str(m7._.value) == "13.0dm"
+    assert str(m8._.value) == "15.0dm"
+
+
+def test_measures_component_scaling(blank_nlp: Language, measure: Measures):
+    doc = blank_nlp(text)
+
+    with raises(KeyError):
+        doc.spans["measures"]
+
+    doc = measure(doc)
+
+    m1, m2, m3, m4, m5, m6, m7, m8 = doc.spans["measures"]
+
+    assert m1._.value.cm == 100.0
+    assert m2._.value.mg == 50000000.0
+    assert m3._.value.h == 8
+    assert m4._.value.mm == (20, 30)
+    assert m5._.value.cm == (0.2, 0.1)
+    assert m6._.value.dm == 8.0
+    assert m7._.value.m == 1.3, (13.0, 100 / 1000, 13.0 * (100 / 1000))
+    assert m8._.value.m == 1.5
+
+
+def test_measure_label(blank_nlp: Language, measure: Measures):
+    doc = blank_nlp(text)
+    doc = measure(doc)
+    m1, m2, m3, m4, m5, m6, m7, m8 = doc.spans["measures"]
+
+    assert m1.label_ == "eds.measures.size"
+    assert m2.label_ == "eds.measures.weight"
+    assert m3.label_ == "eds.measures.angle"
+    assert m4.label_ == "eds.measures.size"
+    assert m5.label_ == "eds.measures.size"
+    assert m6.label_ == "eds.measures.size"
+    assert m7.label_ == "eds.measures.size"
+    assert m8.label_ == "eds.measures.size"
+
+
+def test_measure_str(blank_nlp: Language, measure: Measures):
+    for text, res in [
+        ("1m50", "1.5m"),
+        ("1,50cm", "1.5cm"),
+        ("1h45", "1.75h"),
+        ("1,45h", "1.45h"),
+    ]:
+        doc = blank_nlp(text)
+        doc = measure(doc)
+
+        assert str(doc.spans["measures"][0]._.value) == res
+
+
+def test_measure_repr(blank_nlp: Language, measure: Measures):
+    for text, res in [
+        (
+            "1m50",
+            "Size(1.5, 'm')",
+        ),
+        (
+            "1,50cm",
+            "Size(1.5, 'cm')",
+        ),
+        (
+            "1h45",
+            "Angle(1.75, 'h')",
+        ),
+        (
+            "1,45h",
+            "Angle(1.45, 'h')",
+        ),
+        (
+            "1 x 2cm",
+            "CompositeSize([Size(1.0, 'cm'), Size(2.0, 'cm')])",
+        ),
+    ]:
+        doc = blank_nlp(text)
+        doc = measure(doc)
+
+        assert repr(doc.spans["measures"][0]._.value) == res
+
+
+def test_pooling(blank_nlp: Language, measure: Measures):
+    for text, min_res, first_res in [
+        ("1m50 x 120cm", "120.0cm", "1.5m"),
+        ("150cm30 x 1m x 12dm", "1.0m", "150.3cm"),
+        ("1cm50", "1.5cm", "1.5cm"),
+    ]:
+        doc = blank_nlp(text)
+        doc = measure(doc)
+
+        assert str(min(doc.spans["measures"][0]._.value)) == min_res
+        assert str(doc.spans["measures"][0]._.value[0]) == first_res
+
+
+def test_compare(blank_nlp: Language, measure: Measures):
+    m1, m2 = "1m50 x 120cm", "150cm"
+    m1 = measure(blank_nlp(m1)).spans["measures"][0]
+    m2 = measure(blank_nlp(m2)).spans["measures"][0]
+    assert max(m1._.value) == max(m2._.value)
+
+    m1, m2 = "1m0", "120cm"
+    m1 = measure(blank_nlp(m1)).spans["measures"][0]
+    m2 = measure(blank_nlp(m2)).spans["measures"][0]
+    assert max(m1._.value) <= max(m2._.value)
+    assert max(m2._.value) > max(m1._.value)


### PR DESCRIPTION
## Description

This PR introduces the `measures` pipeline and a `Measure` class to handle the extracted measures.

Instead of having multiple pipelines (one per type of measure) a single instance of this pipeline recognizes different types of measures (eg sizes, weights and angles at the moment) to resolve recognition conflicts in "ambiguous" cases like `1m50kg`, where `1m50` could be extracted as a size if the system had no knowledge of weight measures. This choice is open to discussion.

The `eds.measures` pipeline can extract simple (eg `3cm`) and composite (eg `3 x 2cm`) measures.
It can detect elliptic enumerations (eg `32, 33 et 34kg`) of measures of the same type and split the measures accordingly.

The normalized value can then be accessed via the `span._.value` attribute and converted on the fly to a desired unit.

The current pipeline supports the following measures:

| Measure name         | Example           | Units                       | Allows composite measures |
| -------------------- | ----------------- | --------------------------- | ------------------------- |
| `eds.measures.size`   | `12m50`, `12.50m` | `mm`, `cm`, `dm`, `m`       | YES                       |
| `eds.measures.weight` | `12kg`, `1g300`   | `mg`, `cg`, `dg`, `g`, `kg` | NO                        |
| `eds.measures.angle`  | `8h`, `8h30`      | `h`                         | NO                        |


Example code:
```python
import spacy

nlp = spacy.blank("fr")
nlp.add_pipe(
    "eds.measures", config=dict(measures=["eds.measures.size", "eds.measures.weight"])
)

text = (
    "Le patient est admis hier, fait 1m78 pour 76kg. "
    "Les deux nodules bénins sont larges de 1,2 et 2.4mm."
    "La tumeur fait 1 x 2cm."
)

doc = nlp(text)

measures = doc.spans["measures"]
# Out: [1m78, 76kg, 1,2, 2.4mm, 1 x 2cm]

measures[0]
# Out: "1m78"

str(measures[0]._.value)
# Out: "1.78m"

measures[0]._.value.cm
# Out: 178.0

measures[-3]
# Out: "1,2"

str(measures[-3]._.value)
# Out: "1.2mm"

str(measures[-3]._.value.mm)
# Out: 1.2

str(measures[-1])
# Out: 1 x 2cm

str(measures[-1]._.value)
# Out: 1.0cm x 2.0cm

str(measures[-1]._.value.mm)
# Out: (10.0, 20.0)

# All measures, simple or composite, support iterable operations
str(max(measures[-1]._.value))
# Out: 2.0cm

str(max(measures[0]._.value))
# Out: 1.78m
```

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
