### PR TITLE
Add TNM detection and normalisation pipeline

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,18 @@
 # Changelog
 
-## v0.5.2 (2022-04-29)
+## Pending release
 
 ### Added
 
 - Support for strings in the example utility
+- [TNM](https://en.wikipedia.org/wiki/TNM_staging_system) detection and normalisation with the `eds.TNM` pipeline
+
+## v0.5.2 (2022-04-29)
+
+### Added
+
 - Support for chained attributes in the `processing` pipelines
 - Colour utility with the category20 colour palette
-- [TNM](https://en.wikipedia.org/wiki/TNM_staging_system) detection and normalisation with the `eds.TNM` pipeline
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Support for chained attributes in the `processing` pipelines
 - Colour utility with the category20 colour palette
+- [TNM](https://en.wikipedia.org/wiki/TNM_staging_system) detection and normalisation with the `eds.TNM` pipeline
 
 ## v0.5.1 (2022-04-11)
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Support for strings in the example utility
 - Support for chained attributes in the `processing` pipelines
 - Colour utility with the category20 colour palette
 - [TNM](https://en.wikipedia.org/wiki/TNM_staging_system) detection and normalisation with the `eds.TNM` pipeline

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,6 +106,7 @@ This example is complete, it should run as-is. Check out the [spaCy 101 page](tu
     | `eds.emergency.priority` | A priority score extractor |
     | `eds.emergency.ccmu`     | A CCMU score extractor     |
     | `eds.emergency.gemsa`    | A GEMSA score extractor    |
+    | `eds.TNM`                | A TNM score extractor      |
 
 ## Disclaimer
 

--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -41,6 +41,7 @@ EDS-NLP provides easy-to-use spaCy components.
     | `eds.emergency.priority` | A priority score extractor |
     | `eds.emergency.ccmu`     | A CCMU score extractor     |
     | `eds.emergency.gemsa`    | A GEMSA score extractor    |
+    | `eds.TNM`                | A TNM score extractor      |
 
 You can add them to your spaCy pipeline by simply calling `add_pipe`, for instance:
 

--- a/docs/pipelines/ner/score.md
+++ b/docs/pipelines/ner/score.md
@@ -100,6 +100,8 @@ doc.ents
 # Out: (pTx N1 M1,)
 ```
 
+The TNM score was developed with S. Priou and E. Kempf.
+
 ## Implementing your own score
 
 Using the `eds.score` pipeline, you only have to change its configuration in order to implement a _simple_ score extraction algorithm. As an example, let us see the configuration used for the `eds.charlson` pipe

--- a/docs/pipelines/ner/score.md
+++ b/docs/pipelines/ner/score.md
@@ -82,6 +82,24 @@ ent._.score_method
 
 Score method can here be "24H", "Maximum", "A l'admission" or "Non précisée"
 
+## TNM score
+
+The `eds.TNM` pipe allows to extract SOFA scores.
+
+```python
+import spacy
+
+nlp = spacy.blank("fr")
+nlp.add_pipe("eds.sentences")
+nlp.add_pipe("eds.TNM")
+
+text = "TNM: pTx N1 M1"
+
+doc = nlp(text)
+doc.ents
+# Out: (pTx N1 M1,)
+```
+
 ## Implementing your own score
 
 Using the `eds.score` pipeline, you only have to change its configuration in order to implement a _simple_ score extraction algorithm. As an example, let us see the configuration used for the `eds.charlson` pipe

--- a/edsnlp/pipelines/factories.py
+++ b/edsnlp/pipelines/factories.py
@@ -21,6 +21,7 @@ from .ner.scores.emergency.gemsa.factory import create_component as gemsa
 from .ner.scores.emergency.priority.factory import create_component as priority
 from .ner.scores.factory import create_component as score
 from .ner.scores.sofa.factory import create_component as sofa
+from .ner.scores.tnm.factory import create_component as tnm
 from .qualifiers.family.factory import create_component as family
 from .qualifiers.history.factory import create_component as history
 from .qualifiers.hypothesis.factory import create_component as hypothesis

--- a/edsnlp/pipelines/ner/scores/tnm/__init__.py
+++ b/edsnlp/pipelines/ner/scores/tnm/__init__.py
@@ -1,0 +1,1 @@
+from .tnm import TNM

--- a/edsnlp/pipelines/ner/scores/tnm/factory.py
+++ b/edsnlp/pipelines/ner/scores/tnm/factory.py
@@ -1,0 +1,24 @@
+from typing import List, Optional, Union
+
+from spacy.language import Language
+
+from .tnm import TNM
+
+DEFAULT_CONFIG = dict(
+    pattern=None,
+    attr="LOWER",
+)
+
+
+@Language.factory("eds.tnm", default_config=DEFAULT_CONFIG)
+def create_component(
+    nlp: Language,
+    name: str,
+    pattern: Optional[Union[List[str], str]],
+    attr: str,
+):
+    return TNM(
+        nlp,
+        pattern=pattern,
+        attr=attr,
+    )

--- a/edsnlp/pipelines/ner/scores/tnm/factory.py
+++ b/edsnlp/pipelines/ner/scores/tnm/factory.py
@@ -10,7 +10,7 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.tnm", default_config=DEFAULT_CONFIG)
+@Language.factory("eds.TNM", default_config=DEFAULT_CONFIG)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/tnm/models.py
+++ b/edsnlp/pipelines/ner/scores/tnm/models.py
@@ -36,11 +36,24 @@ class TNM(BaseModel):
     metastasis: Optional[Union[int, Unknown]] = None
 
     version: Optional[str] = None
+    version_year: Optional[int] = None
 
     @validator("*", pre=True)
     def coerce_o(cls, v):
         if isinstance(v, str):
             v = v.replace("o", "0")
+        return v
+
+    @validator("version_year")
+    def validate_year(cls, v):
+        if v is None:
+            return v
+
+        if v < 40:
+            v += 2000
+        elif v < 100:
+            v += 1900
+
         return v
 
     def norm(self) -> str:
@@ -58,7 +71,7 @@ class TNM(BaseModel):
         if self.metastasis is not None:
             norm.append(f"M{self.metastasis}")
 
-        if self.version is not None:
-            norm.append(f" ({self.version.upper()})")
+        if self.version is not None and self.version_year is not None:
+            norm.append(f" ({self.version.upper()} {self.version_year})")
 
         return "".join(norm)

--- a/edsnlp/pipelines/ner/scores/tnm/models.py
+++ b/edsnlp/pipelines/ner/scores/tnm/models.py
@@ -1,6 +1,7 @@
-from typing import Optional, Union
-from pydantic import BaseModel
 from enum import Enum
+from typing import Optional, Union
+
+from pydantic import BaseModel
 
 
 class TnmEnum(Enum):

--- a/edsnlp/pipelines/ner/scores/tnm/models.py
+++ b/edsnlp/pipelines/ner/scores/tnm/models.py
@@ -1,0 +1,52 @@
+from typing import Optional, Union
+from pydantic import BaseModel
+from enum import Enum
+
+
+class TnmEnum(Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
+class Modifier(TnmEnum):
+    c = "c"
+    p = "p"
+    y = "y"
+    a = "a"
+    u = "u"
+    m = "m"
+    s = "s"
+
+
+class Node(TnmEnum):
+    x = "x"
+
+
+class Tumour(TnmEnum):
+    x = "x"
+    i = "is"
+
+
+class TNM(BaseModel):
+
+    modifier: Optional[Union[int, Modifier]] = None
+    tumour: Optional[Union[int, Tumour]] = None
+    node: Optional[Union[int, Node]] = None
+    metastasis: Optional[int] = None
+
+    def norm(self) -> str:
+        norm = []
+
+        if self.modifier is not None:
+            norm.append(str(self.modifier))
+
+        if self.tumour is not None:
+            norm.append(f"T{self.tumour}")
+
+        if self.node is not None:
+            norm.append(f"N{self.node}")
+
+        if self.metastasis is not None:
+            norm.append(f"M{self.metastasis}")
+
+        return "".join(norm)

--- a/edsnlp/pipelines/ner/scores/tnm/patterns.py
+++ b/edsnlp/pipelines/ner/scores/tnm/patterns.py
@@ -4,6 +4,6 @@ node_pattern = r"n\s?(?P<node>([0-3]|x))"
 metastasis_pattern = r"m\s?(?P<metastasis>[01])"
 
 tnm_pattern = f"({modifier_pattern}\\s?)?"
-tnm_pattern += tumour_pattern
-tnm_pattern += node_pattern
-tnm_pattern += metastasis_pattern
+tnm_pattern += r"\s*" + tumour_pattern
+tnm_pattern += r"\s*" + node_pattern
+tnm_pattern += r"\s*" + metastasis_pattern

--- a/edsnlp/pipelines/ner/scores/tnm/patterns.py
+++ b/edsnlp/pipelines/ner/scores/tnm/patterns.py
@@ -4,7 +4,9 @@ node_pattern = r"n\s?(?P<node>[0-3o]|x)x?"
 metastasis_pattern = r"m\s?(?P<metastasis>[01o]|x)x?"
 
 version_pattern = (
-    r"\(?(?P<version>(uicc|tnm|accj)\s+([ée]ditions|[ée]d\.?)?\s*\d{4})\)?"
+    r"\(?(?P<version>uicc|accj|tnm)"
+    r"\s+([ée]ditions|[ée]d\.?)?\s*"
+    r"(?P<version_year>\d{4}|\d{2})\)?"
 )
 
 spacer = r"(.|\n){1,5}"

--- a/edsnlp/pipelines/ner/scores/tnm/patterns.py
+++ b/edsnlp/pipelines/ner/scores/tnm/patterns.py
@@ -1,9 +1,16 @@
-modifier_pattern = r"(?P<modifier>[cpyraums])"
-tumour_pattern = r"t\s?(?P<tumour>([0-4]|x|is))"
-node_pattern = r"n\s?(?P<node>([0-3]|x))"
-metastasis_pattern = r"m\s?(?P<metastasis>[01])"
+modifier_pattern = r"(?P<modifier>[cpyraum])"
+tumour_pattern = r"t\s?(?P<tumour>([0-4o]|is|x))x?"
+node_pattern = r"n\s?(?P<node>[0-3o]|x)x?"
+metastasis_pattern = r"m\s?(?P<metastasis>[01o]|x)x?"
 
-tnm_pattern = f"({modifier_pattern}\\s?)?"
-tnm_pattern += r"\s*" + tumour_pattern
-tnm_pattern += r"\s*" + node_pattern
-tnm_pattern += r"\s*" + metastasis_pattern
+version_pattern = (
+    r"(?P<version>\(?(uicc|tnm|accj)\s+([ée]ditions|[ée]d\.?)?\s*\d{4})\)?"
+)
+
+spacer = r"(.|\n){1,5}"
+
+tnm_pattern = f"(?<={version_pattern}{spacer})?"
+tnm_pattern += modifier_pattern + r"\s*" + f"({tumour_pattern})"
+tnm_pattern += r"\s*" + f"({node_pattern})?"
+tnm_pattern += r"\s*" + f"({metastasis_pattern})?"
+tnm_pattern += f"({spacer}{version_pattern})?"

--- a/edsnlp/pipelines/ner/scores/tnm/patterns.py
+++ b/edsnlp/pipelines/ner/scores/tnm/patterns.py
@@ -4,7 +4,7 @@ node_pattern = r"n\s?(?P<node>[0-3o]|x)x?"
 metastasis_pattern = r"m\s?(?P<metastasis>[01o]|x)x?"
 
 version_pattern = (
-    r"(?P<version>\(?(uicc|tnm|accj)\s+([ée]ditions|[ée]d\.?)?\s*\d{4})\)?"
+    r"\(?(?P<version>(uicc|tnm|accj)\s+([ée]ditions|[ée]d\.?)?\s*\d{4})\)?"
 )
 
 spacer = r"(.|\n){1,5}"

--- a/edsnlp/pipelines/ner/scores/tnm/patterns.py
+++ b/edsnlp/pipelines/ner/scores/tnm/patterns.py
@@ -1,0 +1,9 @@
+modifier_pattern = r"(?P<modifier>[cpyraums])"
+tumour_pattern = r"t\s?(?P<tumour>([0-4]|x|is))"
+node_pattern = r"n\s?(?P<node>([0-3]|x))"
+metastasis_pattern = r"m\s?(?P<metastasis>[01])"
+
+tnm_pattern = f"({modifier_pattern}\\s?)?"
+tnm_pattern += tumour_pattern
+tnm_pattern += node_pattern
+tnm_pattern += metastasis_pattern

--- a/edsnlp/pipelines/ner/scores/tnm/tnm.py
+++ b/edsnlp/pipelines/ner/scores/tnm/tnm.py
@@ -101,6 +101,7 @@ class TNM(BaseComponent):
         for span, groupdict in spans:
 
             span._.value = models.TNM.parse_obj(groupdict)
+            span.kb_id_ = span._.value.norm()
 
         return [span for span, _ in spans]
 
@@ -119,6 +120,8 @@ class TNM(BaseComponent):
             spaCy Doc object, annotated for TNM
         """
         spans = self.process(doc)
+        spans = filter_spans(spans)
+
         spans = self.parse(spans)
 
         doc.spans["tnm"] = spans

--- a/edsnlp/pipelines/ner/scores/tnm/tnm.py
+++ b/edsnlp/pipelines/ner/scores/tnm/tnm.py
@@ -8,7 +8,7 @@ from edsnlp.matchers.regex import RegexMatcher
 from edsnlp.pipelines.base import BaseComponent
 from edsnlp.utils.filter import filter_spans
 
-from . import patterns
+from . import patterns, models
 
 PERIOD_PROXIMITY_THRESHOLD = 3
 
@@ -100,7 +100,7 @@ class TNM(BaseComponent):
 
         for span, groupdict in spans:
 
-            span._.value = groupdict
+            span._.value = models.TNM.parse_obj(groupdict)
 
         return [span for span, _ in spans]
 

--- a/edsnlp/pipelines/ner/scores/tnm/tnm.py
+++ b/edsnlp/pipelines/ner/scores/tnm/tnm.py
@@ -1,0 +1,126 @@
+"""`eds.tnm` pipeline."""
+from typing import Dict, List, Optional, Tuple, Union
+
+from spacy.language import Language
+from spacy.tokens import Doc, Span
+
+from edsnlp.matchers.regex import RegexMatcher
+from edsnlp.pipelines.base import BaseComponent
+from edsnlp.utils.filter import filter_spans
+
+from . import patterns
+
+PERIOD_PROXIMITY_THRESHOLD = 3
+
+
+class TNM(BaseComponent):
+    """
+    Tags and normalizes TNM mentions.
+
+    Parameters
+    ----------
+    nlp : spacy.language.Language
+        Language pipeline object
+    pattern : Optional[Union[List[str], str]]
+        List of regular expressions for TNM mentions.
+    attr : str
+        spaCy attribute to use
+    """
+
+    # noinspection PyProtectedMember
+    def __init__(
+        self,
+        nlp: Language,
+        pattern: Optional[Union[List[str], str]],
+        attr: str,
+    ):
+
+        self.nlp = nlp
+
+        if pattern is None:
+            pattern = patterns.tnm_pattern
+
+        if isinstance(pattern, str):
+            pattern = [pattern]
+
+        self.regex_matcher = RegexMatcher(attr=attr, alignment_mode="strict")
+        self.regex_matcher.add("tnm", pattern)
+
+        self.set_extensions()
+
+    @staticmethod
+    def set_extensions() -> None:
+        """
+        Set extensions for the dates pipeline.
+        """
+
+        if not Span.has_extension("value"):
+            Span.set_extension("value", default=None)
+
+    def process(self, doc: Doc) -> List[Span]:
+        """
+        Find TNM mentions in doc.
+
+        Parameters
+        ----------
+        doc:
+            spaCy Doc object
+
+        Returns
+        -------
+        spans:
+            list of tnm spans
+        """
+
+        spans = self.regex_matcher(
+            doc,
+            as_spans=True,
+            return_groupdict=True,
+        )
+
+        spans = filter_spans(spans)
+
+        return spans
+
+    def parse(self, spans: List[Tuple[Span, Dict[str, str]]]) -> List[Span]:
+        """
+        Parse dates using the groupdict returned by the matcher.
+
+        Parameters
+        ----------
+        spans : List[Tuple[Span, Dict[str, str]]]
+            List of tuples containing the spans and groupdict
+            returned by the matcher.
+
+        Returns
+        -------
+        List[Span]
+            List of processed spans, with the date parsed.
+        """
+
+        for span, groupdict in spans:
+
+            span._.value = groupdict
+
+        return [span for span, _ in spans]
+
+    def __call__(self, doc: Doc) -> Doc:
+        """
+        Tags TNM mentions.
+
+        Parameters
+        ----------
+        doc : Doc
+            spaCy Doc object
+
+        Returns
+        -------
+        doc : Doc
+            spaCy Doc object, annotated for TNM
+        """
+        spans = self.process(doc)
+        spans = self.parse(spans)
+
+        doc.spans["tnm"] = spans
+
+        return doc

--- a/edsnlp/pipelines/ner/scores/tnm/tnm.py
+++ b/edsnlp/pipelines/ner/scores/tnm/tnm.py
@@ -123,4 +123,12 @@ class TNM(BaseComponent):
 
         doc.spans["tnm"] = spans
 
+        ents, discarded = filter_spans(list(doc.ents) + spans, return_discarded=True)
+
+        doc.ents = ents
+
+        if "discarded" not in doc.spans:
+            doc.spans["discarded"] = []
+        doc.spans["discarded"].extend(discarded)
+
         return doc

--- a/edsnlp/pipelines/ner/scores/tnm/tnm.py
+++ b/edsnlp/pipelines/ner/scores/tnm/tnm.py
@@ -8,7 +8,7 @@ from edsnlp.matchers.regex import RegexMatcher
 from edsnlp.pipelines.base import BaseComponent
 from edsnlp.utils.filter import filter_spans
 
-from . import patterns, models
+from . import models, patterns
 
 PERIOD_PROXIMITY_THRESHOLD = 3
 

--- a/notebooks/tnm/prototype.md
+++ b/notebooks/tnm/prototype.md
@@ -1,0 +1,63 @@
+---
+jupyter:
+  jupytext:
+    formats: md,ipynb
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.13.0
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+```python
+%reload_ext autoreload
+%autoreload 2
+```
+
+```python
+import spacy
+from spacy import displacy
+from spacy.tokens import Doc
+```
+
+# TNM mentions
+
+```python
+nlp = spacy.blank("fr")
+dates = nlp.add_pipe("eds.tnm")
+```
+
+```python
+text = "patient a un pTNM : pT0N2M1"
+```
+
+```python
+doc = nlp(text)
+```
+
+```python
+tnms = doc.spans['tnm']
+```
+
+```python
+def display_tnm(doc: Doc):
+    doc.ents = doc.spans['tnm']
+    return displacy.render(doc, style='ent')
+```
+
+```python
+display_tnm(doc)
+```
+
+```python
+for tnm in tnms:
+    print(f"{str(tnm):<25}{repr(tnm._.value)}")
+```
+
+```python
+
+```

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ factories = [
     "quotes = edsnlp.components:quotes",
     "charlson = edsnlp.components:charlson",
     "sofa = edsnlp.components:sofa",
+    "tnm = edsnlp.components:tnm",
     "priority = edsnlp.components:priority",
     "ccmu = edsnlp.components:ccmu",
     'gemsa" = edsnlp.components:gemsa',

--- a/tests/pipelines/ner/test_tnm.py
+++ b/tests/pipelines/ner/test_tnm.py
@@ -1,0 +1,21 @@
+from edsnlp.utils.examples import parse_example
+
+examples = [
+    "TNM: <ent norm=aTxN1M0>aTxN1M0</ent>",
+    "TNM: <ent norm=pTxN1M0>p Tx N1M 0</ent>",
+]
+
+
+def test_scores(blank_nlp):
+
+    blank_nlp.add_pipe("eds.TNM")
+
+    for example in examples:
+
+        text, entities = parse_example(example=example)
+
+        doc = blank_nlp(text)
+
+        for entity, ent in zip(entities, doc.ents):
+            norm = entity.modifiers[0].value
+            assert norm == ent._.value.norm()

--- a/tests/pipelines/ner/test_tnm.py
+++ b/tests/pipelines/ner/test_tnm.py
@@ -3,6 +3,8 @@ from edsnlp.utils.examples import parse_example
 examples = [
     "TNM: <ent norm=aTxN1M0>aTxN1M0</ent>",
     "TNM: <ent norm=pTxN1M0>p Tx N1M 0</ent>",
+    "TNM: <ent norm='pTxN1M0 (UICC 2020)'>p Tx N1M 0 (UICC 20)</ent>",
+    "TNM: <ent norm='aTxN1M0 (UICC 1968)'>aTxN1M0 (UICC 68)</ent>",
 ]
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Closes #48 by adding a TNM detection and normalisation pipeline.

The normalisation includes:
- normalisation of `o` (lowercase O) to `0` (zero)
- detection of T, N, M values
- distinction between quantities that cannot be assessed and quantities that were not presented (`pTxN1M1` v. `pN1M1`)
- detection of the version (both type and year, with year normalisation)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
