### PR TITLE
Simstring

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- New `SimstringMatcher` matcher to perform fuzzy term matching, and `algorithm` parameter in terminology components and `eds.matcher` component
+
 ### Changed
 
 - Add consultation date pattern "CS", and False Positive patterns for dates (namely phone numbers and pagination).
@@ -13,8 +17,8 @@
 
 - Now possible to provide regex flags when using the RegexMatcher
 - New `ContextualMatcher` pipe, aiming at replacing the `AdvancedRegex` pipe.
-- New `as_ents` parameter for `eds.dates`, to save detected dates as entities
 
+- New `as_ents` parameter for `eds.dates`, to save detected dates as entities
 ### Changed
 
 - Faster `eds.sentences` pipeline component with Cython

--- a/changelog.md
+++ b/changelog.md
@@ -17,8 +17,8 @@
 
 - Now possible to provide regex flags when using the RegexMatcher
 - New `ContextualMatcher` pipe, aiming at replacing the `AdvancedRegex` pipe.
-
 - New `as_ents` parameter for `eds.dates`, to save detected dates as entities
+
 ### Changed
 
 - Faster `eds.sentences` pipeline component with Cython

--- a/demo/app.py
+++ b/demo/app.py
@@ -328,7 +328,7 @@ for ent in doc.ents:
             family="YES" if ent._.family else "NO",
             hypothesis="YES" if ent._.hypothesis else "NO",
             reported_speech="YES" if ent._.reported_speech else "NO",
-        )  #
+        )
 
     try:
         if ent.kb_id_ and not ent._.value:

--- a/demo/app.py
+++ b/demo/app.py
@@ -87,9 +87,9 @@ def load_model(
 
     if drugs:
         if fuzzy_drugs:
-            nlp.add_pipe("eds.drugs", config=dict(algorithm="simstring"))
+            nlp.add_pipe("eds.drugs", config=dict(term_matcher="simstring"))
             pipes.append(
-                'nlp.add_pipe("eds.drugs", config=dict(algorithm="simstring"))'
+                'nlp.add_pipe("eds.drugs", config=dict(term_matcher="simstring"))'
             )
         else:
             nlp.add_pipe("eds.drugs")

--- a/demo/app.py
+++ b/demo/app.py
@@ -6,6 +6,8 @@ import streamlit as st
 from spacy import displacy
 from spacy.tokens import Span
 
+from edsnlp.utils.filter import filter_spans
+
 DEFAULT_TEXT = """\
 Motif :
 Le patient est admis le 29 août pour des difficultés respiratoires.
@@ -21,7 +23,7 @@ A noter deux petits kystes bénins de 1 et 2cm biopsiés en 2005.
 Priorité: 2 (établie par l'IAO à l'entrée)
 
 Conclusion
-Possible infection au coronavirus. Prescription de paracétamol pour la fièvre.\
+Possible infection au coronavirus. Prescription de paracétomol pour la fièvre.\
 """
 
 REGEX = """
@@ -65,6 +67,7 @@ doc.ents
 @st.cache(allow_output_mutation=True)
 def load_model(
     drugs: bool,
+    fuzzy_drugs: bool,
     cim10: bool,
     covid: bool,
     dates: bool,
@@ -83,8 +86,14 @@ def load_model(
     nlp.add_pipe("eds.sentences")
 
     if drugs:
-        nlp.add_pipe("eds.drugs")
-        pipes.append('nlp.add_pipe("eds.drugs")')
+        if fuzzy_drugs:
+            nlp.add_pipe("eds.drugs", config=dict(algorithm="simstring"))
+            pipes.append(
+                'nlp.add_pipe("eds.drugs", config=dict(algorithm="simstring"))'
+            )
+        else:
+            nlp.add_pipe("eds.drugs")
+            pipes.append('nlp.add_pipe("eds.drugs")')
 
     if cim10:
         nlp.add_pipe("eds.cim10")
@@ -168,21 +177,25 @@ st.sidebar.markdown(
 )
 
 st.sidebar.header("Custom RegEx")
-custom_regex = st.sidebar.text_input(
+st_custom_regex = st.sidebar.text_input(
     "Regular Expression:",
     r"asthmatique|difficult[ée]s?\srespiratoires?",
 )
 st.sidebar.markdown("The RegEx you defined above is detected under the `custom` label.")
 
 st.sidebar.subheader("Pipeline Components")
-cim10 = st.sidebar.checkbox("CIM10 (loading can be slow)", value=False)
-drugs = st.sidebar.checkbox("Drugs", value=True)
-covid = st.sidebar.checkbox("COVID", value=True)
-dates = st.sidebar.checkbox("Dates", value=True)
-measurements = st.sidebar.checkbox("Measurements", value=True)
-priority = st.sidebar.checkbox("Emergency Priority Score", value=True)
-charlson = st.sidebar.checkbox("Charlson Score", value=True)
-sofa = st.sidebar.checkbox("SOFA Score", value=True)
+st_cim10 = st.sidebar.checkbox("CIM10 (loading can be slow)", value=False)
+st_drugs_container = st.sidebar.columns([1, 2])
+st_drugs = st_drugs_container[0].checkbox("Drugs", value=True)
+st_fuzzy_drugs = st_drugs_container[1].checkbox(
+    "Fuzzy drugs search", value=True, disabled=not st_drugs
+)
+st_covid = st.sidebar.checkbox("COVID", value=True)
+st_dates = st.sidebar.checkbox("Dates", value=True)
+st_measurements = st.sidebar.checkbox("Measurements", value=True)
+st_priority = st.sidebar.checkbox("Emergency Priority Score", value=True)
+st_charlson = st.sidebar.checkbox("Charlson Score", value=True)
+st_sofa = st.sidebar.checkbox("SOFA Score", value=True)
 st.sidebar.markdown(
     "These are just a few of the pipelines provided out-of-the-box by EDS-NLP. "
     "See the [documentation](https://aphp.github.io/edsnlp/latest/pipelines/) "
@@ -192,15 +205,16 @@ st.sidebar.markdown(
 model_load_state = st.info("Loading model...")
 
 nlp, pipes, regex = load_model(
-    drugs=drugs,
-    cim10=cim10,
-    covid=covid,
-    dates=dates,
-    measurements=measurements,
-    charlson=charlson,
-    sofa=sofa,
-    priority=priority,
-    custom_regex=custom_regex,
+    drugs=st_drugs,
+    fuzzy_drugs=st_fuzzy_drugs,
+    cim10=st_cim10,
+    covid=st_covid,
+    dates=st_dates,
+    measurements=st_measurements,
+    charlson=st_charlson,
+    sofa=st_sofa,
+    priority=st_priority,
+    custom_regex=st_custom_regex,
 )
 
 model_load_state.empty()
@@ -238,7 +252,7 @@ for measure in doc.spans.get("measurements", []):
     ents.append(span)
 
 
-doc.ents = ents
+doc.ents = list(filter_spans(ents))
 
 category20 = [
     "#1f77b4",
@@ -314,10 +328,13 @@ for ent in doc.ents:
             family="YES" if ent._.family else "NO",
             hypothesis="YES" if ent._.hypothesis else "NO",
             reported_speech="YES" if ent._.reported_speech else "NO",
-        )
+        )  #
 
     try:
-        d["normalized_value"] = str(ent._.value)
+        if ent.kb_id_ and not ent._.value:
+            d["normalized_value"] = ent.kb_id_
+        else:
+            d["normalized_value"] = str(ent._.value)
     except TypeError:
         d["normalized_value"] = ""
 

--- a/docs/pipelines/core/matcher.md
+++ b/docs/pipelines/core/matcher.md
@@ -21,7 +21,16 @@ regex = dict(
     covid=r"coronavirus|covid[-\s]?19|sars[-\s]cov[-\s]2",  # (3)
 )
 
-nlp.add_pipe("eds.matcher", config=dict(terms=terms, regex=regex, attr="LOWER"))
+nlp.add_pipe(
+    "eds.matcher",
+    config=dict(
+        terms=terms,
+        regex=regex,
+        attr="LOWER",
+        algorithm="exact",
+        algorithm_config={},
+    ),
+)
 ```
 
 1. Every key in the `terms` dictionary is mapped to a concept.
@@ -34,12 +43,14 @@ This snippet is complete, and should run as is.
 
 The pipeline can be configured using the following parameters :
 
-| Parameter         | Explanation                                      | Default                 |
-| ----------------- | ------------------------------------------------ | ----------------------- |
-| `terms`           | Terms patterns. Expects a dictionary.            | `None` (use regex only) |
-| `regex`           | RegExp patterns. Expects a dictionary.           | `None` (use terms only) |
-| `attr`            | spaCy attribute to match on (eg `NORM`, `LOWER`) | `"TEXT"`                |
-| `ignore_excluded` | Whether to skip excluded tokens during matching  | `False`                 |
+| Parameter          | Explanation                                                    | Default                 |
+|--------------------|----------------------------------------------------------------|-------------------------|
+| `terms`            | Terms patterns. Expects a dictionary.                          | `None` (use regex only) |
+| `regex`            | RegExp patterns. Expects a dictionary.                         | `None` (use terms only) |
+| `algorithm`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"`               |
+| `algorithm_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"`               |
+| `attr`             | spaCy attribute to match on (eg `NORM`, `LOWER`)               | `"TEXT"`                |
+| `ignore_excluded`  | Whether to skip excluded tokens during matching                | `False`                 |
 
 Patterns, be they `terms` or `regex`, are defined as dictionaries where keys become the label of the extracted entities. Dictionary values are a either a single expression or a list of expressions that match the concept (see [example](#usage)).
 

--- a/docs/pipelines/core/matcher.md
+++ b/docs/pipelines/core/matcher.md
@@ -27,8 +27,8 @@ nlp.add_pipe(
         terms=terms,
         regex=regex,
         attr="LOWER",
-        algorithm="exact",
-        algorithm_config={},
+        term_matcher="exact",
+        term_matcher_config={},
     ),
 )
 ```
@@ -43,14 +43,14 @@ This snippet is complete, and should run as is.
 
 The pipeline can be configured using the following parameters :
 
-| Parameter          | Explanation                                                    | Default                 |
-|--------------------|----------------------------------------------------------------|-------------------------|
-| `terms`            | Terms patterns. Expects a dictionary.                          | `None` (use regex only) |
-| `regex`            | RegExp patterns. Expects a dictionary.                         | `None` (use terms only) |
-| `algorithm`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"`               |
-| `algorithm_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"`               |
-| `attr`             | spaCy attribute to match on (eg `NORM`, `LOWER`)               | `"TEXT"`                |
-| `ignore_excluded`  | Whether to skip excluded tokens during matching                | `False`                 |
+| Parameter             | Explanation                                                    | Default                 |
+|-----------------------|----------------------------------------------------------------|-------------------------|
+| `terms`               | Terms patterns. Expects a dictionary.                          | `None` (use regex only) |
+| `regex`               | RegExp patterns. Expects a dictionary.                         | `None` (use terms only) |
+| `term_matcher`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"`               |
+| `term_matcher_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"`               |
+| `attr`                | spaCy attribute to match on (eg `NORM`, `LOWER`)               | `"TEXT"`                |
+| `ignore_excluded`     | Whether to skip excluded tokens during matching                | `False`                 |
 
 Patterns, be they `terms` or `regex`, are defined as dictionaries where keys become the label of the extracted entities. Dictionary values are a either a single expression or a list of expressions that match the concept (see [example](#usage)).
 

--- a/docs/pipelines/ner/cim10.md
+++ b/docs/pipelines/ner/cim10.md
@@ -13,7 +13,7 @@ The `eds.cim10` pipeline component matches the CIM10 (French-language ICD) termi
 import spacy
 
 nlp = spacy.blank("fr")
-nlp.add_pipe("eds.cim10")
+nlp.add_pipe("eds.cim10", config=dict(algorithm="simstring"))
 
 text = "Le patient est suivi pour fièvres typhoïde et paratyphoïde."
 
@@ -35,10 +35,12 @@ ent.kb_id_
 
 The pipeline can be configured using the following parameters :
 
-| Parameter         | Description                                              | Default   |
-| ----------------- | -------------------------------------------------------- | --------- |
-| `attr`            | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`) | `"LOWER"` |
-| `ignore_excluded` | Whether to ignore excluded tokens for matching           | `False`   |
+| Parameter          | Description                                                    | Default   |
+|--------------------|----------------------------------------------------------------|-----------|
+| `algorithm`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"` |
+| `algorithm_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"` |
+| `attr`             | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)       | `"LOWER"` |
+| `ignore_excluded`  | Whether to ignore excluded tokens for matching                 | `False`   |
 
 ## Authors and citation
 

--- a/docs/pipelines/ner/cim10.md
+++ b/docs/pipelines/ner/cim10.md
@@ -13,7 +13,7 @@ The `eds.cim10` pipeline component matches the CIM10 (French-language ICD) termi
 import spacy
 
 nlp = spacy.blank("fr")
-nlp.add_pipe("eds.cim10", config=dict(algorithm="simstring"))
+nlp.add_pipe("eds.cim10", config=dict(term_matcher="simstring"))
 
 text = "Le patient est suivi pour fièvres typhoïde et paratyphoïde."
 
@@ -35,12 +35,12 @@ ent.kb_id_
 
 The pipeline can be configured using the following parameters :
 
-| Parameter          | Description                                                    | Default   |
-|--------------------|----------------------------------------------------------------|-----------|
-| `algorithm`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"` |
-| `algorithm_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"` |
-| `attr`             | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)       | `"LOWER"` |
-| `ignore_excluded`  | Whether to ignore excluded tokens for matching                 | `False`   |
+| Parameter             | Description                                                    | Default   |
+|-----------------------|----------------------------------------------------------------|-----------|
+| `term_matcher`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"` |
+| `term_matcher_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"` |
+| `attr`                | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)       | `"LOWER"` |
+| `ignore_excluded`     | Whether to ignore excluded tokens for matching                 | `False`   |
 
 ## Authors and citation
 

--- a/docs/pipelines/ner/drugs.md
+++ b/docs/pipelines/ner/drugs.md
@@ -9,11 +9,12 @@ ATC classifies drugs into groups.
 In this example, we are looking for an oral antidiabetic medication (ATC code: A10B).
 
 ```python
+from edsnlp.pipelines.core.terminology import TerminologyTermMatcher
 import spacy
 
 nlp = spacy.blank("fr")
 nlp.add_pipe("eds.normalizer")
-nlp.add_pipe("eds.drugs", config=dict(algorithm="exact"))
+nlp.add_pipe("eds.drugs", config=dict(term_matcher=TerminologyTermMatcher.exact))
 
 text = "Traitement habituel: Kardégic, cardensiel (bisoprolol), glucophage, lasilix"
 
@@ -37,12 +38,12 @@ Glucophage is the brand name of a medication that contains metformine, the first
 
 The pipeline can be configured using the following parameters :
 
-| Parameter          | Description                                                    | Default   |
-|--------------------|----------------------------------------------------------------|-----------|
-| `algorithm`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"` |
-| `algorithm_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"` |
-| `attr`             | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)       | `"NORM"`  |
-| `ignore_excluded`  | Whether to ignore excluded tokens for matching                 | `False`   |
+| Parameter             | Description                                                    | Default   |
+|-----------------------|----------------------------------------------------------------|-----------|
+| `term_matcher`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"` |
+| `term_matcher_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"` |
+| `attr`                | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)       | `"NORM"`  |
+| `ignore_excluded`     | Whether to ignore excluded tokens for matching                 | `False`   |
 
 ## Authors and citation
 

--- a/docs/pipelines/ner/drugs.md
+++ b/docs/pipelines/ner/drugs.md
@@ -13,7 +13,7 @@ import spacy
 
 nlp = spacy.blank("fr")
 nlp.add_pipe("eds.normalizer")
-nlp.add_pipe("eds.drugs")
+nlp.add_pipe("eds.drugs", config=dict(algorithm="exact"))
 
 text = "Traitement habituel: Kardégic, cardensiel (bisoprolol), glucophage, lasilix"
 
@@ -37,10 +37,12 @@ Glucophage is the brand name of a medication that contains metformine, the first
 
 The pipeline can be configured using the following parameters :
 
-| Parameter         | Description                                              | Default  |
-| ----------------- | -------------------------------------------------------- | -------- |
-| `attr`            | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`) | `"NORM"` |
-| `ignore_excluded` | Whether to ignore excluded tokens for matching           | `False`  |
+| Parameter          | Description                                                    | Default   |
+|--------------------|----------------------------------------------------------------|-----------|
+| `algorithm`        | Which algorithm should we use : `exact` or `simstring`         | `"LOWER"` |
+| `algorithm_config` | Config of the algorithm (`SimstringMatcher`'s for `simstring`) | `"LOWER"` |
+| `attr`             | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)       | `"NORM"`  |
+| `ignore_excluded`  | Whether to ignore excluded tokens for matching                 | `False`   |
 
 ## Authors and citation
 

--- a/docs/utilities/matchers.md
+++ b/docs/utilities/matchers.md
@@ -1,9 +1,10 @@
 # Matchers
 
-We implemented two pattern matchers that are fit to clinical documents:
+We implemented three pattern matchers that are fit to clinical documents:
 
 - the `EDSPhraseMatcher`
 - the `RegexMatcher`
+- the `SimstringMatcher`
 
 However, note that for most use-cases, you should instead use the `eds.matcher` pipeline that wraps these classes to annotate documents.
 
@@ -64,4 +65,57 @@ matcher.build_patterns(
 
 list(matcher(doc, as_spans=True))[0].text
 # Out: Corona =============== virus
+```
+
+
+## SimstringMatcher
+
+The `SimstringMatcher` performs fuzzy term matching by comparing spans of text with a
+similarity metric. It is especially useful to handle spelling variations like
+`paracetomol` (instead of `paracetamol`).
+
+The [`simstring`](https://github.com/Georgetown-IR-Lab/simstring/tree/master/quickumls_simstring) algorithm compares two strings by enumerating their char trigrams and
+measuring the overlap between the two sets. In the previous example:
+- `paracetomol` becomes `##p #pa par ara rac ace cet eto tom omo mol ol# l##`
+- `paracetamol` becomes `##p #pa par ara rac ace cet eta tam amo mol ol# l##`
+and the Dice (or F1) similarity between the two sets is 0.75.
+
+Like the `EDSPhraseMatcher`, this class allows to skip pollution tokens.
+Just like the `RegexMatcher`, this class is significantly slower than the
+`EDSPhraseMatcher`: if you can, try enumerating lexical variations of the target phrases
+and feed them to the `PhraseMatcher` instead.
+
+You can use it as described in the code below.
+
+```python
+import spacy
+from edsnlp.matchers.simstring import SimstringMatcher
+
+nlp = spacy.blank("eds")
+nlp.add_pipe("eds.normalizer")
+doc = nlp(
+    "On ne relève pas de signe du corona-virus. Historique d'un hepatocellulaire carcinome."
+)
+
+matcher = SimstringMatcher(
+    nlp.vocab,
+    attr="NORM",
+    ignore_excluded=True,
+    measure="dice",
+    threshold=0.75,
+    windows=5,
+)
+matcher.build_patterns(
+    nlp,
+    {
+        "covid": ["coronavirus", "covid"],
+        "carcinome": ["carcinome hepatocellulaire"],
+    },
+)
+
+list(matcher(doc, as_spans=True))[0].text
+# Out: corona-virus
+
+list(matcher(doc, as_spans=True))[1].text
+# Out: hepatocellulaire carcinome
 ```

--- a/edsnlp/matchers/phrase.pyx
+++ b/edsnlp/matchers/phrase.pyx
@@ -85,25 +85,25 @@ cdef class EDSPhraseMatcher(PhraseMatcher):
         if not terms:
             terms = dict()
 
-        for key, expressions in terms.items():
-            if isinstance(expressions, dict):
-                attr = expressions.get("attr")
-                expressions = expressions.get("patterns")
-            else:
-                attr = None
-            if isinstance(expressions, str):
-                expressions = [expressions]
-            token_pipelines = [
-                name
-                for name, pipe in nlp.pipeline
-                if any(
-                    "token" in assign and not assign == "token.is_sent_start"
-                    for assign in nlp.get_pipe_meta(name).assigns
-                )
-            ]
-            with nlp.select_pipes(enable=token_pipelines):
+        token_pipelines = [
+            name
+            for name, pipe in nlp.pipeline
+            if any(
+                "token" in assign and not assign == "token.is_sent_start"
+                for assign in nlp.get_pipe_meta(name).assigns
+            )
+        ]
+        with nlp.select_pipes(enable=token_pipelines):
+            for key, expressions in terms.items():
+                if isinstance(expressions, dict):
+                    attr = expressions.get("attr")
+                    expressions = expressions.get("patterns")
+                else:
+                    attr = None
+                if isinstance(expressions, str):
+                    expressions = [expressions]
                 patterns = list(nlp.pipe(expressions))
-            self.add(key, patterns, attr)
+                self.add(key, patterns, attr)
 
     cdef void find_matches(self, Doc doc, int start_idx, int end_idx, vector[SpanC] *matches) nogil:
         cdef MapStruct * current_node = self.c_map

--- a/edsnlp/matchers/phrase.pyx
+++ b/edsnlp/matchers/phrase.pyx
@@ -93,7 +93,16 @@ cdef class EDSPhraseMatcher(PhraseMatcher):
                 attr = None
             if isinstance(expressions, str):
                 expressions = [expressions]
-            patterns = list(nlp.pipe(expressions))
+            token_pipelines = [
+                name
+                for name, pipe in nlp.pipeline
+                if any(
+                    "token" in assign and not assign == "token.is_sent_start"
+                    for assign in nlp.get_pipe_meta(name).assigns
+                )
+            ]
+            with nlp.select_pipes(enable=token_pipelines):
+                patterns = list(nlp.pipe(expressions))
             self.add(key, patterns, attr)
 
     cdef void find_matches(self, Doc doc, int start_idx, int end_idx, vector[SpanC] *matches) nogil:

--- a/edsnlp/matchers/simstring.py
+++ b/edsnlp/matchers/simstring.py
@@ -1,0 +1,282 @@
+import os
+import pickle
+import tempfile
+from collections import defaultdict
+from functools import lru_cache
+from math import sqrt
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple, Union
+
+import quickumls_simstring.simstring as simstring
+from spacy import Language, Vocab
+from spacy.tokens import Doc, Span
+from tqdm import tqdm
+
+from edsnlp.matchers.utils import ATTRIBUTES, get_text
+
+
+class SimstringWriter(object):
+    def __init__(self, path: Union[str, Path]):
+        """
+        A context class to write a simstring database
+
+        Parameters
+        ----------
+        path: Union[str, Path]
+            Path to database
+        """
+        os.makedirs(path, exist_ok=True)
+        self.path = path
+
+    def __enter__(self):
+        path = os.path.join(self.path, "umls-terms.simstring")
+        self.db = simstring.writer(path, 3, False, True)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.db.close()
+
+    def insert(self, term):
+        self.db.insert(term)
+
+
+class SimstringMatcher:
+    def __init__(
+        self,
+        vocab: Vocab,
+        path=None,
+        measure: str = "dice",
+        threshold: float = 0.75,
+        windows: int = 5,
+        ignore_excluded: bool = False,
+        attr: str = "NORM",
+    ):
+        """
+        PhraseMatcher that allows to skip excluded tokens.
+        Heavily inspired by https://github.com/Georgetown-IR-Lab/QuickUMLS
+
+        Parameters
+        ----------
+        vocab : Vocab
+            spaCy vocabulary to match on.
+        path: Union[str, Path]
+            Path where we will store the precomputed patterns
+        measure: str
+            Name of the similarity measure.
+            One of ["jaccard", "dice", "overlap", "cosine"]
+        windows: int
+            Maximum number of words in a candidate span
+        threshold: float
+            Minimum similarity value to match a concept's synonym
+        ignore_excluded : bool, optional
+            Whether to exclude tokens that have a "SPACE" tag, by default False
+        attr : str
+            Default attribute to match on, by default "TEXT".
+            Can be overridden in the `add` method.
+            To match on a custom attribute, prepend the attribute name with `_`.
+        """
+
+        assert measure in ("jaccard", "dice", "overlap", "cosine")
+
+        self.vocab = vocab
+        self.windows = windows
+        self.measure = measure
+        self.threshold = threshold
+        self.ignore_excluded = ignore_excluded
+        self.attr = attr
+
+        if path is None:
+            path = tempfile.mkdtemp()
+        self.path = Path(path)
+
+        self.ss_reader = None
+        self.syn2cuis = None
+
+    def build_patterns(self, nlp: Language, terms: Dict[str, Iterable[str]]):
+        """
+        Build patterns and adds them for matching.
+
+        Parameters
+        ----------
+        nlp : Language
+            The instance of the spaCy language class.
+        terms : Patterns
+            Dictionary of label/terms, or label/dictionary of terms/attribute.
+        """
+
+        self.ss_reader = None
+        self.syn2cuis = None
+
+        syn2cuis = defaultdict(lambda: [])
+        token_pipelines = [
+            name
+            for name, pipe in nlp.pipeline
+            if any(
+                "token" in assign and not assign == "token.is_sent_start"
+                for assign in nlp.get_pipe_meta(name).assigns
+            )
+        ]
+        with nlp.select_pipes(enable=token_pipelines):
+            with SimstringWriter(self.path) as ss_db:
+                for cui, synset in tqdm(terms.items()):
+                    for term in nlp.pipe(synset):
+                        norm_text = get_text(
+                            term, self.attr, ignore_excluded=self.ignore_excluded
+                        )
+                        term = "##" + norm_text + "##"
+                        ss_db.insert(term)
+                        syn2cuis[term].append(cui)
+        syn2cuis = {term: tuple(sorted(set(cuis))) for term, cuis in syn2cuis.items()}
+        with open(self.path / "cui-db.pkl", "wb") as f:
+            pickle.dump(syn2cuis, f)
+
+    def load(self):
+        if self.ss_reader is None:
+            self.ss_reader = simstring.reader(
+                os.path.join(self.path, "umls-terms.simstring")
+            )
+            self.ss_reader.measure = getattr(simstring, self.measure)
+            self.ss_reader.threshold = self.threshold
+
+            with open(os.path.join(self.path, "cui-db.pkl"), "rb") as f:
+                self.syn2cuis = pickle.load(f)
+
+    def __call__(self, doc, as_spans=False):
+        self.load()
+
+        root = getattr(doc, "doc", doc)
+        if root.has_annotation("IS_SENT_START"):
+            sents = tuple(doc.sents)
+        else:
+            sents = (doc,)
+
+        ents = []
+
+        for sent in sents:
+            text, offsets = get_text_and_offsets(
+                doclike=sent,
+                attr=self.attr,
+                ignore_excluded=self.ignore_excluded,
+            )
+            sent_start = getattr(sent, "start", 0)
+            for size in range(1, self.windows):
+                for i in range(0, len(offsets) - size):
+                    begin_char, _, begin_i = offsets[i]
+                    _, end_char, end_i = offsets[i + size]
+                    span_text = "##" + text[begin_char:end_char] + "##"
+                    matches = self.ss_reader.retrieve(span_text)
+                    for res in matches:
+                        sim = similarity(span_text, res, measure=self.measure)
+                        for cui in self.syn2cuis[res]:
+                            ents.append(
+                                (cui, begin_i + sent_start, end_i + sent_start, sim)
+                            )
+
+        sorted_spans = sorted(ents, key=simstring_sort_key, reverse=True)
+        results = []
+        seen_tokens = set()
+        for span in sorted_spans:
+            # Check for end - 1 here because boundaries are inclusive
+            span_tokens = set(range(span[1], span[2]))
+            if not (span_tokens & seen_tokens):
+                results.append(span)
+                seen_tokens.update(span_tokens)
+        results = sorted(results, key=lambda span: span[1])
+        if as_spans:
+            spans = [
+                Span(root, span_data[1], span_data[2], span_data[0])
+                for span_data in results
+            ]
+            return spans
+        else:
+            return [(self.vocab.strings[span[0]], span[1], span[2]) for span in results]
+
+
+def similarity(x, y, measure="dice"):
+
+    x_ngrams = {x[i : i + 3] for i in range(0, len(x) - 3)}
+    y_ngrams = {y[i : i + 3] for i in range(0, len(y) - 3)}
+
+    if measure == "jaccard":
+        return len(x_ngrams & y_ngrams) / (len(x_ngrams | y_ngrams))
+
+    if measure == "dice":
+        return 2 * len(x_ngrams & y_ngrams) / (len(x_ngrams) + len(y_ngrams))
+
+    if measure == "cosine":
+        return len(x_ngrams & y_ngrams) / sqrt(len(x_ngrams) * len(y_ngrams))
+
+    if measure == "overlap":
+        return len(x_ngrams & y_ngrams)
+
+    raise ValueError("Cannot compute similarity {}".format(repr(measure)))
+
+
+def simstring_sort_key(span_data):
+    return span_data[3], span_data[2] - span_data[1], -span_data[1]
+
+
+@lru_cache(maxsize=128)
+def get_text_and_offsets(
+    doclike: Union[Span, Doc],
+    attr: str = "TEXT",
+    ignore_excluded: bool = True,
+) -> Tuple[str, List[Tuple[int, int, int]]]:
+    """
+    Align different representations of a `Doc` or `Span` object.
+
+    Parameters
+    ----------
+    doclike : Doc
+        spaCy `Doc` or `Span` object
+    attr : str, optional
+        Attribute to use, by default `"TEXT"`
+    ignore_excluded : bool, optional
+        Whether to remove excluded tokens, by default True
+
+    Returns
+    -------
+    Tuple[str, List[Tuple[int, int, int]]]
+        The new clean text and offset tuples for each word giving the begin char indice
+        of the word in the new text, the end char indice of its preceding word and the
+        indice of the word in the original document
+    """
+    attr = attr.upper()
+    attr = ATTRIBUTES.get(attr, attr)
+
+    custom = attr.startswith("_")
+
+    if custom:
+        attr = attr[1:].lower()
+
+    offsets = []
+
+    cursor = 0
+
+    text = []
+
+    last = cursor
+    for i, token in enumerate(doclike):
+
+        if not ignore_excluded or not token._.excluded:
+            if custom:
+                token_text = getattr(token._, attr)
+            else:
+                token_text = getattr(token, attr)
+
+            # We add the cursor
+            end = cursor + len(token_text)
+            offsets.append((cursor, last, i))
+
+            cursor = end
+            last = end
+
+            text.append(token_text)
+
+            if token.whitespace_:
+                cursor += 1
+                text.append(" ")
+
+    offsets.append((cursor, last, len(doclike)))
+
+    return "".join(text), offsets

--- a/edsnlp/matchers/simstring.py
+++ b/edsnlp/matchers/simstring.py
@@ -163,7 +163,7 @@ class SimstringMatcher:
         else:
             sents = (doc,)
 
-        ents = []
+        ents: List[Tuple[str, int, int, float]] = []
 
         for sent in sents:
             text, offsets = get_text_and_offsets(
@@ -205,27 +205,27 @@ class SimstringMatcher:
             return [(self.vocab.strings[span[0]], span[1], span[2]) for span in results]
 
 
-def similarity(x, y, measure="dice"):
+def similarity(x: str, y: str, measure: SimilarityMeasure = SimilarityMeasure.dice):
 
     x_ngrams = {x[i : i + 3] for i in range(0, len(x) - 3)}
     y_ngrams = {y[i : i + 3] for i in range(0, len(y) - 3)}
 
-    if measure == "jaccard":
+    if measure == SimilarityMeasure.jaccard:
         return len(x_ngrams & y_ngrams) / (len(x_ngrams | y_ngrams))
 
-    if measure == "dice":
+    if measure == SimilarityMeasure.dice:
         return 2 * len(x_ngrams & y_ngrams) / (len(x_ngrams) + len(y_ngrams))
 
-    if measure == "cosine":
+    if measure == SimilarityMeasure.cosine:
         return len(x_ngrams & y_ngrams) / sqrt(len(x_ngrams) * len(y_ngrams))
 
-    if measure == "overlap":
+    if measure == SimilarityMeasure.overlap:
         return len(x_ngrams & y_ngrams)
 
     raise ValueError("Cannot compute similarity {}".format(repr(measure)))
 
 
-def simstring_sort_key(span_data):
+def simstring_sort_key(span_data: Tuple[str, int, int, float]):
     return span_data[3], span_data[2] - span_data[1], -span_data[1]
 
 

--- a/edsnlp/pipelines/core/context/factory.py
+++ b/edsnlp/pipelines/core/context/factory.py
@@ -9,7 +9,10 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.context", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.context",
+    default_config=DEFAULT_CONFIG,
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/matcher/factory.py
+++ b/edsnlp/pipelines/core/matcher/factory.py
@@ -14,7 +14,9 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("matcher", "eds.matcher", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.matcher", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.matcher", default_config=DEFAULT_CONFIG, assigns=["doc.ents", "doc.spans"]
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/matcher/factory.py
+++ b/edsnlp/pipelines/core/matcher/factory.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 from spacy.language import Language
 
 from edsnlp.pipelines.core.matcher import GenericMatcher
+from edsnlp.pipelines.core.matcher.matcher import GenericTermMatcher
 from edsnlp.utils.deprecation import deprecated_factory
 
 DEFAULT_CONFIG = dict(
@@ -10,8 +11,8 @@ DEFAULT_CONFIG = dict(
     regex=None,
     attr="TEXT",
     ignore_excluded=False,
-    algorithm="exact",
-    algorithm_config={},
+    term_matcher=GenericTermMatcher.exact,
+    term_matcher_config={},
 )
 
 
@@ -31,8 +32,8 @@ def create_component(
     attr: Union[str, Dict[str, str]],
     regex: Optional[Dict[str, Union[str, List[str]]]],
     ignore_excluded: bool,
-    algorithm: str,
-    algorithm_config: Dict[str, Any],
+    term_matcher: GenericTermMatcher,
+    term_matcher_config: Dict[str, Any],
 ):
     assert not (terms is None and regex is None)
 
@@ -47,6 +48,6 @@ def create_component(
         attr=attr,
         regex=regex,
         ignore_excluded=ignore_excluded,
-        algorithm=algorithm,
-        algorithm_config=algorithm_config,
+        term_matcher=term_matcher,
+        term_matcher_config=term_matcher_config,
     )

--- a/edsnlp/pipelines/core/matcher/factory.py
+++ b/edsnlp/pipelines/core/matcher/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from spacy.language import Language
 
@@ -10,6 +10,8 @@ DEFAULT_CONFIG = dict(
     regex=None,
     attr="TEXT",
     ignore_excluded=False,
+    algorithm="exact",
+    algorithm_config={},
 )
 
 
@@ -24,6 +26,8 @@ def create_component(
     attr: Union[str, Dict[str, str]],
     regex: Optional[Dict[str, Union[str, List[str]]]],
     ignore_excluded: bool,
+    algorithm: str,
+    algorithm_config: Dict[str, Any],
 ):
     assert not (terms is None and regex is None)
 
@@ -38,4 +42,6 @@ def create_component(
         attr=attr,
         regex=regex,
         ignore_excluded=ignore_excluded,
+        algorithm=algorithm,
+        algorithm_config=algorithm_config,
     )

--- a/edsnlp/pipelines/core/matcher/factory.py
+++ b/edsnlp/pipelines/core/matcher/factory.py
@@ -15,7 +15,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("matcher", "eds.matcher", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "matcher",
+    "eds.matcher",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 @Language.factory(
     "eds.matcher", default_config=DEFAULT_CONFIG, assigns=["doc.ents", "doc.spans"]
 )

--- a/edsnlp/pipelines/core/matcher/matcher.py
+++ b/edsnlp/pipelines/core/matcher/matcher.py
@@ -19,8 +19,6 @@ class GenericMatcher(BaseComponent):
     ----------
     nlp : Language
         The spaCy object.
-    label : str
-        Top-level label
     terms : Optional[Patterns]
         A dictionary of terms.
     regex : Optional[Patterns]
@@ -41,7 +39,7 @@ class GenericMatcher(BaseComponent):
         attr: str,
         ignore_excluded: bool,
         algorithm: str = "exact",
-        algorithm_config: Dict[str, Any] = {},
+        algorithm_config: Dict[str, Any] = None,
     ):
 
         self.nlp = nlp
@@ -53,13 +51,19 @@ class GenericMatcher(BaseComponent):
                 self.nlp.vocab,
                 attr=attr,
                 ignore_excluded=ignore_excluded,
+                **(algorithm_config or {}),
             )
-        else:
+        elif algorithm == "simstring":
             self.phrase_matcher = SimstringMatcher(
                 self.nlp.vocab,
                 attr=attr,
                 ignore_excluded=ignore_excluded,
-                **algorithm_config,
+                **(algorithm_config or {}),
+            )
+        else:
+            raise ValueError(
+                f"Algorithm {repr(algorithm)} does not belong to"
+                f' known algorithms ["exact", "simstring"].'
             )
 
         self.regex_matcher = RegexMatcher(

--- a/edsnlp/pipelines/core/matcher/matcher.py
+++ b/edsnlp/pipelines/core/matcher/matcher.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from spacy.language import Language
 from spacy.tokens import Doc, Span
 
 from edsnlp.matchers.phrase import EDSPhraseMatcher
 from edsnlp.matchers.regex import RegexMatcher
+from edsnlp.matchers.simstring import SimstringMatcher
 from edsnlp.matchers.utils import Patterns
 from edsnlp.pipelines.base import BaseComponent
 from edsnlp.utils.filter import filter_spans
@@ -39,17 +40,28 @@ class GenericMatcher(BaseComponent):
         regex: Optional[Patterns],
         attr: str,
         ignore_excluded: bool,
+        algorithm: str = "exact",
+        algorithm_config: Dict[str, Any] = {},
     ):
 
         self.nlp = nlp
 
         self.attr = attr
 
-        self.phrase_matcher = EDSPhraseMatcher(
-            self.nlp.vocab,
-            attr=attr,
-            ignore_excluded=ignore_excluded,
-        )
+        if algorithm == "exact":
+            self.phrase_matcher = EDSPhraseMatcher(
+                self.nlp.vocab,
+                attr=attr,
+                ignore_excluded=ignore_excluded,
+            )
+        else:
+            self.phrase_matcher = SimstringMatcher(
+                self.nlp.vocab,
+                attr=attr,
+                ignore_excluded=ignore_excluded,
+                **algorithm_config,
+            )
+
         self.regex_matcher = RegexMatcher(
             attr=attr,
             ignore_excluded=ignore_excluded,

--- a/edsnlp/pipelines/core/normalizer/accents/factory.py
+++ b/edsnlp/pipelines/core/normalizer/accents/factory.py
@@ -11,7 +11,9 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("accents", "eds.accents", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "accents", "eds.accents", default_config=DEFAULT_CONFIG, assigns=["token.norm"]
+)
 @Language.factory(
     "eds.accents",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/core/normalizer/accents/factory.py
+++ b/edsnlp/pipelines/core/normalizer/accents/factory.py
@@ -12,7 +12,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("accents", "eds.accents", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.accents", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.accents",
+    default_config=DEFAULT_CONFIG,
+    assigns=["token.norm"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/normalizer/factory.py
+++ b/edsnlp/pipelines/core/normalizer/factory.py
@@ -19,7 +19,9 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("normalizer", "eds.normalizer", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.normalizer", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.normalizer", default_config=DEFAULT_CONFIG, assigns=["token.norm", "token.tag"]
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/normalizer/factory.py
+++ b/edsnlp/pipelines/core/normalizer/factory.py
@@ -18,7 +18,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("normalizer", "eds.normalizer", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "normalizer",
+    "eds.normalizer",
+    default_config=DEFAULT_CONFIG,
+    assigns=["token.norm", "token.tag"],
+)
 @Language.factory(
     "eds.normalizer", default_config=DEFAULT_CONFIG, assigns=["token.norm", "token.tag"]
 )

--- a/edsnlp/pipelines/core/normalizer/pollution/factory.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/factory.py
@@ -12,7 +12,9 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("pollution", "eds.pollution", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.pollution", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.pollution", default_config=DEFAULT_CONFIG, assigns=["token.norm"]
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/normalizer/pollution/factory.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/factory.py
@@ -11,10 +11,10 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("pollution", "eds.pollution", default_config=DEFAULT_CONFIG)
-@Language.factory(
-    "eds.pollution", default_config=DEFAULT_CONFIG, assigns=["token.norm"]
+@deprecated_factory(
+    "pollution", "eds.pollution", default_config=DEFAULT_CONFIG, assigns=["token.tag"]
 )
+@Language.factory("eds.pollution", default_config=DEFAULT_CONFIG, assigns=["token.tag"])
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/normalizer/quotes/factory.py
+++ b/edsnlp/pipelines/core/normalizer/quotes/factory.py
@@ -12,7 +12,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("quotes", "eds.quotes", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.quotes", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.quotes",
+    default_config=DEFAULT_CONFIG,
+    assigns=["token.norm"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/normalizer/quotes/factory.py
+++ b/edsnlp/pipelines/core/normalizer/quotes/factory.py
@@ -11,7 +11,9 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("quotes", "eds.quotes", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "quotes", "eds.quotes", default_config=DEFAULT_CONFIG, assigns=["token.norm"]
+)
 @Language.factory(
     "eds.quotes",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/core/sentences/factory.py
+++ b/edsnlp/pipelines/core/sentences/factory.py
@@ -14,7 +14,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("sentences", "eds.sentences", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.sentences", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.sentences",
+    default_config=DEFAULT_CONFIG,
+    assigns=["token.is_sent_start"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/sentences/factory.py
+++ b/edsnlp/pipelines/core/sentences/factory.py
@@ -13,7 +13,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("sentences", "eds.sentences", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "sentences",
+    "eds.sentences",
+    default_config=DEFAULT_CONFIG,
+    assigns=["token.is_sent_start"],
+)
 @Language.factory(
     "eds.sentences",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/core/terminology/__init__.py
+++ b/edsnlp/pipelines/core/terminology/__init__.py
@@ -1,1 +1,1 @@
-from .terminology import TerminologyMatcher
+from .terminology import TerminologyMatcher, TerminologyTermMatcher

--- a/edsnlp/pipelines/core/terminology/factory.py
+++ b/edsnlp/pipelines/core/terminology/factory.py
@@ -2,15 +2,15 @@ from typing import Any, Dict, List, Optional, Union
 
 from spacy.language import Language
 
-from edsnlp.pipelines.core.terminology import TerminologyMatcher
+from edsnlp.pipelines.core.terminology import TerminologyMatcher, TerminologyTermMatcher
 
 DEFAULT_CONFIG = dict(
     terms=None,
     regex=None,
     attr="TEXT",
     ignore_excluded=False,
-    algorithm="exact",
-    algorithm_config={},
+    term_matcher="exact",
+    term_matcher_config={},
 )
 
 
@@ -27,8 +27,8 @@ def create_component(
     attr: Union[str, Dict[str, str]],
     regex: Optional[Dict[str, Union[str, List[str]]]],
     ignore_excluded: bool,
-    algorithm: str,
-    algorithm_config: Dict[str, Any],
+    term_matcher: TerminologyTermMatcher,
+    term_matcher_config: Dict[str, Any],
 ):
     assert not (terms is None and regex is None)
 
@@ -44,6 +44,6 @@ def create_component(
         attr=attr,
         regex=regex,
         ignore_excluded=ignore_excluded,
-        algorithm=algorithm,
-        algorithm_config=algorithm_config,
+        term_matcher=term_matcher,
+        term_matcher_config=term_matcher_config,
     )

--- a/edsnlp/pipelines/core/terminology/factory.py
+++ b/edsnlp/pipelines/core/terminology/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from spacy.language import Language
 
@@ -9,6 +9,8 @@ DEFAULT_CONFIG = dict(
     regex=None,
     attr="TEXT",
     ignore_excluded=False,
+    algorithm="exact",
+    algorithm_config={},
 )
 
 
@@ -25,6 +27,8 @@ def create_component(
     attr: Union[str, Dict[str, str]],
     regex: Optional[Dict[str, Union[str, List[str]]]],
     ignore_excluded: bool,
+    algorithm: str,
+    algorithm_config: Dict[str, Any],
 ):
     assert not (terms is None and regex is None)
 
@@ -40,4 +44,6 @@ def create_component(
         attr=attr,
         regex=regex,
         ignore_excluded=ignore_excluded,
+        algorithm=algorithm,
+        algorithm_config=algorithm_config,
     )

--- a/edsnlp/pipelines/core/terminology/factory.py
+++ b/edsnlp/pipelines/core/terminology/factory.py
@@ -12,7 +12,11 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.terminology", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.terminology",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/core/terminology/terminology.py
+++ b/edsnlp/pipelines/core/terminology/terminology.py
@@ -61,6 +61,7 @@ class TerminologyMatcher(BaseComponent):
                 self.nlp.vocab,
                 attr=attr,
                 ignore_excluded=ignore_excluded,
+                **(algorithm_config or {}),
             )
         elif algorithm == "simstring":
             self.phrase_matcher = SimstringMatcher(
@@ -68,6 +69,11 @@ class TerminologyMatcher(BaseComponent):
                 attr=attr,
                 ignore_excluded=ignore_excluded,
                 **(algorithm_config or {}),
+            )
+        else:
+            raise ValueError(
+                f"Algorithm {repr(algorithm)} does not belong to"
+                f' known algorithms ["exact", "simstring"].'
             )
 
         self.regex_matcher = RegexMatcher(

--- a/edsnlp/pipelines/core/terminology/terminology.py
+++ b/edsnlp/pipelines/core/terminology/terminology.py
@@ -6,6 +6,7 @@ from spacy.tokens import Doc, Span
 
 from edsnlp.matchers.phrase import EDSPhraseMatcher
 from edsnlp.matchers.regex import RegexMatcher
+from edsnlp.matchers.simstring import SimstringMatcher
 from edsnlp.matchers.utils import Patterns
 from edsnlp.pipelines.base import BaseComponent
 from edsnlp.utils.filter import filter_spans
@@ -45,6 +46,8 @@ class TerminologyMatcher(BaseComponent):
         regex: Optional[Patterns],
         attr: str,
         ignore_excluded: bool,
+        algorithm="exact",
+        algorithm_config=None,
     ):
 
         self.nlp = nlp
@@ -53,11 +56,20 @@ class TerminologyMatcher(BaseComponent):
 
         self.attr = attr
 
-        self.phrase_matcher = EDSPhraseMatcher(
-            self.nlp.vocab,
-            attr=attr,
-            ignore_excluded=ignore_excluded,
-        )
+        if algorithm == "exact":
+            self.phrase_matcher = EDSPhraseMatcher(
+                self.nlp.vocab,
+                attr=attr,
+                ignore_excluded=ignore_excluded,
+            )
+        elif algorithm == "simstring":
+            self.phrase_matcher = SimstringMatcher(
+                vocab=self.nlp.vocab,
+                attr=attr,
+                ignore_excluded=ignore_excluded,
+                **(algorithm_config or {}),
+            )
+
         self.regex_matcher = RegexMatcher(
             attr=attr,
             ignore_excluded=ignore_excluded,

--- a/edsnlp/pipelines/misc/consultation_dates/factory.py
+++ b/edsnlp/pipelines/misc/consultation_dates/factory.py
@@ -18,7 +18,11 @@ DEFAULT_CONFIG = dict(
     "eds.consultation_dates",
     default_config=DEFAULT_CONFIG,
 )
-@Language.factory("eds.consultation_dates", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.consultation_dates",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc._.consultation_dates"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/misc/consultation_dates/factory.py
+++ b/edsnlp/pipelines/misc/consultation_dates/factory.py
@@ -17,6 +17,7 @@ DEFAULT_CONFIG = dict(
     "consultation_dates",
     "eds.consultation_dates",
     default_config=DEFAULT_CONFIG,
+    assigns=["doc._.consultation_dates"],
 )
 @Language.factory(
     "eds.consultation_dates",

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -18,7 +18,9 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("dates", "eds.dates", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "dates", "eds.dates", default_config=DEFAULT_CONFIG, assigns=["doc.spans"]
+)
 @Language.factory("eds.dates", default_config=DEFAULT_CONFIG, assigns=["doc.spans"])
 def create_component(
     nlp: Language,

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -19,7 +19,7 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("dates", "eds.dates", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.dates", default_config=DEFAULT_CONFIG)
+@Language.factory("eds.dates", default_config=DEFAULT_CONFIG, assigns=["doc.spans"])
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/cim10/factory.py
+++ b/edsnlp/pipelines/ner/cim10/factory.py
@@ -2,15 +2,15 @@ from typing import Any, Dict, Union
 
 from spacy.language import Language
 
-from edsnlp.pipelines.core.terminology import TerminologyMatcher
+from edsnlp.pipelines.core.terminology import TerminologyMatcher, TerminologyTermMatcher
 
 from . import patterns
 
 DEFAULT_CONFIG = dict(
     attr="NORM",
     ignore_excluded=False,
-    algorithm="exact",
-    algorithm_config={},
+    term_matcher=TerminologyTermMatcher.exact,
+    term_matcher_config={},
 )
 
 
@@ -22,8 +22,8 @@ def create_component(
     name: str,
     attr: Union[str, Dict[str, str]],
     ignore_excluded: bool,
-    algorithm: str,
-    algorithm_config: Dict[str, Any],
+    term_matcher: TerminologyTermMatcher,
+    term_matcher_config: Dict[str, Any],
 ):
 
     return TerminologyMatcher(
@@ -33,6 +33,6 @@ def create_component(
         terms=patterns.get_patterns(),
         attr=attr,
         ignore_excluded=ignore_excluded,
-        algorithm=algorithm,
-        algorithm_config=algorithm_config,
+        term_matcher=term_matcher,
+        term_matcher_config=term_matcher_config,
     )

--- a/edsnlp/pipelines/ner/cim10/factory.py
+++ b/edsnlp/pipelines/ner/cim10/factory.py
@@ -12,7 +12,9 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.cim10", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.cim10", default_config=DEFAULT_CONFIG, assigns=["doc.ents", "doc.spans"]
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/cim10/factory.py
+++ b/edsnlp/pipelines/ner/cim10/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 from spacy.language import Language
 
@@ -9,6 +9,8 @@ from . import patterns
 DEFAULT_CONFIG = dict(
     attr="NORM",
     ignore_excluded=False,
+    algorithm="exact",
+    algorithm_config={},
 )
 
 
@@ -20,6 +22,8 @@ def create_component(
     name: str,
     attr: Union[str, Dict[str, str]],
     ignore_excluded: bool,
+    algorithm: str,
+    algorithm_config: Dict[str, Any],
 ):
 
     return TerminologyMatcher(
@@ -29,4 +33,6 @@ def create_component(
         terms=patterns.get_patterns(),
         attr=attr,
         ignore_excluded=ignore_excluded,
+        algorithm=algorithm,
+        algorithm_config=algorithm_config,
     )

--- a/edsnlp/pipelines/ner/covid/factory.py
+++ b/edsnlp/pipelines/ner/covid/factory.py
@@ -12,7 +12,11 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.covid", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.covid",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/drugs/factory.py
+++ b/edsnlp/pipelines/ner/drugs/factory.py
@@ -2,15 +2,15 @@ from typing import Any, Dict
 
 from spacy.language import Language
 
-from edsnlp.pipelines.core.terminology import TerminologyMatcher
+from edsnlp.pipelines.core.terminology import TerminologyMatcher, TerminologyTermMatcher
 
 from . import patterns
 
 DEFAULT_CONFIG = dict(
     attr="NORM",
     ignore_excluded=False,
-    algorithm="exact",
-    algorithm_config={},
+    term_matcher=TerminologyTermMatcher.exact,
+    term_matcher_config={},
 )
 
 
@@ -24,8 +24,8 @@ def create_component(
     name: str,
     attr: str,
     ignore_excluded: bool,
-    algorithm: str,
-    algorithm_config: Dict[str, Any],
+    term_matcher: TerminologyTermMatcher,
+    term_matcher_config: Dict[str, Any],
 ):
     return TerminologyMatcher(
         nlp,
@@ -34,6 +34,6 @@ def create_component(
         regex=dict(),
         attr=attr,
         ignore_excluded=ignore_excluded,
-        algorithm=algorithm,
-        algorithm_config=algorithm_config,
+        term_matcher=term_matcher,
+        term_matcher_config=term_matcher_config,
     )

--- a/edsnlp/pipelines/ner/drugs/factory.py
+++ b/edsnlp/pipelines/ner/drugs/factory.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from spacy.language import Language
 
 from edsnlp.pipelines.core.terminology import TerminologyMatcher
@@ -7,6 +9,8 @@ from . import patterns
 DEFAULT_CONFIG = dict(
     attr="NORM",
     ignore_excluded=False,
+    algorithm="exact",
+    algorithm_config={},
 )
 
 
@@ -20,6 +24,8 @@ def create_component(
     name: str,
     attr: str,
     ignore_excluded: bool,
+    algorithm: str,
+    algorithm_config: Dict[str, Any],
 ):
     return TerminologyMatcher(
         nlp,
@@ -28,4 +34,6 @@ def create_component(
         regex=dict(),
         attr=attr,
         ignore_excluded=ignore_excluded,
+        algorithm=algorithm,
+        algorithm_config=algorithm_config,
     )

--- a/edsnlp/pipelines/ner/drugs/factory.py
+++ b/edsnlp/pipelines/ner/drugs/factory.py
@@ -10,7 +10,11 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.drugs", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.drugs",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/charlson/factory.py
+++ b/edsnlp/pipelines/ner/scores/charlson/factory.py
@@ -18,7 +18,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("charlson", "eds.charlson", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "charlson",
+    "eds.charlson",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 @Language.factory(
     "eds.charlson",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/ner/scores/charlson/factory.py
+++ b/edsnlp/pipelines/ner/scores/charlson/factory.py
@@ -19,7 +19,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("charlson", "eds.charlson", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.charlson", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.charlson",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/emergency/ccmu/factory.py
+++ b/edsnlp/pipelines/ner/scores/emergency/ccmu/factory.py
@@ -21,7 +21,11 @@ DEFAULT_CONFIG = dict(
 @deprecated_factory(
     "emergency.ccmu", "eds.emergency.ccmu", default_config=DEFAULT_CONFIG
 )
-@Language.factory("eds.emergency.ccmu", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.emergency.ccmu",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/emergency/ccmu/factory.py
+++ b/edsnlp/pipelines/ner/scores/emergency/ccmu/factory.py
@@ -19,7 +19,10 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory(
-    "emergency.ccmu", "eds.emergency.ccmu", default_config=DEFAULT_CONFIG
+    "emergency.ccmu",
+    "eds.emergency.ccmu",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
 )
 @Language.factory(
     "eds.emergency.ccmu",

--- a/edsnlp/pipelines/ner/scores/emergency/gemsa/factory.py
+++ b/edsnlp/pipelines/ner/scores/emergency/gemsa/factory.py
@@ -21,7 +21,11 @@ DEFAULT_CONFIG = dict(
 @deprecated_factory(
     "emergency.gemsa", "eds.emergency.gemsa", default_config=DEFAULT_CONFIG
 )
-@Language.factory("eds.emergency.gemsa", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.emergency.gemsa",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/emergency/gemsa/factory.py
+++ b/edsnlp/pipelines/ner/scores/emergency/gemsa/factory.py
@@ -19,7 +19,10 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory(
-    "emergency.gemsa", "eds.emergency.gemsa", default_config=DEFAULT_CONFIG
+    "emergency.gemsa",
+    "eds.emergency.gemsa",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
 )
 @Language.factory(
     "eds.emergency.gemsa",

--- a/edsnlp/pipelines/ner/scores/emergency/priority/factory.py
+++ b/edsnlp/pipelines/ner/scores/emergency/priority/factory.py
@@ -19,7 +19,10 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory(
-    "emergency.priority", "eds.emergency.priority", default_config=DEFAULT_CONFIG
+    "emergency.priority",
+    "eds.emergency.priority",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
 )
 @Language.factory(
     "eds.emergency.priority",

--- a/edsnlp/pipelines/ner/scores/emergency/priority/factory.py
+++ b/edsnlp/pipelines/ner/scores/emergency/priority/factory.py
@@ -21,7 +21,11 @@ DEFAULT_CONFIG = dict(
 @deprecated_factory(
     "emergency.priority", "eds.emergency.priority", default_config=DEFAULT_CONFIG
 )
-@Language.factory("eds.emergency.priority", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.emergency.priority",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/factory.py
+++ b/edsnlp/pipelines/ner/scores/factory.py
@@ -15,7 +15,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("score", "eds.score", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.score", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.score",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/factory.py
+++ b/edsnlp/pipelines/ner/scores/factory.py
@@ -14,7 +14,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("score", "eds.score", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "score",
+    "eds.score",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 @Language.factory(
     "eds.score",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/ner/scores/sofa/factory.py
+++ b/edsnlp/pipelines/ner/scores/sofa/factory.py
@@ -17,7 +17,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("SOFA", "eds.SOFA", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "SOFA",
+    "eds.SOFA",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 @Language.factory(
     "eds.SOFA",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/ner/scores/sofa/factory.py
+++ b/edsnlp/pipelines/ner/scores/sofa/factory.py
@@ -18,7 +18,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("SOFA", "eds.SOFA", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.SOFA", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.SOFA",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/ner/scores/tnm/factory.py
+++ b/edsnlp/pipelines/ner/scores/tnm/factory.py
@@ -10,7 +10,11 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@Language.factory("eds.TNM", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.TNM",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/qualifiers/family/factory.py
+++ b/edsnlp/pipelines/qualifiers/family/factory.py
@@ -15,7 +15,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("family", "eds.family", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "family",
+    "eds.family",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.family"],
+)
 @Language.factory(
     "eds.family",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/qualifiers/family/factory.py
+++ b/edsnlp/pipelines/qualifiers/family/factory.py
@@ -16,7 +16,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("family", "eds.family", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.family", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.family",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.family"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/qualifiers/history/factory.py
+++ b/edsnlp/pipelines/qualifiers/history/factory.py
@@ -16,9 +16,24 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("antecedents", "eds.history", default_config=DEFAULT_CONFIG)
-@deprecated_factory("eds.antecedents", "eds.history", default_config=DEFAULT_CONFIG)
-@deprecated_factory("history", "eds.history", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "antecedents",
+    "eds.history",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.history"],
+)
+@deprecated_factory(
+    "eds.antecedents",
+    "eds.history",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.history"],
+)
+@deprecated_factory(
+    "history",
+    "eds.history",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.history"],
+)
 @Language.factory(
     "eds.history",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/qualifiers/history/factory.py
+++ b/edsnlp/pipelines/qualifiers/history/factory.py
@@ -19,7 +19,11 @@ DEFAULT_CONFIG = dict(
 @deprecated_factory("antecedents", "eds.history", default_config=DEFAULT_CONFIG)
 @deprecated_factory("eds.antecedents", "eds.history", default_config=DEFAULT_CONFIG)
 @deprecated_factory("history", "eds.history", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.history", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.history",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.history"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/qualifiers/hypothesis/factory.py
+++ b/edsnlp/pipelines/qualifiers/hypothesis/factory.py
@@ -19,7 +19,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("hypothesis", "eds.hypothesis", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "hypothesis",
+    "eds.hypothesis",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.hypothesis"],
+)
 @Language.factory(
     "eds.hypothesis",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/qualifiers/hypothesis/factory.py
+++ b/edsnlp/pipelines/qualifiers/hypothesis/factory.py
@@ -20,7 +20,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("hypothesis", "eds.hypothesis", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.hypothesis", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.hypothesis",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.hypothesis"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/qualifiers/negation/factory.py
+++ b/edsnlp/pipelines/qualifiers/negation/factory.py
@@ -19,7 +19,11 @@ DEFAULT_CONFIG = dict(
 
 
 @deprecated_factory("negation", "eds.negation", default_config=DEFAULT_CONFIG)
-@Language.factory("eds.negation", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.negation",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.negation"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/qualifiers/negation/factory.py
+++ b/edsnlp/pipelines/qualifiers/negation/factory.py
@@ -18,7 +18,12 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("negation", "eds.negation", default_config=DEFAULT_CONFIG)
+@deprecated_factory(
+    "negation",
+    "eds.negation",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.negation"],
+)
 @Language.factory(
     "eds.negation",
     default_config=DEFAULT_CONFIG,

--- a/edsnlp/pipelines/qualifiers/reported_speech/factory.py
+++ b/edsnlp/pipelines/qualifiers/reported_speech/factory.py
@@ -22,7 +22,11 @@ DEFAULT_CONFIG = dict(
 @deprecated_factory(
     "reported_speech", "eds.reported_speech", default_config=DEFAULT_CONFIG
 )
-@Language.factory("eds.reported_speech", default_config=DEFAULT_CONFIG)
+@Language.factory(
+    "eds.reported_speech",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.reported_speech"],
+)
 def create_component(
     nlp: Language,
     name: str,

--- a/edsnlp/pipelines/qualifiers/reported_speech/factory.py
+++ b/edsnlp/pipelines/qualifiers/reported_speech/factory.py
@@ -18,9 +18,17 @@ DEFAULT_CONFIG = dict(
 )
 
 
-@deprecated_factory("rspeech", "eds.reported_speech", default_config=DEFAULT_CONFIG)
 @deprecated_factory(
-    "reported_speech", "eds.reported_speech", default_config=DEFAULT_CONFIG
+    "rspeech",
+    "eds.reported_speech",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.reported_speech"],
+)
+@deprecated_factory(
+    "reported_speech",
+    "eds.reported_speech",
+    default_config=DEFAULT_CONFIG,
+    assigns=["span._.reported_speech"],
 )
 @Language.factory(
     "eds.reported_speech",

--- a/edsnlp/utils/deprecation.py
+++ b/edsnlp/utils/deprecation.py
@@ -47,6 +47,7 @@ def deprecated_factory(
     new_name: Optional[str] = None,
     default_config: Optional[Dict[str, Any]] = None,
     func: Optional[Callable] = None,
+    **kwargs,
 ) -> Callable:
     """
     Execute the Language.factory method on a modified factory function.
@@ -71,7 +72,7 @@ def deprecated_factory(
     if default_config is None:
         default_config = dict()
 
-    wrapper = Language.factory(name, default_config=default_config)
+    wrapper = Language.factory(name, default_config=default_config, **kwargs)
 
     def wrap(factory):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ numpy>=1.21
 pandas>=1.1
 pendulum
 pydantic>=1.8.2,<1.10.0
+quickumls_simstring
 regex<=2022.3.2  # due to dateparser bug issue 1045
 scikit-learn>=1.0.0
 spacy>=3.1<4.0.0

--- a/tests/matchers/test_simstring.py
+++ b/tests/matchers/test_simstring.py
@@ -1,0 +1,92 @@
+from edsnlp.matchers.simstring import SimstringMatcher
+
+
+def test_simstring_matcher(doc, nlp):
+    matcher = SimstringMatcher(nlp.vocab, attr="TEXT")
+
+    matcher.build_patterns(
+        nlp,
+        {
+            "patient": ["patient"],
+            "locomotion": ["locomotions"],
+        },
+    )
+
+    matches = [m.text for m in matcher(doc, as_spans=True)]
+
+    assert matches == ["patient", "locomotion", "patient"]
+
+
+def test_with_normalizer(blank_nlp):
+    blank_nlp.add_pipe("eds.normalizer")
+    pattern = "matching"
+    matcher = SimstringMatcher(
+        blank_nlp.vocab, attr="NORM", threshold=0.75, measure="dice"
+    )
+
+    matcher.build_patterns(
+        blank_nlp,
+        {
+            "test": [pattern],
+            "C220": ["carcinome hépatocellulaire", "carc. hépatocellulaire"],
+            "N02BE01": ["paracetamol"],
+        },
+    )
+
+    texts = (
+        ("Ceci est un test de matching", ["matching"]),
+        ("Ceci est un test de matchings", ["matchings"]),
+        ("On prescrit du paracétomol, un medicament.", ["paracétomol"]),
+        (
+            "Le patient a un carcinome hépatacellulaire !",
+            ["carcinome hépatacellulaire"],
+        ),
+    )
+
+    for text, ents in texts:
+        doc = blank_nlp(text)
+        matches = list(matcher(doc))
+        assert len(matches) > 0
+
+        assert sorted([m.text for m in matcher(doc[2:], as_spans=True)]) == ents
+        assert sorted([doc[s:e].text for _, s, e in matcher(doc[2:])]) == ents
+
+        assert sorted([m.text for m in matcher(doc, as_spans=True)]) == ents
+        assert sorted([doc[s:e].text for _, s, e in matcher(doc)]) == ents
+
+
+def test_without_normalizer(blank_nlp):
+    pattern = "matching"
+    matcher = SimstringMatcher(
+        blank_nlp.vocab, attr="NORM", threshold=0.75, measure="dice"
+    )
+
+    matcher.build_patterns(
+        blank_nlp,
+        {
+            "test": [pattern],
+            "C220": ["carcinome hépatocellulaire", "carc. hépatocellulaire"],
+            "N02BE01": ["paracétamol"],
+        },
+    )
+
+    texts = (
+        ("Ceci est un test de matching", ["matching"]),
+        ("Ceci est un test de matchings", ["matchings"]),
+        ("On prescrit du paracétomol, un médicament.", ["paracétomol"]),
+        (
+            "Le patient a un carcinome hépatacellulaire !",
+            ["carcinome hépatacellulaire"],
+        ),
+    )
+
+    for text, ents in texts:
+        doc = blank_nlp(text)
+        matches = list(matcher(doc))
+        assert len(matches) > 0
+
+        assert sorted([m.text for m in matcher(doc[2:], as_spans=True)]) == ents
+        assert sorted([doc[s:e].text for _, s, e in matcher(doc[2:])]) == ents
+
+        assert sorted([m.text for m in matcher(doc, as_spans=True)]) == ents
+        assert sorted([doc[s:e].text for _, s, e in matcher(doc)]) == ents

--- a/tests/pipelines/core/test_matcher.py
+++ b/tests/pipelines/core/test_matcher.py
@@ -1,4 +1,6 @@
+import pytest
 from pytest import fixture
+from thinc.config import ConfigValidationError
 
 from edsnlp.pipelines.core.matcher import GenericMatcher
 
@@ -26,6 +28,40 @@ def matcher_factory(blank_nlp):
         )
 
     return factory
+
+
+def test_matcher_config_typo(blank_nlp):
+    with pytest.raises(ConfigValidationError):
+        blank_nlp.add_pipe(
+            "matcher",
+            config={
+                "terms": {"test": ["test"]},
+                "term_matcher": "exoct",
+            },
+        )
+
+
+def test_exact_matcher_spacy_factory(blank_nlp):
+    blank_nlp.add_pipe(
+        "matcher",
+        config={
+            "terms": {"test": ["test"]},
+            "term_matcher": "exact",
+        },
+    )
+
+
+def test_simstring_matcher_spacy_factory(blank_nlp):
+    blank_nlp.add_pipe(
+        "matcher",
+        config={
+            "terms": {"test": ["test"]},
+            "term_matcher": "simstring",
+            "term_matcher_config": {
+                "measure": "dice",
+            },
+        },
+    )
 
 
 def test_terms(blank_doc, matcher_factory):


### PR DESCRIPTION
## Description

This PR introduces the `SimstringMatcher` to perform fuzzy term matching with the `simstring` algorithm.

I believe we could reimplement the simstring algorithm and speedup the matching by performing the full-text search directly instead of splitting the text into candidates. We could :
- keep the trigram database in memory for small terminologies
- avoid performing redundant trigram lookups as the window moves over the text

At the moment, the trigram db is recomputed every time we instantiate the matcher. To avoid doing this preprocessing multiple times, we could either:
- let the user execute it once with an external command and give the path of the db
- compute a hash given the matcher parameters and cache the db under a dynamically generated path (something along these lines : [joblib's cache](https://joblib.readthedocs.io/en/latest/memory.html) or [nlstruct's cache](https://github.com/percevalw/nlstruct/blob/0b13a8bc29d0e7946eb72ff2fb599f2a95f525e9/nlstruct/environment/cache.py))

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
