### PR TITLE
Add generic callback for multiprocessing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## Pending release
+
+### Added
+
+- Support for arbitrary callback for Pandas multiprocessing, with the `callback` argument
+
 ## v0.5.2 (2022-04-29)
 
 ### Added
 
 - Support for chained attributes in the `processing` pipelines
 - Colour utility with the category20 colour palette
-- Support for arbitrary callback for Pandas multiprocessing, with the `callback` argument
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Support for chained attributes in the `processing` pipelines
 - Colour utility with the category20 colour palette
+- Support for arbitrary callback for Pandas multiprocessing, with the `callback` argument
 
 ## v0.5.1 (2022-04-11)
 

--- a/docs/tutorials/multiple-texts.md
+++ b/docs/tutorials/multiple-texts.md
@@ -5,7 +5,7 @@ Once the pipeline is tested and ready to be applied on an entire corpus, we'll w
 
 In this tutorial, we'll cover a few best practices and some _caveats_ to avoid.
 Then, we'll explore methods that EDS-NLP provides to use a spaCy pipeline directly on a pandas or Spark DataFrame.
-These can drastically increase throughput (up to 20x speed increase on our 64-core machines).
+These can drastically increase throughput.
 
 Consider this simple pipeline:
 
@@ -206,11 +206,11 @@ data = data[["note_id"]].join(pd.json_normalize(data.entities))
 
 The result on the first note:
 
-| note_id | start |  end | label      | lexical_variant   | negation | hypothesis | family | key   |
-| ------: | ----: | ---: | :--------- | :---------------- | -------: | ---------: | -----: | :---- |
-|       0 |     0 |    7 | patient    | Patient           |        0 |          0 |      0 | ents  |
-|       0 |   114 |  121 | patient    | patient           |        0 |          0 |      1 | ents  |
-|       0 |    17 |   34 | 2021-09-25 | 25 septembre 2021 |      nan |        nan |    nan | dates |
+| note_id | start | end | label      | lexical_variant   | negation | hypothesis | family | key   |
+| ------: | ----: | --: | :--------- | :---------------- | -------: | ---------: | -----: | :---- |
+|       0 |     0 |   7 | patient    | Patient           |        0 |          0 |      0 | ents  |
+|       0 |   114 | 121 | patient    | patient           |        0 |          0 |      1 | ents  |
+|       0 |    17 |  34 | 2021-09-25 | 25 septembre 2021 |      nan |        nan |    nan | dates |
 
 ## Using EDS-NLP's helper functions
 
@@ -218,19 +218,23 @@ Let's see how we can efficiently deploy our pipeline using EDS-NLP's utility met
 
 They share the same arguments:
 
-| Argument           | Description                                                     | Default  |
-| ------------------ | --------------------------------------------------------------- | -------- |
-| `note`             | A DataFrame, with two required columns, `note_id` and `note_id` | Required |
-| `nlp`              | The pipeline object                                             | Required |
-| `context`          | A list of column names to add context to the generate `Doc`     | `[]`     |
-| `additional_spans` | Keys in `doc.spans` to include besides `doc.ents`               | `[]`     |
-| `extensions`       | Custom extensions to use                                        | `[]`     |
+| Argument           | Description                                                                   | Default                 |
+| ------------------ | ----------------------------------------------------------------------------- | ----------------------- |
+| `note`             | A DataFrame, with two required columns, `note_id` and `note_id`               | Required                |
+| `nlp`              | The pipeline object                                                           | Required                |
+| `context`          | A list of column names to add context to the generate `Doc`                   | `[]`                    |
+| `additional_spans` | Keys in `doc.spans` to include besides `doc.ents`                             | `[]`                    |
+| `extensions`       | Custom extensions to use                                                      | `[]`                    |
+| `extractor`        | An arbitrary callback function that turns a `Doc` into a list of dictionaries | `None` (use extensions) |
 
-!!! tip "Adding 'context'"
+!!! tip "Adding context"
 
-    You may want to store some values contained in your `note` DataFrame as an extension in the generated `Doc` object.
+    You might want to store some context information contained in the `note` DataFrame as an extension in the generated `Doc` object.
 
-    For instance, the [dates](../pipelines/misc/dates.md) pipeline will use, if provided, the `note_datetime` to add a _year_ to an incomplete year such as in: _"The 21st of August, the patient came to the hospital"_.
+    For instance, you may use the [`eds.dates` pipeline](../pipelines/misc/dates.md)
+    in coordination with the `note_datetime` field to normalise a relative date
+    (eg `Le patient est venu il y a trois jours/The patient came three days ago`).
+
     In this case, you can use the `context` parameter and provide a list of column names you want to add:
 
     <!-- no-check -->
@@ -245,7 +249,40 @@ They share the same arguments:
     )
     ```
 
-Depending on your pipeline, you may want to extract other extensions. To do so, simply provide those extension names (without the leading underscore) to the `extensions` argument.
+Depending on your pipeline, you may want to extract other extensions.
+To do so, simply provide those extension names (without the leading underscore) to the `extensions` argument.
+**This should cover most use-cases**.
+
+In case you need more fine-grained control over how you want to process the results of your pipeline,
+you can provide an arbitrary function to the pipeline. Said function is expected to take a spaCy `Doc`
+object as input, and return a list of dictionaries that will be used to construct the `note_nlp` table.
+For instance, the `get_entities` function defined earlier could be distributed directly:
+
+<!-- no-check -->
+
+```python
+# ↑ Omitted code above ↑
+from edsnlp.processing.simple import pipe as single_pipe
+from processing import get_entities
+
+note_nlp = single_pipe(
+    data,
+    nlp,
+    extractor=get_entities,
+)
+```
+
+!!! danger "A few caveats on using an arbitrary function"
+
+    Should you use multiprocessing, your arbitrary function needs to be serialisable
+    as a pickle object in order to be distributed. That implies a few limitations on the way your
+    function can be defined.
+
+    Namely, your function needs to be discoverable: it should be defined in a module that can be accessed by the worker processes.
+    See the [pickle documentation on the subject](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled) for detail.
+
+    For that reason, **arbitrary functions can only be distributed via Spark/Koalas if their source code is advertised to the Spark workers**.
+    To that end, pip installing your function should do the trick.
 
 ### Single process
 

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -220,7 +220,7 @@ def pipe(
 def custom_pipe(
     note: DataFrames,
     nlp: Language,
-    extractor: Callable[[Doc], List[Dict[str, Any]]],
+    results_extractor: Callable[[Doc], List[Dict[str, Any]]],
     dtypes: Dict[str, T.DataType],
     context: List[str] = [],
 ) -> DataFrame:
@@ -235,14 +235,14 @@ def custom_pipe(
         A Pyspark or Koalas DataFrame with a `note_id` and `note_text` column
     nlp : Language
         A spaCy pipe
-    extractor : Callable[[Doc], List[Dict[str, Any]]]
+    results_extractor : Callable[[Doc], List[Dict[str, Any]]]
         Arbitrary function that takes extract serialisable results from the computed
         spaCy `Doc` object. The output of the function must be a list of dictionaries
         containing the extracted spans or entities.
 
         There is no requirement for all entities to provide every dictionary key.
     dtypes : Dict[str, T.DataType]
-        Dictionary containing all expected keys from the extractor function,
+        Dictionary containing all expected keys from the `results_extractor` function,
         along with their types.
     context : List[str]
         A list of column to add to the generated SpaCy document as an extension.
@@ -294,7 +294,7 @@ def custom_pipe(
 
         results = []
 
-        for res in extractor(doc):
+        for res in results_extractor(doc):
             results.append([res.get(key) for key in dtypes])
 
         return results

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -221,13 +221,14 @@ def pipe(
 def custom_pipe(
     note: DataFrames,
     nlp: Language,
-    callback: Callable[[Doc], List[Dict[str, Any]]],
+    extractor: Callable[[Doc], List[Dict[str, Any]]],
     dtypes: Dict[str, T.DataType],
     context: List[str] = [],
 ) -> DataFrame:
     """
     Function to apply a spaCy pipe to a pyspark or koalas DataFrame note,
-    a generic callback function.
+    a generic callback function that converts a spaCy `Doc` object into a 
+    list of dictionaries.
 
     Parameters
     ----------
@@ -235,14 +236,15 @@ def custom_pipe(
         A Pyspark or Koalas DataFrame with a `note_id` and `note_text` column
     nlp : Language
         A spaCy pipe
-    callback : Callable[[Doc], List[Dict[str, Any]]]
+    extractor : Callable[[Doc], List[Dict[str, Any]]]
         Arbitrary function that takes extract serialisable results from the computed
         spaCy `Doc` object. The output of the function must be a list of dictionaries
         containing the extracted spans or entities.
 
         There is no requirement for all entities to provide every dictionary key.
     dtypes : Dict[str, T.DataType]
-        Dictionary containing all expected keys from the callback, along with their types.
+        Dictionary containing all expected keys from the extractor function,
+        along with their types.
     context : List[str]
         A list of column to add to the generated SpaCy document as an extension.
         For instance, if `context=["note_datetime"], the corresponding value found
@@ -293,7 +295,7 @@ def custom_pipe(
 
         results = []
 
-        for res in callback(doc):
+        for res in extractor(doc):
             results.append([res.get(key) for key in dtypes])
 
         return results

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -211,7 +211,7 @@ def pipe(
     )
     note_nlp = note_nlp.withColumn("matches", F.explode(note_nlp.matches))
 
-    note_nlp = note_nlp.select("note_id", "matches.*")
+    note_nlp = note_nlp.select("note_id", "matches.*", *context)
 
     return note_nlp
 
@@ -280,17 +280,17 @@ def custom_pipe(
         if text is None:
             return []
 
-        nlp = nlp_bc.value
+        nlp_ = nlp_bc.value
 
         for _, pipe in nlp.pipeline:
             if isinstance(pipe, BaseComponent):
                 pipe.set_extensions()
 
-        doc = nlp.make_doc(text)
+        doc = nlp_.make_doc(text)
         for context_name, context_value in zip(context, context_values):
             doc._.set(context_name, context_value)
 
-        doc = nlp(doc)
+        doc = nlp_(doc)
 
         results = []
 
@@ -304,6 +304,6 @@ def custom_pipe(
     )
 
     note_nlp = note_nlp.withColumn("matches", F.explode(note_nlp.matches))
-    note_nlp = note_nlp.select("note_id", "matches.*")
+    note_nlp = note_nlp.select("note_id", "matches.*", *context)
 
     return note_nlp

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -1,14 +1,12 @@
 from functools import partial
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from loguru import logger
-
 from decorator import decorator
+from loguru import logger
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql import types as T
 from spacy import Language
-
 from spacy.tokens import Doc
 
 from edsnlp.pipelines.base import BaseComponent
@@ -81,7 +79,8 @@ def pipe(
     additional_spans : Union[List[str], str], by default "discarded"
         A name (or list of names) of SpanGroup on which to apply the pipe too:
         SpanGroup are available as `doc.spans[spangroup_name]` and can be generated
-        by some pipes. For instance, the `eds.dates` pipeline component populates `doc.spans['dates']`
+        by some pipes. For instance, the `eds.dates` pipeline
+        component populates `doc.spans['dates']`
     extensions : List[Tuple[str, T.DataType]], by default []
         Spans extensions to add to the extracted results:
         For instance, if `extensions=["score_name"]`, the extracted result
@@ -227,7 +226,7 @@ def custom_pipe(
 ) -> DataFrame:
     """
     Function to apply a spaCy pipe to a pyspark or koalas DataFrame note,
-    a generic callback function that converts a spaCy `Doc` object into a 
+    a generic callback function that converts a spaCy `Doc` object into a
     list of dictionaries.
 
     Parameters

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -211,7 +211,7 @@ def pipe(
     )
     note_nlp = note_nlp.withColumn("matches", F.explode(note_nlp.matches))
 
-    note_nlp = note_nlp.select("note_id", "matches.*", *context)
+    note_nlp = note_nlp.select("note_id", "matches.*")
 
     return note_nlp
 
@@ -304,6 +304,6 @@ def custom_pipe(
     )
 
     note_nlp = note_nlp.withColumn("matches", F.explode(note_nlp.matches))
-    note_nlp = note_nlp.select("note_id", "matches.*", *context)
+    note_nlp = note_nlp.select("note_id", "matches.*")
 
     return note_nlp

--- a/edsnlp/processing/helpers.py
+++ b/edsnlp/processing/helpers.py
@@ -44,14 +44,14 @@ def check_spacy_version_for_context():  # pragma: no cover
 
 def rgetattr(obj: Any, attr: str, *args: List[Any]) -> Any:
     """
-    Recursively getting attribute
+    Get attribute recursively
 
     Parameters
     ----------
     obj : Any
         An object
     attr : str
-        The name of the attriute to get. Can contain dots.
+        The name of the attribute to get. Can contain dots.
     """
 
     def _getattr(obj, attr):

--- a/edsnlp/processing/parallel.py
+++ b/edsnlp/processing/parallel.py
@@ -81,7 +81,7 @@ def pipe(
         by some pipes. For instance, the `date` pipe populates doc.spans['dates']
     extensions : List[Tuple[str, T.DataType]], by default []
         Spans extensions to add to the extracted results:
-        FOr instance, if `extensions=["score_name"]`, the extracted result
+        For instance, if `extensions=["score_name"]`, the extracted result
         will include, for each entity, `ent._.score_name`.
     chunksize: int, by default 100
         Batch size used to split tasks

--- a/edsnlp/processing/parallel.py
+++ b/edsnlp/processing/parallel.py
@@ -51,7 +51,7 @@ def pipe(
     context: List[str] = [],
     additional_spans: Union[List[str], str] = [],
     extensions: ExtensionSchema = [],
-    callback: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     chunksize: int = 100,
     n_jobs: int = -2,
     progress_bar: bool = True,
@@ -71,7 +71,7 @@ def pipe(
         For instance, if `context=["note_datetime"], the corresponding value found
         in the `note_datetime` column will be stored in `doc._.note_datetime`,
         which can be useful e.g. for the `dates` pipeline.
-    callback : Optional[Callable[[Doc], List[Dict[str, Any]]]]
+    extractor : Optional[Callable[[Doc], List[Dict[str, Any]]]]
         Arbitrary function that takes extract serialisable results from the computed
         spaCy `Doc` object. The output of the function must be a list of dictionaries
         containing the extracted spans or entities.
@@ -114,7 +114,7 @@ def pipe(
 
     pipe_kwargs["additional_spans"] = additional_spans
     pipe_kwargs["extensions"] = extensions
-    pipe_kwargs["callback"] = callback
+    pipe_kwargs["extractor"] = extractor
     pipe_kwargs["context"] = context
 
     if verbose:

--- a/edsnlp/processing/parallel.py
+++ b/edsnlp/processing/parallel.py
@@ -1,10 +1,9 @@
-from typing import Callable, Iterable, List, Optional, Union, Dict, Any
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import pandas as pd
 import spacy
 from joblib import Parallel, delayed
 from spacy import Language
-
 from spacy.tokens import Doc
 
 from .helpers import check_spacy_version_for_context

--- a/edsnlp/processing/parallel.py
+++ b/edsnlp/processing/parallel.py
@@ -50,7 +50,7 @@ def pipe(
     context: List[str] = [],
     additional_spans: Union[List[str], str] = [],
     extensions: ExtensionSchema = [],
-    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    results_extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     chunksize: int = 100,
     n_jobs: int = -2,
     progress_bar: bool = True,
@@ -70,7 +70,7 @@ def pipe(
         For instance, if `context=["note_datetime"], the corresponding value found
         in the `note_datetime` column will be stored in `doc._.note_datetime`,
         which can be useful e.g. for the `dates` pipeline.
-    extractor : Optional[Callable[[Doc], List[Dict[str, Any]]]]
+    results_extractor : Optional[Callable[[Doc], List[Dict[str, Any]]]]
         Arbitrary function that takes extract serialisable results from the computed
         spaCy `Doc` object. The output of the function must be a list of dictionaries
         containing the extracted spans or entities.
@@ -113,7 +113,7 @@ def pipe(
 
     pipe_kwargs["additional_spans"] = additional_spans
     pipe_kwargs["extensions"] = extensions
-    pipe_kwargs["extractor"] = extractor
+    pipe_kwargs["results_extractor"] = results_extractor
     pipe_kwargs["context"] = context
 
     if verbose:

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -101,7 +101,7 @@ def _pipe_generator(
     for doc in tqdm(pipeline, total=n_docs, disable=not progress_bar):
 
         if callback:
-            yield from callback(doc)
+            yield callback(doc)
 
         else:
             yield _full_schema(

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import pandas as pd
 import spacy

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -72,7 +72,7 @@ def _pipe_generator(
     note: pd.DataFrame,
     nlp: Language,
     context: List[str] = [],
-    callback: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     additional_spans: Union[List[str], str] = [],
     extensions: ExtensionSchema = [],
     batch_size: int = 50,
@@ -100,8 +100,8 @@ def _pipe_generator(
 
     for doc in tqdm(pipeline, total=n_docs, disable=not progress_bar):
 
-        if callback:
-            yield callback(doc)
+        if extractor:
+            yield extractor(doc)
 
         else:
             yield _full_schema(
@@ -181,7 +181,7 @@ def pipe(
     note: pd.DataFrame,
     nlp: Language,
     context: List[str] = [],
-    callback: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     additional_spans: Union[List[str], str] = [],
     extensions: Union[List[str], str] = [],
     batch_size: int = 1000,
@@ -226,7 +226,7 @@ def pipe(
                 note=note,
                 nlp=nlp,
                 context=context,
-                callback=callback,
+                extractor=extractor,
                 additional_spans=additional_spans,
                 extensions=extensions,
                 batch_size=batch_size,

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -72,7 +72,7 @@ def _pipe_generator(
     note: pd.DataFrame,
     nlp: Language,
     context: List[str] = [],
-    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    results_extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     additional_spans: Union[List[str], str] = [],
     extensions: ExtensionSchema = [],
     batch_size: int = 50,
@@ -100,8 +100,8 @@ def _pipe_generator(
 
     for doc in tqdm(pipeline, total=n_docs, disable=not progress_bar):
 
-        if extractor:
-            yield extractor(doc)
+        if results_extractor:
+            yield results_extractor(doc)
 
         else:
             yield _full_schema(
@@ -181,7 +181,7 @@ def pipe(
     note: pd.DataFrame,
     nlp: Language,
     context: List[str] = [],
-    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    results_extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     additional_spans: Union[List[str], str] = [],
     extensions: Union[List[str], str] = [],
     batch_size: int = 1000,
@@ -226,7 +226,7 @@ def pipe(
                 note=note,
                 nlp=nlp,
                 context=context,
-                extractor=extractor,
+                results_extractor=results_extractor,
                 additional_spans=additional_spans,
                 extensions=extensions,
                 batch_size=batch_size,

--- a/edsnlp/processing/utils.py
+++ b/edsnlp/processing/utils.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict, List
+
+from spacy.tokens import Doc
+
+
+def dummy_extractor(doc: Doc) -> List[Dict[str, Any]]:
+    return [
+        dict(snippet=ent.text, length=len(ent.text), note_datetime=doc._.note_datetime)
+        for ent in doc.ents
+    ]

--- a/edsnlp/processing/wrapper.py
+++ b/edsnlp/processing/wrapper.py
@@ -14,7 +14,7 @@ def pipe(
     nlp: Language,
     n_jobs: int = -2,
     context: List[str] = [],
-    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    results_extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     additional_spans: Union[List[str], str] = [],
     extensions: ExtensionSchema = [],
     **kwargs: Dict[str, Any],
@@ -70,7 +70,7 @@ def pipe(
                 note=note,
                 nlp=nlp,
                 context=context,
-                extractor=extractor,
+                results_extractor=results_extractor,
                 additional_spans=additional_spans,
                 extensions=extensions,
                 **kwargs,
@@ -82,7 +82,7 @@ def pipe(
                 note=note,
                 nlp=nlp,
                 context=context,
-                extractor=extractor,
+                results_extractor=results_extractor,
                 additional_spans=additional_spans,
                 extensions=extensions,
                 n_jobs=n_jobs,
@@ -101,7 +101,7 @@ def pipe(
     from .distributed import custom_pipe
     from .distributed import pipe as distributed_pipe
 
-    if extractor is None:
+    if results_extractor is None:
 
         return distributed_pipe(
             note=note,
@@ -119,7 +119,7 @@ def pipe(
             note=note,
             nlp=nlp,
             context=context,
-            extractor=extractor,
+            results_extractor=results_extractor,
             dtypes=dtypes,
             **kwargs,
         )

--- a/edsnlp/processing/wrapper.py
+++ b/edsnlp/processing/wrapper.py
@@ -15,7 +15,7 @@ def pipe(
     nlp: Language,
     n_jobs: int = -2,
     context: List[str] = [],
-    callback: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
+    extractor: Optional[Callable[[Doc], List[Dict[str, Any]]]] = None,
     additional_spans: Union[List[str], str] = [],
     extensions: ExtensionSchema = [],
     **kwargs: Dict[str, Any],
@@ -71,7 +71,7 @@ def pipe(
                 note=note,
                 nlp=nlp,
                 context=context,
-                callback=callback,
+                extractor=extractor,
                 additional_spans=additional_spans,
                 extensions=extensions,
                 **kwargs,
@@ -83,7 +83,7 @@ def pipe(
                 note=note,
                 nlp=nlp,
                 context=context,
-                callback=callback,
+                extractor=extractor,
                 additional_spans=additional_spans,
                 extensions=extensions,
                 n_jobs=n_jobs,
@@ -101,7 +101,7 @@ def pipe(
 
     from .distributed import pipe as distributed_pipe, custom_pipe
 
-    if callback is None:
+    if extractor is None:
 
         return distributed_pipe(
             note=note,
@@ -119,7 +119,7 @@ def pipe(
             note=note,
             nlp=nlp,
             context=context,
-            callback=callback,
+            extractor=extractor,
             dtypes=dtypes,
             **kwargs,
         )

--- a/edsnlp/processing/wrapper.py
+++ b/edsnlp/processing/wrapper.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, List, Union, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from spacy import Language
-
 from spacy.tokens import Doc
 
 from .helpers import DataFrameModules, DataFrames, get_module
@@ -99,7 +98,8 @@ def pipe(
             """  # noqa W291
         )
 
-    from .distributed import pipe as distributed_pipe, custom_pipe
+    from .distributed import custom_pipe
+    from .distributed import pipe as distributed_pipe
 
     if extractor is None:
 

--- a/edsnlp/processing/wrapper.py
+++ b/edsnlp/processing/wrapper.py
@@ -62,6 +62,9 @@ def pipe(
     module = get_module(note)
 
     if module == DataFrameModules.PANDAS:
+
+        kwargs.pop("dtypes", None)
+
         if n_jobs == 1:
 
             return simple_pipe(

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -197,6 +197,5 @@ def test_arbitrary_callback(param, model):
             "note_id",
             "snippet",
             "length",
-            "note_datetime",
         }
         assert (note_nlp.snippet.str.len() == note_nlp.length).all()

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -1,15 +1,13 @@
 from datetime import datetime
+from typing import Any, Dict, List
 
 import databricks.koalas  # noqa F401
 import pandas as pd
 import pytest
 import spacy
-
-from spacy.tokens import Doc
-from typing import Any, Dict, List
-
 from pyspark.sql import types as T
 from pyspark.sql.session import SparkSession
+from spacy.tokens import Doc
 
 from edsnlp.processing import pipe
 from edsnlp.processing.helpers import DataFrameModules

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -167,7 +167,7 @@ def test_spark_missing_types(model):
         )
 
 
-def callback(doc: Doc) -> List[Dict[str, Any]]:
+def extractor(doc: Doc) -> List[Dict[str, Any]]:
     return [dict(snippet=ent.text, length=len(ent.text)) for ent in doc.ents]
 
 
@@ -181,7 +181,7 @@ def test_arbitrary_callback(param, model):
         nlp=model,
         n_jobs=param["n_jobs"],
         context=["note_datetime"],
-        callback=callback,
+        extractor=extractor,
         dtypes={
             "snippet": T.StringType(),
             "length": T.IntegerType(),

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -165,7 +165,7 @@ def test_spark_missing_types(model):
         )
 
 
-def extractor(doc: Doc) -> List[Dict[str, Any]]:
+def results_extractor(doc: Doc) -> List[Dict[str, Any]]:
     return [dict(snippet=ent.text, length=len(ent.text)) for ent in doc.ents]
 
 
@@ -179,7 +179,7 @@ def test_arbitrary_callback(param, model):
         nlp=model,
         n_jobs=param["n_jobs"],
         context=["note_datetime"],
-        extractor=extractor,
+        results_extractor=results_extractor,
         dtypes={
             "snippet": T.StringType(),
             "length": T.IntegerType(),

--- a/tests/processing/test_processing.py
+++ b/tests/processing/test_processing.py
@@ -166,7 +166,10 @@ def test_spark_missing_types(model):
 
 
 def results_extractor(doc: Doc) -> List[Dict[str, Any]]:
-    return [dict(snippet=ent.text, length=len(ent.text)) for ent in doc.ents]
+    return [
+        dict(snippet=ent.text, length=len(ent.text), note_datetime=doc._.note_datetime)
+        for ent in doc.ents
+    ]
 
 
 @pytest.mark.parametrize("param", params[:2])
@@ -191,5 +194,5 @@ def test_arbitrary_callback(param, model):
     elif module == DataFrameModules.KOALAS:
         note_nlp = note_nlp.to_pandas()
 
-    assert set(note_nlp.columns) == {"snippet", "length"}
+    assert set(note_nlp.columns) == {"snippet", "length", "note_datetime"}
     assert (note_nlp.snippet.str.len() == note_nlp.length).all()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR adds back the possibility to define an arbitrary callback function that handles returning results from a processed spaCy doc object.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
