### PR TITLE
fix: eds.sentences behaviour with dates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,10 @@
 - Faster `eds.sentences` pipeline component with Cython
 - Bump version of PyDantic in `requirements.txt` to 1.8.2 to handle an incompatibility with the ContextualMatcher
 
+### Fixed
+
+- `eds.sentences` behaviour with dot-delimited dates (eg `02.07.2022`, which counted as three sentences)
+
 ## v0.6.0 (2022-06-17)
 
 ### Added

--- a/edsnlp/pipelines/core/sentences/sentences.pyx
+++ b/edsnlp/pipelines/core/sentences/sentences.pyx
@@ -90,6 +90,8 @@ cdef class SentenceSegmenter(object):
             is_newline = Lexeme.c_check_flag(token.lex, IS_SPACE) and token.lex.orth == self.newline_hash
 
             if seen_period or seen_newline:
+                if seen_period and Lexeme.c_check_flag(token.lex, IS_DIGIT):
+                    continue
                 if is_in_punct_chars or is_newline or Lexeme.c_check_flag(token.lex, IS_PUNCT):
                     continue
                 if seen_period:

--- a/tests/pipelines/core/test_sentences.py
+++ b/tests/pipelines/core/test_sentences.py
@@ -39,3 +39,14 @@ def test_sentences(nlp, endlines):
     assert len(list(sentencizer(doc).sents)) == 7
 
     segmenter(nlp_blank(""))
+
+
+def test_false_positives(blank_nlp):
+
+    false_positives = [
+        "02.04.2018",
+    ]
+
+    for fp in false_positives:
+        doc = blank_nlp(fp)
+        assert len(list(doc.sents)) == 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->
This PR fixes the behaviour of the `eds.sentences` pipeline, which counted dot-delimited dates as individual sentences.

## Description

The pipeline checks for the presence of a digit immediately after the punctuation.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
