### PR TITLE
Fix numpy header issues with binary packages

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - v*.*.*
+      - build-*
 
 jobs:
   build_wheels:

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@
 - Add consultation date pattern "CS", and False Positive patterns for dates (namely phone numbers and pagination).
 - Update the pipeline score `eds.TNM`. Now it is possible to return a dictionary where the results are whether str or int values. Also change patterns and matching attribute.
 
+### Fixed
+
+- Simstring dependency on Windows
+
 ### Added
 - Makefile to install,test the application and see the documentation
 ## v0.6.1 (2022-07-11)

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Numpy header issues with binary distributed packages
 - Simstring dependency on Windows
 
 ### Added

--- a/docs/utilities/matchers.md
+++ b/docs/utilities/matchers.md
@@ -74,7 +74,7 @@ The `SimstringMatcher` performs fuzzy term matching by comparing spans of text w
 similarity metric. It is especially useful to handle spelling variations like
 `paracetomol` (instead of `paracetamol`).
 
-The [`simstring`](https://github.com/Georgetown-IR-Lab/simstring/tree/master/quickumls_simstring) algorithm compares two strings by enumerating their char trigrams and
+The [`simstring`](www.chokkan.org/software/simstring/) algorithm compares two strings by enumerating their char trigrams and
 measuring the overlap between the two sets. In the previous example:
 - `paracetomol` becomes `##p #pa par ara rac ace cet eto tom omo mol ol# l##`
 - `paracetamol` becomes `##p #pa par ara rac ace cet eta tam amo mol ol# l##`

--- a/edsnlp/matchers/simstring.py
+++ b/edsnlp/matchers/simstring.py
@@ -8,7 +8,7 @@ from math import sqrt
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
-import quickumls_simstring.simstring as simstring
+import pysimstring.simstring as simstring
 from spacy import Language, Vocab
 from spacy.tokens import Doc, Span
 from tqdm import tqdm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,11 @@ requires = [
     "setuptools",
     "cython>=0.25,<3.0",
     "spacy>=3.2<4.0",
-    "numpy>=1.21",
+    "numpy==1.15.0; python_version<='3.7'",
+    "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.3; python_version=='3.9'",
+    "numpy==1.21.3; python_version=='3.10'",
+    "numpy; python_version>='3.11'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.21
 pandas>=1.1
 pendulum
 pydantic>=1.8.2,<1.10.0
-quickumls_simstring
+pysimstring>=1.2.1
 regex<=2022.3.2  # due to dateparser bug issue 1045
 scikit-learn>=1.0.0
 spacy>=3.1<4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 decorator
 loguru
-numpy>=1.21
-pandas>=1.1
+numpy>=1.15.0
+pandas
 pendulum
 pydantic>=1.8.2,<1.10.0
 pysimstring>=1.2.1


### PR DESCRIPTION
## Description

This PR aims at fixing issues with numpy headers, as observed in https://github.com/aphp/edsnlp/issues/97.
Following [spaCy's docs](https://spacy.io/usage#:~:text=Using%20build%20constraints%20when%20compiling%20from%20source), we need to add build constraints and rely on [numpy binaries forward compatibility], (https://numpy.org/doc/stable/user/depending_on_numpy.html#build-time-dependency), so using the lowest possible version on numpy to build the lib.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).