### PR TITLE
Prevent section titles from capturing surrounding tokens

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Prevent section titles from capturing surrounding tokens, causing overlaps (#113)
+
 ## v0.6.2 (2022-08-02)
 
 ### Added

--- a/docs/pipelines/misc/sections.md
+++ b/docs/pipelines/misc/sections.md
@@ -68,7 +68,7 @@ text = "CRU du 10/09/2021\n" "Motif :\n" "Patient admis pour suspicion de COVID"
 doc = nlp(text)
 
 doc.spans["section_titles"]
-# Out: [Motif :]
+# Out: [Motif]
 ```
 
 ## Configuration

--- a/edsnlp/pipelines/misc/sections/sections.py
+++ b/edsnlp/pipelines/misc/sections/sections.py
@@ -79,7 +79,9 @@ class Sections(GenericMatcher):
         self.add_patterns = add_patterns
         if add_patterns:
             for k, v in sections.items():
-                sections[k] = [r"\n[^\n]{0,5}" + ent + r"[^\n]{0,5}\n" for ent in v]
+                sections[k] = [
+                    r"(?<=\n[^\n]{0,5})" + ent + r"(?=[^\n]{0,5}\n)" for ent in v
+                ]
 
         super().__init__(
             nlp,
@@ -119,13 +121,6 @@ class Sections(GenericMatcher):
             spaCy Doc object, annotated for sections
         """
         titles = filter_spans(self.process(doc))
-
-        if self.add_patterns:
-            # Remove preceding newline
-            titles = [
-                Span(doc, title.start + 1, title.end - 1, label=title.label_)
-                for title in titles
-            ]
 
         sections = []
 


### PR DESCRIPTION
## Description

This PR prevents section titles from capturing surrounding tokens, which was causing overlaps. This prevents some sections that are too close to each other from going undetected, as in #113.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
