### PR TITLE
Force batch size of 2000 when distributing pipe

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Pending v0.5.3
+
+### Added
+
+- Using a batch size of 2000 when distributing a pipeline with Spark
+
 ## v0.5.3 (2022-05-04)
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Pending v0.5.3
+## Pending Release
 
 ### Added
 

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -206,7 +206,7 @@ def pipe(
         extensions=extensions,
     )
 
-    n_needed_partitions = note.count() // 2000  # Batch sizes of 2000
+    n_needed_partitions = max(note.count() // 2000, 1)  # Batch sizes of 2000
 
     note_nlp = note.repartition(n_needed_partitions).withColumn(
         "matches", matcher(F.col("note_text"), *[F.col(c) for c in context])

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -206,9 +206,12 @@ def pipe(
         extensions=extensions,
     )
 
-    note_nlp = note.withColumn(
+    n_needed_partitions = note.count() // 2000  # Batch sizes of 2000
+
+    note_nlp = note.repartition(n_needed_partitions).withColumn(
         "matches", matcher(F.col("note_text"), *[F.col(c) for c in context])
     )
+
     note_nlp = note_nlp.withColumn("matches", F.explode(note_nlp.matches))
 
     note_nlp = note_nlp.select("note_id", "matches.*")


### PR DESCRIPTION
Force batch size of 2000 when distributing pipe

## Description

We use the `repartition` method of `PySpark` to split data in partitions of roughly 2000 texts before applying the matcher's UDF.
This will improve performances by removing a common bottleneck of very skewed tasks.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
