### PR TITLE
Fix `history` factory parameter type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 
 - Prevent section titles from capturing surrounding tokens, causing overlaps (#113)
 - Enhance existing patterns for section detection and add patterns for previously ignored sections (introduction, evolution, modalites de sortie, vaccination) .
+- Fix explain mode, which was always triggered, in `eds.history` factory.
 
 ## v0.6.2 (2022-08-02)
 

--- a/edsnlp/pipelines/qualifiers/history/factory.py
+++ b/edsnlp/pipelines/qualifiers/history/factory.py
@@ -46,7 +46,7 @@ def create_component(
     termination: Optional[List[str]],
     use_sections: bool,
     attr: str,
-    explain: str,
+    explain: bool,
     on_ents_only: bool,
 ):
     return History(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Describe the changes. -->
This (very simple) PR fixes #116 by correcting the type of `explain` in `History`'s factory.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
