### PR TITLE
fix: add "non" preceding pattern

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,10 +9,11 @@
 ### Changed
 
 - Add consultation date pattern "CS", and False Positive patterns for dates (namely phone numbers and pagination).
-- Update the pipeline score `eds.TNM`. Now it is possible to return a dictionary where the results are whether str or int values. Also change patterns and matching attribute.
+- Update the pipeline score `eds.TNM`. Now it is possible to return a dictionary where the results are either `str` or `int` values
 
 ### Fixed
 
+- Add new patterns to the negation qualifier
 - Numpy header issues with binary distributed packages
 - Simstring dependency on Windows
 

--- a/edsnlp/pipelines/qualifiers/negation/patterns.py
+++ b/edsnlp/pipelines/qualifiers/negation/patterns.py
@@ -80,6 +80,7 @@ preceding: List[str] = [
     "niant",
     "nie",
     "nié",
+    "non",
     "nullement",
     "pas d",
     "pas de cause de",
@@ -94,7 +95,6 @@ preceding: List[str] = [
     "sans présenter de",
     "sans",
     "symptôme atypique",
-    "non",
 ]
 
 following: List[str] = [

--- a/edsnlp/pipelines/qualifiers/negation/patterns.py
+++ b/edsnlp/pipelines/qualifiers/negation/patterns.py
@@ -94,6 +94,7 @@ preceding: List[str] = [
     "sans présenter de",
     "sans",
     "symptôme atypique",
+    "non",
 ]
 
 following: List[str] = [

--- a/tests/pipelines/qualifiers/test_family.py
+++ b/tests/pipelines/qualifiers/test_family.py
@@ -23,6 +23,7 @@ examples: List[str] = [
         "Antécédent familiaux de diabète mais pas "
         "<ent family_=PATIENT>détecté</ent> jusqu'ici."
     ),
+    "mère : <ent family=True>diabète de type II</ent>",
 ]
 
 

--- a/tests/pipelines/qualifiers/test_negation.py
+++ b/tests/pipelines/qualifiers/test_negation.py
@@ -11,6 +11,7 @@ negation_examples: List[str] = [
         "Pas de <ent negated=true>lésion pulmonaire avec "
         "l'absence de lésion secondaire</ent>."
     ),
+    "Cancer non <ent negation=true>métastasé</ent>.",
     "Absence d'<ent negated=true>image osseuse d'allure évolutive</ent>.",
     "il n'y a pas de <ent polarity_=NEG>métas,tases</ent>",
     "Le patient n'est pas <ent polarity_=NEG>malade</ent>.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This PR proposes a new pattern for preceding negations, and adds the failing example.

Thank you @etienneguevel for looking out.

<!--- Describe the changes. -->

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
