### PR TITLE
Simple terminology matcher

### DIFF
--- a/docs/pipelines/core/terminology.md
+++ b/docs/pipelines/core/terminology.md
@@ -1,0 +1,70 @@
+# Terminology
+
+EDS-NLP simplifies the terminology matching process by exposing a `eds.terminology` pipeline
+that can match on terms or regular expressions.
+
+The terminology matcher is very similar to the [generic matcher](matcher.md), although the use case differs slightly.
+The generic matcher is designed to extract any entity, while the terminology matcher is specifically tailored
+towards high volume terminologies.
+
+There are some key differences:
+
+1. It labels every matched entity to the same value, provided to the pipeline.
+2. The keys provided in the `regex` and `terms` dictionaries are used as the `kb_id_` of the entity.
+
+For instance, a terminology matcher could detect every drug mention under the top-level label `drug`,
+and link each individual mention to a given drug through its `kb_id_` attribute.
+
+## Usage
+
+Let us redefine the pipeline :
+
+```python
+import spacy
+
+nlp = spacy.blank("fr")
+
+terms = dict(
+    covid=["coronavirus", "covid19"],  # (1)
+    flu=["grippe saisonnière"],  # (2)
+)
+
+regex = dict(
+    covid=r"coronavirus|covid[-\s]?19|sars[-\s]cov[-\s]2",  # (3)
+)
+
+nlp.add_pipe(
+    "eds.terminology",
+    config=dict(
+        label="disease",
+        terms=terms,
+        regex=regex,
+        attr="LOWER",
+    ),
+)
+```
+
+1. Every key in the `terms` dictionary is mapped to a concept.
+2. The `eds.matcher` pipeline expects a list of expressions, or a single expression.
+3. We can also define regular expression patterns.
+
+This snippet is complete, and should run as is.
+
+## Configuration
+
+The pipeline can be configured using the following parameters :
+
+| Parameter         | Explanation                                      | Default                 |
+| ----------------- | ------------------------------------------------ | ----------------------- |
+| `label`           | Top-level label.                                 | Required                |
+| `terms`           | Terms patterns. Expects a dictionary.            | `None` (use regex only) |
+| `regex`           | RegExp patterns. Expects a dictionary.           | `None` (use terms only) |
+| `attr`            | spaCy attribute to match on (eg `NORM`, `LOWER`) | `"TEXT"`                |
+| `ignore_excluded` | Whether to skip excluded tokens during matching  | `False`                 |
+
+Patterns, be they `terms` or `regex`, are defined as dictionaries where keys become the `kb_id_` of the extracted entities.
+Dictionary values are a either a single expression or a list of expressions that match the concept (see [example](#usage)).
+
+## Authors and citation
+
+The `eds.terminology` pipeline was developed by AP-HP's Data Science team.

--- a/edsnlp/pipelines/core/terminology/__init__.py
+++ b/edsnlp/pipelines/core/terminology/__init__.py
@@ -1,0 +1,1 @@
+from .terminology import TerminologyMatcher

--- a/edsnlp/pipelines/core/terminology/factory.py
+++ b/edsnlp/pipelines/core/terminology/factory.py
@@ -1,0 +1,39 @@
+from typing import Dict, List, Optional, Union
+
+from spacy.language import Language
+
+from edsnlp.pipelines.core.terminology import TerminologyMatcher
+
+DEFAULT_CONFIG = dict(
+    terms=None,
+    regex=None,
+    attr="TEXT",
+    ignore_excluded=False,
+)
+
+
+@Language.factory("eds.terminology", default_config=DEFAULT_CONFIG)
+def create_component(
+    nlp: Language,
+    name: str,
+    label: str,
+    terms: Optional[Dict[str, Union[str, List[str]]]],
+    attr: Union[str, Dict[str, str]],
+    regex: Optional[Dict[str, Union[str, List[str]]]],
+    ignore_excluded: bool,
+):
+    assert not (terms is None and regex is None)
+
+    if terms is None:
+        terms = dict()
+    if regex is None:
+        regex = dict()
+
+    return TerminologyMatcher(
+        nlp,
+        label=label,
+        terms=terms,
+        attr=attr,
+        regex=regex,
+        ignore_excluded=ignore_excluded,
+    )

--- a/edsnlp/pipelines/factories.py
+++ b/edsnlp/pipelines/factories.py
@@ -9,6 +9,7 @@ from .core.normalizer.lowercase.factory import remove_lowercase
 from .core.normalizer.pollution.factory import create_component as pollution
 from .core.normalizer.quotes.factory import create_component as quotes
 from .core.sentences.factory import create_component as sentences
+from .core.terminology.factory import create_component as terminology
 from .misc.consultation_dates.factory import create_component as consultation_dates
 from .misc.dates.factory import create_component as dates
 from .misc.measures.factory import create_component as measures

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - Core Pipelines:
       - pipelines/core/index.md
       - pipelines/core/matcher.md
+      - pipelines/core/terminology.md
       - pipelines/core/normalisation.md
       - pipelines/core/endlines.md
       - pipelines/core/sentences.md

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 factories = [
     "matcher = edsnlp.components:matcher",
+    "terminology = edsnlp.components:terminology",
     "advanced = edsnlp.components:advanced",
     "endlines = edsnlp.components:endlines",
     "sentences = edsnlp.components:sentences",

--- a/tests/pipelines/core/test_terminology.py
+++ b/tests/pipelines/core/test_terminology.py
@@ -1,0 +1,26 @@
+from spacy.language import Language
+
+from edsnlp.utils.examples import parse_example
+
+example = "1g de <ent kb_id=paracetamol>doliprane</ent>"
+
+
+def test_terminology(blank_nlp: Language):
+    blank_nlp.add_pipe(
+        "eds.terminology",
+        config=dict(
+            label="drugs",
+            terms=dict(paracetamol=["doliprane", "tylenol", "paracetamol"]),
+            attr="NORM",
+        ),
+    )
+
+    text, entities = parse_example(example)
+
+    doc = blank_nlp(text)
+
+    assert len(entities) == len(doc.ents)
+
+    for ent, entity in zip(doc.ents, entities):
+        assert ent.text == text[entity.start_char : entity.end_char]
+        assert ent.kb_id_ == entity.modifiers[0].value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR proposes a simple terminology matcher. The proposed component closely resembles the `GenericMatcher`, with two key differences:

1. All matched entities are given the same label, provided in the configuration of the component
2. The keys of `regex` and `terms`, used as labels in the `GenericMatcher`, now populate the `kb_id_` attribute

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
