### PR TITLE
bump pydantic version to minimal 1.8.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Faster `eds.sentences` pipeline component with Cython
+- Bump version of PyDantic in `requirements.txt` to 1.8.2 to handle an incompatibility with the ContextualMatcher
 
 ## v0.6.0 (2022-06-17)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ regex<=2022.3.2  # due to dateparser bug issue 1045
 scikit-learn>=1.0.0
 spacy>=3.1<4.0.0
 tqdm
+pydantic>=1.8.2,<1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ loguru
 numpy>=1.21
 pandas>=1.1
 pendulum
-regex<=2022.3.2  # due to dateparser bug issue 1045
 pydantic>=1.8.2,<1.10.0
+regex<=2022.3.2  # due to dateparser bug issue 1045
 scikit-learn>=1.0.0
 spacy>=3.1<4.0.0
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.21
 pandas>=1.1
 pendulum
 regex<=2022.3.2  # due to dateparser bug issue 1045
+pydantic>=1.8.2,<1.10.0
 scikit-learn>=1.0.0
 spacy>=3.1<4.0.0
 tqdm
-pydantic>=1.8.2,<1.10.0


### PR DESCRIPTION
Bug with ContextualMatcher when using PyDantic < 1.8.2

## Description

Updating the minimal version in `requirements.txt`