### PR TITLE
Fix issue with Numpy and bump to v0.5.1

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,33 @@
+# This tries to build packages, and tests the packages.
+# It runs on every push to branches following the pattern v*.*.*.
+# It makes sure that everything will run when the version is released.
+
+name: Test Build
+
+on:
+  push:
+    branches:    
+      - v*.*.*
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.4.0
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ name: Test Build
 
 on:
   push:
-    branches:    
+    branches:
       - v*.*.*
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.5.0
+pip install edsnlp==0.5.1
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.1 (2022-04-09)
+
+### Fixed
+
+- Numpy requirements compatible with the `EDSPhraseMatcher`
+
 ## v0.5.0 (2022-04-08)
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## v0.5.1 (2022-04-09)
+## v0.5.1 (2022-04-11)
 
 ### Fixed
 
-- Numpy requirements compatible with the `EDSPhraseMatcher`
+- Updated Numpy requirements to be compatible with the `EDSPhraseMatcher`
 
 ## v0.5.0 (2022-04-08)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ color:green Successfully installed!
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.5.0
+pip install edsnlp==0.5.1
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -7,6 +7,6 @@ from pathlib import Path
 from . import extensions
 from .language import *
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 BASE_DIR = Path(__file__).parent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,5 @@ skip = [
     "*-manylinux_s390x",    # Skip slow Linux
 ]
 
+before-test = "pip install pytest"
 test-command = "pytest {project}/tests/pipelines/test_pipelines.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "cython>=0.25,<3.0",
     "spacy>=3.2<4.0",
-    "numpy>=1.21",
+    "numpy>=1.22",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -42,5 +42,4 @@ skip = [
     "*-manylinux_s390x",    # Skip slow Linux
 ]
 
-before-test = "pip install pytest numpy==1.21"
 test-command = "pytest {project}/tests/pipelines/test_pipelines.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ skip = [
     "*-manylinux_s390x",    # Skip slow Linux
 ]
 
+before-test = "pip install pytest numpy==1.20"
 test-command = "pytest {project}/tests/pipelines/test_pipelines.py"
-before-test = "pip install pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "cython>=0.25,<3.0",
     "spacy>=3.2<4.0",
-    "numpy>=1.22",
+    "numpy>=1.21",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "cython>=0.25,<3.0",
     "spacy>=3.2<4.0",
-    "numpy>=1.15.0",
+    "numpy>=1.21",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -42,5 +42,5 @@ skip = [
     "*-manylinux_s390x",    # Skip slow Linux
 ]
 
-before-test = "pip install pytest numpy==1.20"
+before-test = "pip install pytest numpy==1.21"
 test-command = "pytest {project}/tests/pipelines/test_pipelines.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator
 loguru
-numpy>=1.22
+numpy>=1.21
 pandas>=1.1
 pendulum
 regex<=2022.3.2  # due to dateparser bug issue 1045

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator
 loguru
-numpy>=1.21
+numpy>=1.22
 pandas>=1.1
 pendulum
 regex<=2022.3.2  # due to dateparser bug issue 1045

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator
 loguru
-numpy
+numpy>=1.20
 pandas>=1.1
 pendulum
 regex<=2022.3.2  # due to dateparser bug issue 1045

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator
 loguru
-numpy>=1.20
+numpy>=1.21
 pandas>=1.1
 pendulum
 regex<=2022.3.2  # due to dateparser bug issue 1045

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     },
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     packages=find_packages(),
     install_requires=get_lines("requirements.txt"),
     ext_modules=ext_modules,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The issue seems to be resolved when upgrading numpy. See discussion [here](https://stackoverflow.com/questions/66060487/valueerror-numpy-ndarray-size-changed-may-indicate-binary-incompatibility-exp).

This PR upgrades the minimum requirement for Numpy, alleviating most issues. However, it does seem that the issue depends on the Python version. In a future fix, we might want to make the numpy version dependent on the Python distribution to make sure that a) the constraint is not unnecessarily high and b) it is adapted to each supported Python version.

In the meantime, we could add a note for users to suggest upgrading numpy in case of issues.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
