### PR TITLE
fix: remove trailing spaces on get_text function

### DIFF
--- a/edsnlp/matchers/utils/text.py
+++ b/edsnlp/matchers/utils/text.py
@@ -42,10 +42,17 @@ def get_text(
     else:
         tokens = [t for t in doclike if not t._.excluded]
 
+    if not tokens:
+        return ""
+
     attr = ATTRIBUTES.get(attr, attr)
 
     if attr.startswith("_"):
         attr = attr[1:].lower()
-        return "".join([getattr(t._, attr) + t.whitespace_ for t in tokens])
+        return "".join(
+            [getattr(t._, attr) + t.whitespace_ for t in tokens[:-1]]
+        ) + getattr(tokens[-1], attr)
     else:
-        return "".join([getattr(t, attr) + t.whitespace_ for t in tokens])
+        return "".join(
+            [getattr(t, attr) + t.whitespace_ for t in tokens[:-1]]
+        ) + getattr(tokens[-1], attr)

--- a/tests/matchers/test_regex.py
+++ b/tests/matchers/test_regex.py
@@ -169,8 +169,8 @@ def test_wrong_extraction(
     )
     doc = blank_nlp(text)
 
-    clean = get_text(doc, attr="NORM", ignore_excluded=True).strip()
-    if leading_text.strip():
+    clean = get_text(doc, attr="NORM", ignore_excluded=True)
+    if leading_text:
         assert clean == f"{leading_text.lower()} transplantation cardiaque en 2000."
     else:
         assert clean == "transplantation cardiaque en 2000."
@@ -178,5 +178,5 @@ def test_wrong_extraction(
     assert doc.ents
     assert doc.ents[0][0].text == "transplantation"
 
-    clean = get_text(doc.ents[0], attr="NORM", ignore_excluded=True).strip()
+    clean = get_text(doc.ents[0], attr="NORM", ignore_excluded=True)
     assert clean == "transplantation cardiaque"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

Currently, the `get_text()` function in `edsnlp.matcher.utils` adds a trailing whitespace when applied on a `Span`
This PR fixes this

As such, `strip()` methods can be removed from the `test_regex.py` file

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
