### PR TITLE
Differentiate duration and datetime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- New `to_duration` method to convert an absolute date into a date relative to the note_datetime (or None)
+- New `use_date_label` in `eds.dates` to store absolute and relative dates under a same `date` label (instead of `absolute` and `relative`)
+
+### Changed
+
+- Duration time entities (from `eds.dates`) are now stored in the `durations` span group, different than the `dates` span group
+- `to_datetime` now only return absolute dates, converts relative dates into absolute if `doc._.note_datetime` is given, and None otherwise
+
 ## v0.8.0 (2023-03-09)
 
 ### Added

--- a/docs/pipelines/misc/dates.md
+++ b/docs/pipelines/misc/dates.md
@@ -35,27 +35,30 @@ doc = nlp(text)
 
 dates = doc.spans["dates"]
 dates
-# Out: [23 août 2021, il y a un an, pendant une semaine, mai 1995]
+# Out: [23 août 2021, il y a un an, mai 1995]
 
 dates[0]._.date.to_datetime()
 # Out: 2021-08-23T00:00:00+02:00
 
 dates[1]._.date.to_datetime()
-# Out: -1 year
+# Out: None
 
 note_datetime = pendulum.datetime(2021, 8, 27, tz="Europe/Paris")
 
 dates[1]._.date.to_datetime(note_datetime=note_datetime)
-# Out: DateTime(2020, 8, 27, 0, 0, 0, tzinfo=Timezone('Europe/Paris'))
+# Out: 2020-08-27T00:00:00+02:00
 
-date_3_output = dates[3]._.date.to_datetime(
+date_2_output = dates[2]._.date.to_datetime(
     note_datetime=note_datetime,
     infer_from_context=True,
     tz="Europe/Paris",
     default_day=15,
 )
-date_3_output
-# Out: DateTime(1995, 5, 15, 0, 0, 0, tzinfo=Timezone('Europe/Paris'))
+date_2_output
+# Out: 1995-05-15T00:00:00+02:00
+
+doc.spans["durations"]
+# Out: [pendant une semaine]
 ```
 
 ## Declared extensions

--- a/docs/pipelines/misc/dates.md
+++ b/docs/pipelines/misc/dates.md
@@ -69,17 +69,9 @@ The `eds.dates` pipeline declares one [spaCy extension](https://spacy.io/usage/p
 
 The pipeline can be configured using the following parameters :
 
-| Parameter        | Explanation                                      | Default                           |
-|------------------|--------------------------------------------------|-----------------------------------|
-| `absolute`       | Absolute date patterns, eg `le 5 août 2020`      | `None` (use pre-defined patterns) |
-| `relative`       | Relative date patterns, eg `hier`)               | `None` (use pre-defined patterns) |
-| `durations`      | Duration patterns, eg `pendant trois mois`)      | `None` (use pre-defined patterns) |
-| `false_positive` | Some false positive patterns to exclude          | `None` (use pre-defined patterns) |
-| `detect_periods` | Whether to look for periods                      | `False`                           |
-| `detect_time`    | Whether to look for time around dates            | `True`                            |
-| `on_ents_only`   | Whether to look for dates around entities only   | `False`                           |
-| `as_ents`        | Whether to save detected dates as entities       | `False`                           |
-| `attr`           | spaCy attribute to match on, eg `NORM` or `TEXT` | `"NORM"`                          |
+::: edsnlp.pipelines.misc.dates.factory.create_component
+    options:
+        only_parameters: true
 
 ## Authors and citation
 

--- a/docs/pipelines/qualifiers/history.md
+++ b/docs/pipelines/qualifiers/history.md
@@ -80,18 +80,9 @@ doc.ents[3]._.history  # (2)
 
 The pipeline can be configured using the following parameters :
 
-| Parameter            | Explanation                                                                                                          | Default                           |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `attr`               | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)                                                             | `"NORM"`                          |
-| `history`            | History patterns                                                                                                     | `None` (use pre-defined patterns) |
-| `termination`        | Termination patterns (for syntagma/proposition extraction)                                                           | `None` (use pre-defined patterns) |
-| `use_sections`       | Whether to use pre-annotated sections (requires the `sections` pipeline)                                             | `False`                           |
-| `use_dates`          | Whether to use dates pipeline (requires the `dates` pipeline and ``note_datetime`` context is recommended)           | `False`                           |
-| `history_limit`      | If `use_dates = True`. The number of days after which the event is considered as history.                            | `14` (2 weeks)                    |
-| `exclude_birthdate`  | If `use_dates = True`. Whether to exclude the birth date from history dates.                                         | `True`                            |
-| `closest_dates_only` | If `use_dates = True`. Whether to include the closest dates only. If `False`, it includes all dates in the sentence. | `True`                            |
-| `on_ents_only`       | Whether to qualify pre-extracted entities only                                                                       | `True`                            |
-| `explain`            | Whether to keep track of the cues for each entity                                                                    | `False`                           |
+::: edsnlp.pipelines.qualifiers.history.factory.create_component
+    options:
+        only_parameters: true
 
 ## Declared extensions
 

--- a/edsnlp/pipelines/misc/dates/dates.py
+++ b/edsnlp/pipelines/misc/dates/dates.py
@@ -55,6 +55,9 @@ class Dates(BaseComponent):
         Whether to treat dates as entities
     attr : str
         spaCy attribute to use
+    use_date_label: bool
+        Whether to use a shared `date` label for absolute and relative dates
+        instead of `absolute` and `relative` labels
     """
 
     # noinspection PyProtectedMember
@@ -70,8 +73,10 @@ class Dates(BaseComponent):
         detect_time: bool,
         as_ents: bool,
         attr: str,
+        use_date_label: bool = False,
     ):
 
+        self.use_date_label = use_date_label
         self.nlp = nlp
 
         if absolute is None:
@@ -195,8 +200,12 @@ class Dates(BaseComponent):
         for span, groupdict in dates:
             if span.label_ == "relative":
                 parsed = RelativeDate.parse_obj(groupdict)
+                if self.use_date_label:
+                    span.label_ = "date"
             elif span.label_ == "absolute":
                 parsed = AbsoluteDate.parse_obj(groupdict)
+                if self.use_date_label:
+                    span.label_ = "date"
             else:
                 parsed = Duration.parse_obj(groupdict)
 
@@ -277,7 +286,8 @@ class Dates(BaseComponent):
         dates = self.process(doc)
         dates = self.parse(dates)
 
-        doc.spans["dates"] = dates
+        doc.spans["dates"] = [d for d in dates if d.label_ != "duration"]
+        doc.spans["durations"] = [d for d in dates if d.label_ == "duration"]
 
         if self.detect_periods:
             doc.spans["periods"] = self.process_periods(dates)

--- a/edsnlp/pipelines/misc/dates/dates.py
+++ b/edsnlp/pipelines/misc/dates/dates.py
@@ -41,7 +41,7 @@ class Dates(BaseComponent):
     false_positive : Union[List[str], str]
         List of regular expressions for false positive (eg phone numbers, etc).
     on_ents_only : Union[bool, str, List[str]]
-        Wether to look on dates in the whole document or in specific sentences:
+        Whether to look on dates in the whole document or in specific sentences:
 
         - If `True`: Only look in the sentences of each entity in doc.ents
         - If False: Look in the whole document
@@ -49,6 +49,8 @@ class Dates(BaseComponent):
           each entity in `#!python doc.spans[key]`
     detect_periods : bool
         Whether to detect periods (experimental)
+    detect_time: bool
+        Whether to detect time inside dates
     as_ents : bool
         Whether to treat dates as entities
     attr : str

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -35,6 +35,7 @@ def create_component(
     detect_time: bool = True,
     as_ents: bool = False,
     attr: str = "LOWER",
+    use_date_label: bool = False,
 ):
     """
     Tags and normalizes dates, using the open-source `dateparser` library.
@@ -73,6 +74,9 @@ def create_component(
         Whether to treat dates as entities
     attr : str
         spaCy attribute to use
+    use_date_label: bool
+        Whether to use a shared `date` label for absolute and relative dates
+        instead of `absolute` and `relative` labels
     """
     return Dates(
         nlp,
@@ -85,4 +89,5 @@ def create_component(
         detect_time=detect_time,
         as_ents=as_ents,
         attr=attr,
+        use_date_label=use_date_label,
     )

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -25,17 +25,55 @@ DEFAULT_CONFIG = dict(
 @Language.factory("eds.dates", default_config=DEFAULT_CONFIG, assigns=["doc.spans"])
 def create_component(
     nlp: Language,
-    name: str,
-    absolute: Optional[List[str]],
-    relative: Optional[List[str]],
-    duration: Optional[List[str]],
-    false_positive: Optional[List[str]],
-    on_ents_only: Union[bool, List[str]],
-    detect_periods: bool,
-    detect_time: bool,
-    as_ents: bool,
-    attr: str,
+    name: str = "eds.dates",
+    absolute: Optional[List[str]] = None,
+    relative: Optional[List[str]] = None,
+    duration: Optional[List[str]] = None,
+    false_positive: Optional[List[str]] = None,
+    on_ents_only: Union[bool, List[str]] = False,
+    detect_periods: bool = False,
+    detect_time: bool = True,
+    as_ents: bool = False,
+    attr: str = "LOWER",
 ):
+    """
+    Tags and normalizes dates, using the open-source `dateparser` library.
+
+    The pipeline uses spaCy's `filter_spans` function.
+    It filters out false positives, and introduce a hierarchy between patterns.
+    For instance, in case of ambiguity, the pipeline will decide that a date is a
+    date without a year rather than a date without a day.
+
+    Parameters
+    ----------
+    nlp : spacy.language.Language
+        Language pipeline object
+    absolute : Union[List[str], str]
+        List of regular expressions for absolute dates.
+    relative : Union[List[str], str]
+        List of regular expressions for relative dates
+        (eg `hier`, `la semaine prochaine`).
+    duration : Union[List[str], str]
+        List of regular expressions for durations
+        (eg `pendant trois mois`).
+    false_positive : Union[List[str], str]
+        List of regular expressions for false positive (eg phone numbers, etc).
+    on_ents_only : Union[bool, str, List[str]]
+        Whether to look on dates in the whole document or in specific sentences:
+
+        - If `True`: Only look in the sentences of each entity in doc.ents
+        - If False: Look in the whole document
+        - If given a string `key` or list of string: Only look in the sentences of
+          each entity in `#!python doc.spans[key]`
+    detect_periods : bool
+        Whether to detect periods (experimental)
+    detect_time: bool
+        Whether to detect time inside dates
+    as_ents : bool
+        Whether to treat dates as entities
+    attr : str
+        spaCy attribute to use
+    """
     return Dates(
         nlp,
         absolute=absolute,

--- a/edsnlp/pipelines/qualifiers/history/factory.py
+++ b/edsnlp/pipelines/qualifiers/history/factory.py
@@ -3,13 +3,13 @@ from typing import List, Optional
 from spacy.language import Language
 
 from edsnlp.pipelines.qualifiers.history import History, patterns
-from edsnlp.pipelines.terminations import termination
+from edsnlp.pipelines.terminations import termination as termination_patterns
 from edsnlp.utils.deprecation import deprecated_factory
 
 DEFAULT_CONFIG = dict(
     attr="NORM",
     history=patterns.history,
-    termination=termination,
+    termination=termination_patterns,
     use_sections=False,
     use_dates=False,
     history_limit=14,
@@ -45,18 +45,54 @@ DEFAULT_CONFIG = dict(
 )
 def create_component(
     nlp: Language,
-    name: str,
-    history: Optional[List[str]],
-    termination: Optional[List[str]],
-    use_sections: bool,
-    use_dates: bool,
-    history_limit: int,
-    exclude_birthdate: bool,
-    closest_dates_only: bool,
-    attr: str,
-    explain: bool,
-    on_ents_only: bool,
+    name: str = "eds.history",
+    history: Optional[List[str]] = patterns.history,
+    termination: Optional[List[str]] = termination_patterns,
+    use_sections: bool = False,
+    use_dates: bool = False,
+    history_limit: int = 14,
+    exclude_birthdate: bool = True,
+    closest_dates_only: bool = True,
+    attr: str = "NORM",
+    explain: bool = False,
+    on_ents_only: bool = True,
 ):
+    """
+    Implements a history detection algorithm.
+
+    The component looks for terms indicating history in the text.
+
+    Parameters
+    ----------
+    nlp : Language
+        spaCy nlp pipeline to use for matching.
+    name : str
+        Name of the component.
+    history : Optional[List[str]]
+        List of terms indicating medical history reference.
+    termination : Optional[List[str]]
+        List of syntagms termination terms.
+    use_sections : bool
+        Whether to use section pipeline to detect medical history section.
+    use_dates : bool
+        Whether to use dates pipeline to detect if the event occurs
+         a long time before the document date.
+    history_limit : int
+        The number of days after which the event is considered as history.
+    exclude_birthdate : bool
+        Whether to exclude the birthdate from history dates.
+    closest_dates_only : bool
+        Whether to include the closest dates only.
+    attr : str
+        spaCy's attribute to use:
+        a string with the value "TEXT" or "NORM", or a dict with the key 'term_attr'
+        we can also add a key for each regex.
+    on_ents_only : bool
+        Whether to look for matches around detected entities only.
+        Useful for faster inference in downstream tasks.
+    explain : bool
+        Whether to keep track of cues for each entity.
+    """
     return History(
         nlp,
         attr=attr,

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -17,9 +17,9 @@ from .patterns import history, sections_history
 
 class History(Qualifier):
     """
-    Implements an history detection algorithm.
+    Implements a history detection algorithm.
 
-    The components looks for terms indicating history in the text.
+    The component looks for terms indicating history in the text.
 
     Parameters
     ----------
@@ -28,7 +28,7 @@ class History(Qualifier):
     history : Optional[List[str]]
         List of terms indicating medical history reference.
     termination : Optional[List[str]]
-        List of syntagme termination terms.
+        List of syntagms termination terms.
     use_sections : bool
         Whether to use section pipeline to detect medical history section.
     use_dates : bool
@@ -37,7 +37,7 @@ class History(Qualifier):
     history_limit : int
         The number of days after which the event is considered as history.
     exclude_birthdate : bool
-        Whether to exclude the birth date from history dates.
+        Whether to exclude the birthdate from history dates.
     closest_dates_only : bool
         Whether to include the closest dates only.
     attr : str
@@ -47,8 +47,6 @@ class History(Qualifier):
     on_ents_only : bool
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
-    regex : Optional[Dict[str, Union[List[str], str]]]
-        A dictionary of regex patterns.
     explain : bool
         Whether to keep track of cues for each entity.
     """

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -300,7 +300,15 @@ class History(Qualifier):
                                 Span(doc, date.start, date.end, label="relative_date")
                             )
                     elif date._.date.direction.value == "PAST":
-                        if -date._.date.to_datetime() >= self.history_limit:
+                        if (
+                            -date._.date.to_duration(
+                                note_datetime=doc._.note_datetime,
+                                infer_from_context=True,
+                                tz="Europe/Paris",
+                                default_day=15,
+                            )
+                            >= self.history_limit
+                        ):
                             history_dates.append(
                                 Span(doc, date.start, date.end, label="relative_date")
                             )

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -6,7 +6,7 @@ import spacy
 from pytest import fixture
 from spacy.language import Language
 
-from edsnlp.pipelines.misc.dates.models import AbsoluteDate, Direction, Mode
+from edsnlp.pipelines.misc.dates.models import AbsoluteDate, Direction, Mode, Relative
 from edsnlp.utils.examples import parse_example
 
 TZ = pytz.timezone("Europe/Paris")
@@ -183,6 +183,8 @@ def test_dates_component(blank_nlp: Language):
                         note_datetime=note_datetime, infer_from_context=True
                     ) == TZ.localize(datetime(**d))
 
+            elif isinstance(date, Relative):
+                assert date.to_datetime() is None
             else:
                 assert date.to_duration()
                 assert date.to_datetime(note_datetime=note_datetime)

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -184,7 +184,8 @@ def test_dates_component(blank_nlp: Language):
                     ) == TZ.localize(datetime(**d))
 
             else:
-                assert date.to_datetime() is not None
+                assert date.to_duration()
+                assert date.to_datetime(note_datetime=note_datetime)
 
 
 def test_periods(blank_nlp: Language):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Differentiate results of type duration and datetime.

### Identified problem:
When applying the dates pipeline in batch, we obtain in the same column of the result dataframe objects of differnt data type. 
Also, the to_datetime() method of a RelativeDate class returns either datetime or duration types depending if note_datetime is given

### Some ideas:
- save spans into different keys
- replace `to_datetime()` by `to_pendulum()` or maybe `to_datetime` should be a wraper of `to_duration()` and `to_absolute()`


<!--- Describe the changes. -->

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
