### PR TITLE
Fix norm and to_datetime dates methods

### DIFF
--- a/edsnlp/pipelines/misc/dates/models.py
+++ b/edsnlp/pipelines/misc/dates/models.py
@@ -71,7 +71,10 @@ class AbsoluteDate(BaseDate):
         d = self.dict(exclude_none=True)
         d.pop("mode", None)
         if self.year and self.month and self.day:
-            return pendulum.datetime(**d, tz=tz)
+            try:
+                return pendulum.datetime(**d, tz=tz)
+            except ValueError:
+                return None
 
         elif infer_from_context:
             # no year
@@ -207,9 +210,10 @@ class RelativeDate(Relative):
 
         if self.direction == Direction.CURRENT:
             d = self.dict(exclude_none=True)
-            d.pop("direction")
+            d.pop("direction", None)
+            d.pop("mode", None)
 
-            (key,) = d.keys()
+            key = next(iter(d.keys()), "day")
 
             norm = f"~0 {key}"
         else:

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -11,37 +11,60 @@ from edsnlp.utils.examples import parse_example
 TZ = pytz.timezone("Europe/Paris")
 
 examples = [
-    "Le patient est venu en <ent year=2019>2019</ent> pour une consultation",
-    "Le patient est venu <ent direction=PAST day=1>hier</ent>",
-    "le <ent day=4 month=9 year=2021>04/09/2021</ent>",
-    "Il est cas contact <ent direction=PAST week=1>depuis la semaine dernière</ent>",
-    "le <ent day=9 month=8>09/08</ent>",
-    "Le patient est venu le <ent day=4 month=8>4 août</ent>",
-    "Le patient est venu le <ent day=4 month=8 hour=11 minute=13>4 août à 11h13</ent>",
-    "Il est venu le <ent day=1 month=9>1er Septembre</ent> pour",
-    "Il est venu en <ent month=10 year=2020>octobre 2020</ent> pour...",
-    "Il est venu <ent direction=PAST month=3>il y a trois mois</ent> pour...",
-    "Il lui était arrivé la même chose <ent direction=PAST year=1>il y a un an</ent>.",
-    "Il est venu le <ent day=20 month=9 year=2001>20/09/2001</ent> pour...",
-    "Consultation du <ent mode=FROM day=3 month=7 year=2019>03 07 19</ent>",
-    "En <ent month=11 year=2017>11/2017</ent> stabilité sur...",
-    "<ent direction=PAST month=3>depuis 3 mois</ent>",
-    "- <ent month=12 year=2004>Décembre 2004</ent> :",
-    "- <ent month=6 year=2005>Juin 2005</ent>:  ",
-    # "-<ent month=6 year=2005>Juin 2005</ent>:  ",  # issues with "fr" language
-    "<ent month=9 year=2017>sept 2017</ent> :",
     (
-        "<ent direction=PAST year=1>il y a 1 an</ent> "
-        "<ent mode=DURATION month=1>pdt 1 mois</ent>"
+        "Le patient est venu en <ent norm='2019-??-??' year=2019>2019</ent> pour une "
+        "consultation"
+    ),
+    "Le patient est venu <ent norm='-1 day' direction=PAST day=1>hier</ent>",
+    "le <ent norm='2021-09-04' day=4 month=9 year=2021>04/09/2021</ent>",
+    (
+        "Il est cas contact <ent norm='-1 week' direction=PAST week=1>"
+        "depuis la semaine dernière</ent>"
+    ),
+    "le <ent norm='????-08-09' day=9 month=8>09/08</ent>",
+    "Le patient est venu le <ent norm='????-08-04' day=4 month=8>4 août</ent>",
+    (
+        "Le patient est venu le <ent norm='????-08-04 11h13m' day=4 month=8 "
+        "hour=11 minute=13>4 août à 11h13</ent>"
+    ),
+    "Il est venu le <ent norm='????-09-01' day=1 month=9>1er Septembre</ent> pour",
+    (
+        "Il est venu en <ent norm='2020-10-??' month=10 year=2020>octobre 2020</ent> "
+        "pour..."
     ),
     (
-        "Prélevé le : <ent day=22 month=4 year=2016>22/04/2016</ent> "
+        "Il est venu <ent norm='-3 months' direction=PAST month=3>il y a "
+        "trois mois</ent> pour..."
+    ),
+    (
+        "Il lui était arrivé la même chose <ent norm='-1 year' "
+        "direction=PAST year=1>il y a un an</ent>."
+    ),
+    (
+        "Il est venu le <ent norm='2001-09-20' day=20 month=9 "
+        "year=2001>20/09/2001</ent> pour..."
+    ),
+    (
+        "Consultation du <ent norm='2019-07-03' mode=FROM "
+        "day=3 month=7 year=2019>03 07 19</ent>"
+    ),
+    "En <ent norm='2017-11-??' month=11 year=2017>11/2017</ent> stabilité sur...",
+    "<ent norm='-3 months' direction=PAST month=3>depuis 3 mois</ent>",
+    "- <ent norm='2004-12-??' month=12 year=2004>Décembre 2004</ent> :",
+    "- <ent norm='2005-06-??' month=6 year=2005>Juin 2005</ent>:  ",
+    # "-<ent norm=" month=6 year=2005>Juin 2005</ent>:  ",  # issues with "fr" language
+    "<ent norm='2017-09-??' month=9 year=2017>sept 2017</ent> :",
+    (
+        "<ent norm='-1 year' direction=PAST year=1>il y a 1 an</ent> "
+        "<ent norm='during 1 month' mode=DURATION month=1>pdt 1 mois</ent>"
+    ),
+    (
+        "Prélevé le : <ent norm='2016-04-22' day=22 month=4 year=2016>22/04/2016</ent> "
         "\n78 rue du Général Leclerc"
     ),
-    "Le <ent day=7 month=1>07/01</ent>.",
-    # "il est venu <ent year=0 direction=CURRENT>cette année</ent>",
-    # "je vous écris <ent direction=CURRENT day=0>ce jour</ent> à propos du patient",
-    "Il est venu en <ent month=8>août</ent>.",
+    "Le <ent norm='????-01-07' day=7 month=1>07/01</ent>.",
+    "Il est venu en <ent norm='????-08-??' month=8>août</ent>.",
+    "Il est venu <ent norm='~0 day' day=0 direction=CURRENT>ce jour</ent>.",
 ]
 
 
@@ -65,12 +88,14 @@ def test_dates_component(blank_nlp: Language):
 
             date = span._.date
             d = {modifier.key: modifier.value for modifier in entity.modifiers}
+            norm = d.pop("norm")
             if "direction" in d:
                 d["direction"] = Direction[d["direction"]]
             if "mode" in d:
                 d["mode"] = Mode[d["mode"]]
 
             assert date.dict(exclude_none=True) == d
+            assert date.norm() == norm
 
             set_d = set(d)
 
@@ -114,8 +139,48 @@ def test_dates_component(blank_nlp: Language):
                         note_datetime=note_datetime, infer_from_context=True
                     ) == TZ.localize(datetime(**d))
 
+            if isinstance(date, AbsoluteDate) and {"year", "month", "day"}.issubset(
+                set_d
+            ):
+                d.pop("direction", None)
+                d.pop("mode", None)
+                assert date.to_datetime() == TZ.localize(datetime(**d))
+
+            elif isinstance(date, AbsoluteDate):
+                assert date.to_datetime() is None
+
+                # no year
+                if {"month", "day"}.issubset(set_d) and {"year"}.isdisjoint(set_d):
+                    d["year"] = note_datetime.year
+                    assert date.to_datetime(
+                        note_datetime=note_datetime, infer_from_context=True
+                    ) == TZ.localize(datetime(**d))
+
+                # no day
+                if {"month", "year"}.issubset(set_d) and {"day"}.isdisjoint(set_d):
+                    d["day"] = 1
+                    assert date.to_datetime(
+                        note_datetime=note_datetime, infer_from_context=True
+                    ) == TZ.localize(datetime(**d))
+
+                # year only
+                if {"year"}.issubset(set_d) and {"day", "month"}.isdisjoint(set_d):
+                    d["day"] = 1
+                    d["month"] = 1
+                    assert date.to_datetime(
+                        note_datetime=note_datetime, infer_from_context=True
+                    ) == TZ.localize(datetime(**d))
+
+                # month only
+                if {"month"}.issubset(set_d) and {"day", "year"}.isdisjoint(set_d):
+                    d["day"] = 1
+                    d["year"] = note_datetime.year
+                    assert date.to_datetime(
+                        note_datetime=note_datetime, infer_from_context=True
+                    ) == TZ.localize(datetime(**d))
+
             else:
-                assert date.to_datetime()
+                assert date.to_datetime() is not None
 
 
 def test_periods(blank_nlp: Language):
@@ -185,3 +250,14 @@ def test_dates_on_ents_only():
 
     for span, entity in zip(doc.spans["dates"], entities):
         assert span.text == text[entity.start_char : entity.end_char]
+
+
+def test_illegal_dates(blank_nlp):
+    texts = (
+        " Le 31/06/17, la dernière dose.",
+        " Le 30/02/18 n'est pas une vraie date",
+    )
+    for text in texts:
+        doc = blank_nlp(text)
+        ent = doc.spans["dates"][0]
+        assert ent._.date.to_datetime() is None


### PR DESCRIPTION
## Description

Fixes https://github.com/aphp/edsnlp/issues/90 and https://github.com/aphp/edsnlp/issues/91.
Added some tests for the `_.date.norm()` method and illegal dates.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
