### PR TITLE
Restore demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Tests](https://img.shields.io/github/workflow/status/aphp/edsnlp/Tests%20and%20Linting?label=tests&style=flat-square)
 [![Documentation](https://img.shields.io/github/workflow/status/aphp/edsnlp/Documentation?label=docs&style=flat-square)](https://aphp.github.io/edsnlp/latest/)
 [![PyPI](https://img.shields.io/pypi/v/edsnlp?color=blue&style=flat-square)](https://pypi.org/project/edsnlp/)
-[![Demo](https://img.shields.io/badge/demo%20%F0%9F%9A%80-streamit-grean?style=flat-square)](https://aphp-edsnlp-demoapp-863wcd.streamlitapp.com/)
+[![Demo](https://img.shields.io/badge/demo%20%F0%9F%9A%80-streamit-grean?style=flat-square)](https://aphp.github.io/edsnlp/demo/)
 [![Codecov](https://img.shields.io/codecov/c/github/aphp/edsnlp?logo=codecov&style=flat-square)](https://codecov.io/gh/aphp/edsnlp)
 [![DOI](https://zenodo.org/badge/467585436.svg)](https://zenodo.org/badge/latestdoi/467585436)
 
@@ -9,7 +9,7 @@
 
 EDS-NLP provides a set of spaCy components that are used to extract information from clinical notes written in French.
 
-Check out the interactive [demo](https://aphp-edsnlp-demoapp-863wcd.streamlitapp.com/)!
+Check out the interactive [demo](https://aphp.github.io/edsnlp/demo/)!
 
 If it's your first time with spaCy, we recommend you familiarise yourself with some of their key concepts by looking at the "[spaCy 101](https://aphp.github.io/edsnlp/latest/tutorials/spacy101/)" page in the documentation.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- Change links to streamlit demo
-
 ## v0.6.2 (2022-08-02)
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ theme:
 
 nav:
   - index.md
-  - Demo: https://aphp-edsnlp-demoapp-863wcd.streamlitapp.com/" target="_blank
+  - Demo: https://aphp.github.io/edsnlp/demo" target="_blank
   - Tutorials:
     - tutorials/index.md
     - tutorials/spacy101.md

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     url="https://github.com/aphp/edsnlp",
     project_urls={
         "Documentation": "https://aphp.github.io/edsnlp",
-        "Demo": "https://aphp-edsnlp-demoapp-863wcd.streamlitapp.com/",
+        "Demo": "https://aphp.github.io/edsnlp/demo",
         "Bug Tracker": "https://github.com/aphp/edsnlp/issues",
     },
     long_description=long_description,


### PR DESCRIPTION
## Description

This PR restores original demo links since the streamlit embedded iframe issue has been resolved.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
