### PR TITLE
feat: allow recursive attributes in processing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Adding support for chained attributes in the `processing` pipelines
+
 ## v0.5.1 (2022-04-11)
 
 ### Fixed

--- a/docs/tutorials/multiple-texts.md
+++ b/docs/tutorials/multiple-texts.md
@@ -362,6 +362,7 @@ EDS-NLP provides a helper function, [`pyspark_type_finder`][edsnlp.processing.di
 
 ```python
 int_type = pyspark_type_finder(1)
+
 # Out: IntegerType()
 ```
 

--- a/docs/tutorials/multiple-texts.md
+++ b/docs/tutorials/multiple-texts.md
@@ -387,11 +387,7 @@ Once again, using the helper is trivial:
         df,
         nlp,
         additional_spans=["dates"],
-        extensions={
-            "date.year": int_type,
-            "date.month": int_type,
-            "date.day": int_type
-        },
+        extensions={"date.year": int_type, "date.month": int_type, "date.day": int_type},
     )
 
     # Check that the pipeline was correctly distributed:

--- a/docs/tutorials/multiple-texts.md
+++ b/docs/tutorials/multiple-texts.md
@@ -206,11 +206,11 @@ data = data[["note_id"]].join(pd.json_normalize(data.entities))
 
 The result on the first note:
 
-| note_id | start | end | label      | lexical_variant   | negation | hypothesis | family | key   |
-| ------: | ----: | --: | :--------- | :---------------- | -------: | ---------: | -----: | :---- |
-|       0 |     0 |   7 | patient    | Patient           |        0 |          0 |      0 | ents  |
-|       0 |   114 | 121 | patient    | patient           |        0 |          0 |      1 | ents  |
-|       0 |    17 |  34 | 2021-09-25 | 25 septembre 2021 |      nan |        nan |    nan | dates |
+| note_id | start |  end | label      | lexical_variant   | negation | hypothesis | family | key   |
+| ------: | ----: | ---: | :--------- | :---------------- | -------: | ---------: | -----: | :---- |
+|       0 |     0 |    7 | patient    | Patient           |        0 |          0 |      0 | ents  |
+|       0 |   114 |  121 | patient    | patient           |        0 |          0 |      1 | ents  |
+|       0 |    17 |   34 | 2021-09-25 | 25 septembre 2021 |      nan |        nan |    nan | dates |
 
 ## Using EDS-NLP's helper functions
 
@@ -241,7 +241,7 @@ They share the same arguments:
         nlp,
         context=["note_datetime"],
         additional_spans=["dates"],
-        extensions=["date"],
+        extensions=["date.day", "date.month", "date.year"],
     )
     ```
 
@@ -259,7 +259,7 @@ note_nlp = single_pipe(
     data,
     nlp,
     additional_spans=["dates"],
-    extensions=["date"],
+    extensions=["date.day", "date.month", "date.year"],
 )
 ```
 
@@ -277,7 +277,7 @@ note_nlp = parallel_pipe(
     data,
     nlp,
     additional_spans=["dates"],
-    extensions=["date"],
+    extensions=["date.day", "date.month", "date.year"],
     n_jobs=-2,  # (1)
 )
 ```
@@ -361,7 +361,8 @@ EDS-NLP provides a helper function, [`pyspark_type_finder`][edsnlp.processing.di
 <!-- no-check -->
 
 ```python
-dt_type = pyspark_type_finder(datetime.datetime(2020, 1, 1))
+int_type = pyspark_type_finder(1)
+# Out: IntegerType()
 ```
 
 !!! danger "Be careful when providing the example"
@@ -385,7 +386,11 @@ Once again, using the helper is trivial:
         df,
         nlp,
         additional_spans=["dates"],
-        extensions={"date": dt_type},
+        extensions={
+            "date.year": int_type,
+            "date.month": int_type,
+            "date.day": int_type
+        },
     )
 
     # Check that the pipeline was correctly distributed:
@@ -404,7 +409,7 @@ Once again, using the helper is trivial:
         df,
         nlp,
         additional_spans=["dates"],
-        extensions={"date": dt_type},
+        extensions={"date.year": int_type, "date.month": int_type, "date.day": int_type},
     )
 
     # Check that the pipeline was correctly distributed:
@@ -429,7 +434,7 @@ note_nlp = pipe(
     nlp=nlp,
     n_jobs=1,
     additional_spans=["dates"],
-    extensions=["date"],
+    extensions=["date.day", "date.month", "date.year"],
 )
 
 ### Larger pandas DataFrame
@@ -438,7 +443,7 @@ note_nlp = pipe(
     nlp=nlp,
     n_jobs=-2,
     additional_spans=["dates"],
-    extensions=["date"],
+    extensions=["date.day", "date.month", "date.year"],
 )
 
 ### Huge Spark or Koalas DataFrame
@@ -447,6 +452,6 @@ note_nlp = pipe(
     nlp=nlp,
     how="spark",
     additional_spans=["dates"],
-    extensions={"date": dt_type},
+    extensions={"date.year": int_type, "date.month": int_type, "date.day": int_type},
 )
 ```

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -14,6 +14,8 @@ from .helpers import (
     DataFrames,
     check_spacy_version_for_context,
     get_module,
+    rgetattr,
+    slugify,
 )
 
 
@@ -112,7 +114,7 @@ def pipe(
                     T.StructField("start", T.IntegerType(), False),
                     T.StructField("end", T.IntegerType(), False),
                     *[
-                        T.StructField(extension_name, extension_type, True)
+                        T.StructField(slugify(extension_name), extension_type, True)
                         for extension_name, extension_type in extensions.items()
                     ],
                 ]
@@ -144,7 +146,7 @@ def pipe(
 
             for ent in doc.ents:
                 parsed_extensions = [
-                    getattr(ent._, extension) for extension in extensions.keys()
+                    rgetattr(ent._, extension) for extension in extensions.keys()
                 ]
 
                 ents.append(
@@ -169,7 +171,7 @@ def pipe(
                 for ent in doc.spans.get(spans_name, []):
 
                     parsed_extensions = [
-                        getattr(ent._, extension) for extension in extensions.keys()
+                        rgetattr(ent._, extension) for extension in extensions.keys()
                     ]
 
                     ents.append(

--- a/edsnlp/processing/helpers.py
+++ b/edsnlp/processing/helpers.py
@@ -67,11 +67,11 @@ def slugify(chained_attr: str) -> str:
     Parameters
     ----------
     chained_attr : str
-        The string to slugify (replace dots by -)
+        The string to slugify (replace dots by _)
 
     Returns
     -------
     str
         The slugified string
     """
-    return chained_attr.replace(".", "-")
+    return chained_attr.replace(".", "_")

--- a/edsnlp/processing/helpers.py
+++ b/edsnlp/processing/helpers.py
@@ -1,7 +1,8 @@
+import functools
 import importlib
 from distutils.version import LooseVersion
 from enum import Enum
-from typing import Union
+from typing import Any, List, Union
 
 from pkg_resources import VersionConflict
 
@@ -39,3 +40,38 @@ def check_spacy_version_for_context():  # pragma: no cover
             f"However, we found SpaCy version {spacy_version}.\n",
             "Please upgrade SpaCy ;)",
         )
+
+
+def rgetattr(obj: Any, attr: str, *args: List[Any]) -> Any:
+    """
+    Recursively getting attribute
+
+    Parameters
+    ----------
+    obj : Any
+        An object
+    attr : str
+        The name of the attriute to get. Can contain dots.
+    """
+
+    def _getattr(obj, attr):
+        return None if obj is None else getattr(obj, attr, *args)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))
+
+
+def slugify(chained_attr: str) -> str:
+    """
+    Slugify a chained attribute name
+
+    Parameters
+    ----------
+    chained_attr : str
+        The string to slugify (replace dots by -)
+
+    Returns
+    -------
+    str
+        The slugified string
+    """
+    return chained_attr.replace(".", "-")

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -6,7 +6,7 @@ from spacy import Language
 from spacy.tokens import Doc, Span
 from tqdm import tqdm
 
-from .helpers import check_spacy_version_for_context
+from .helpers import check_spacy_version_for_context, rgetattr, slugify
 
 nlp = spacy.blank("eds")
 
@@ -52,7 +52,7 @@ def _df_to_spacy(
         note_text = context_values.note_text
         doc = nlp.make_doc(note_text)
         for col in context:
-            doc._.set(col, getattr(context_values, col))
+            doc._.set(slugify(col), rgetattr(context_values, col))
         return doc
 
     yield from map(
@@ -118,7 +118,7 @@ def _single_schema(
         "span_type": span_type,
         "start": ent.start_char,
         "end": ent.end_char,
-        **{extension: getattr(ent._, extension) for extension in extensions},
+        **{slugify(extension): rgetattr(ent._, extension) for extension in extensions},
     }
 
 

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -12,7 +12,7 @@ from edsnlp.processing.helpers import DataFrameModules
 
 text = """
 Motif :
-Le patient est admis le 29 août pour des difficultés respiratoires.
+Le patient est admis le 29 août 2020 pour des difficultés respiratoires.
 
 Antécédents familiaux :
 Le père est asthmatique, sans traitement particulier.
@@ -26,12 +26,10 @@ Conclusion
 Possible infection au coronavirus
 """
 
-NOTE_YEAR = 1980
-
 
 def note(module: DataFrameModules):
 
-    data = [(i, i // 5, text, datetime(NOTE_YEAR, 1, 1)) for i in range(20)]
+    data = [(i, i // 5, text, datetime(2021, 1, 1)) for i in range(20)]
 
     if module == DataFrameModules.PANDAS:
         return pd.DataFrame(
@@ -124,8 +122,8 @@ def test_pipelines(param, model):
             "hypothesis": T.BooleanType(),
             "family": T.BooleanType(),
             "reported_speech": T.BooleanType(),
-            # "parsed_date": T.TimestampType(),
-            # "date": T.StringType(),
+            "date.year": T.IntegerType(),
+            "date.month": T.IntegerType(),
         },
         additional_spans=["dates"],
     )
@@ -149,11 +147,10 @@ def test_pipelines(param, model):
             "reported_speech",
             "family",
             "score_method",
+            "date-year",
+            "date-month",
         )
     )
-
-    # # Check that context is correctly added
-    # assert f"{NOTE_YEAR}-08-29" in note_nlp["date"].unique()
 
 
 def test_spark_missing_types(model):
@@ -163,5 +160,4 @@ def test_spark_missing_types(model):
             note(module=DataFrameModules.PYSPARK),
             nlp=model,
             extensions={"negation", "hypothesis", "family"},
-            # additional_spans=["dates"],
         )

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -147,8 +147,8 @@ def test_pipelines(param, model):
             "reported_speech",
             "family",
             "score_method",
-            "date-year",
-            "date-month",
+            "date_year",
+            "date_month",
         )
     )
 


### PR DESCRIPTION
Allow recursive attributes in processing

## Description

It is now possible to provide chained attributes in the processing pipes:

```
note_nlp = pipe(
    note=df.limit(1000).toPandas(),
    nlp=nlp,
    n_jobs=1,
    additional_spans=["dates"],
    extensions=["date.day", "date.month", "date.year"],
)
```

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
