### PR TITLE
Make streamlit demo install master instead of release

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,2 +1,2 @@
-edsnlp==0.4.4
+git+https://github.com/aphp/edsnlp.git
 streamlit


### PR DESCRIPTION
## Description

Make streamlit demo install from master instead of released Pypi versions.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
