### PR TITLE
Add consultation date pattern and date False Positive

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,10 @@
 # Changelog
 
-### Added
-- Add consultation date pattern "CS", and False Positive patterns for dates (namely phone numbers and pagination).
+## Unreleased
+
 ### Changed
+
+- Add consultation date pattern "CS", and False Positive patterns for dates (namely phone numbers and pagination).
 - Update the pipeline score `eds.TNM`. Now it is possible to return a dictionary where the results are whether str or int values. Also change patterns and matching attribute.
 
 ## v0.6.1 (2022-07-11)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+### Added
+- Add consultation date pattern "CS", and False Positive patterns for dates (namely phone numbers and pagination).
 ### Changed
 - Update the pipeline score `eds.TNM`. Now it is possible to return a dictionary where the results are whether str or int values. Also change patterns and matching attribute.
 

--- a/edsnlp/pipelines/misc/consultation_dates/patterns.py
+++ b/edsnlp/pipelines/misc/consultation_dates/patterns.py
@@ -2,6 +2,7 @@ consultation_mention = [
     "rendez-vous pris",
     r"consultation",
     r"consultation.{1,8}examen",
+    r"\bcs\b",
     "examen clinique",
     r"de compte rendu",
     r"date de l'examen",

--- a/edsnlp/pipelines/misc/dates/patterns/false_positive.py
+++ b/edsnlp/pipelines/misc/dates/patterns/false_positive.py
@@ -1,10 +1,11 @@
 from edsnlp.utils.regex import make_pattern
 
-from .atomic.delimiters import delimiter_pattern
+from .atomic.delimiters import delimiters
 
-false_positive_pattern = make_pattern(
-    [
-        r"(\d+" + delimiter_pattern + r"){3,}\d+(?!:\d\d)\b",
-        r"\d\/\d",
-    ]
-)
+# Pagination
+page_patterns = [r"\d\/\d"]
+
+# Phone numbers
+phone_patterns = [r"(\d\d" + delimiter + r"){3,}\d\d" for delimiter in delimiters]
+
+false_positive_pattern = make_pattern(page_patterns + phone_patterns)

--- a/tests/pipelines/misc/test_consultation_date.py
+++ b/tests/pipelines/misc/test_consultation_date.py
@@ -6,7 +6,11 @@ TEXT = """
 Références : AMO/AMO
 Objet : Compte-Rendu de Consultation du 07/10/2018
 Madame BEESLY Pamela, âgée de 45 ans, née le 05/10/1987, a été vue en consultation
-dans le service de NCK CS RHUMATO.
+dans le service de NCK CS RHUMATO. Tel: 01-02-03-04-05
+
+####
+
+CR CS 3-1-2019 1/2
 
 ####
 
@@ -20,18 +24,26 @@ Document signé le 10/02/2020
 
 cons = dict(
     additional_params=dict(),
-    result=[dict(year=2018, month=10, day=7)],
+    result=[
+        dict(year=2018, month=10, day=7),
+        dict(year=2019, month=1, day=3),
+    ],
 )
 
 cons_town = dict(
     additional_params=dict(town_mention=True),
-    result=[dict(year=2018, month=10, day=7), dict(year=2020, month=1, day=24)],
+    result=[
+        dict(year=2018, month=10, day=7),
+        dict(year=2019, month=1, day=3),
+        dict(year=2020, month=1, day=24),
+    ],
 )
 
 cons_town_doc = dict(
     additional_params=dict(town_mention=True, document_date_mention=True),
     result=[
         dict(year=2018, month=10, day=7),
+        dict(year=2019, month=1, day=3),
         dict(year=2020, month=1, day=24),
         dict(year=2020, month=2, day=10),
     ],
@@ -43,20 +55,20 @@ cons_town_doc = dict(
 def test_cons_dates(date_pipeline, example, blank_nlp):
 
     blank_nlp.add_pipe(
-        "normalizer",
+        "eds.normalizer",
         config=dict(lowercase=True, accents=True, quotes=True, pollution=False),
     )
 
-    if date_pipeline:
-        blank_nlp.add_pipe("dates")
-
     blank_nlp.add_pipe(
-        "consultation_dates", config=dict(**example["additional_params"])
+        "eds.consultation_dates", config=dict(**example["additional_params"])
     )
+
+    if date_pipeline:
+        blank_nlp.add_pipe("eds.dates")
 
     doc = blank_nlp(TEXT)
 
-    assert len(doc.spans["dates"]) == 4 or not date_pipeline
+    assert len(doc.spans["dates"]) == 5 or not date_pipeline
 
     assert len(doc.spans["consultation_dates"]) == len(example["result"])
 

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -65,6 +65,7 @@ examples = [
     "Le <ent norm='????-01-07' day=7 month=1>07/01</ent>.",
     "Il est venu en <ent norm='????-08-??' month=8>août</ent>.",
     "Il est venu <ent norm='~0 day' day=0 direction=CURRENT>ce jour</ent>.",
+    "CS le <ent norm='2017-01-11' day=11 month=1 year=2017>11-01-2017</ent> 1/3",
 ]
 
 


### PR DESCRIPTION
## Description

- Add "CS" pattern in consultation dates (ex : "CS du 19/07/2022")
- Update False Positive in date patterns with pagination and telephone number patterns.
- Add corresponding tests

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
