### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.6.2
+pip install edsnlp==0.7.0
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.7.0 (2022-09-06)
 
 ### Added
 
@@ -10,14 +10,16 @@
 - Add attribute `section` to entities
 - Add new cases for separator pattern when components of the TNM score are separated by a forward slash
 - Add NER `eds.adicap` pipeline to identify ADICAP codes
+
+### Changed
 - Update of the `ContextualMatcher` (and all pipelines depending on it), rendering it more flexible to use
+- Rename R component of score TNM as "resection_completeness"
 
 ### Fixed
 
 - Prevent section titles from capturing surrounding tokens, causing overlaps (#113)
 - Enhance existing patterns for section detection and add patterns for previously ignored sections (introduction, evolution, modalites de sortie, vaccination) .
 - Fix explain mode, which was always triggered, in `eds.history` factory.
-- Rename R component of score TNM as "resection_completeness"
 - Fix test in `eds.sections`. Previously, no check was done
 - Remove SOFA scores spurious span suffixes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ color:green Successfully installed!
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.6.2
+pip install edsnlp==0.7.0
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -7,6 +7,6 @@ from pathlib import Path
 from . import extensions
 from .language import *
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
## Description

New version 0.7.0

### Added

- New nested NER trainable `nested_ner` pipeline component
- Support for nested entities and attributes in BratDataConnector
- Pytorch wrappers and experimental training utils
- Add attribute `section` to entities
- Add new cases for separator pattern when components of the TNM score are separated by a forward slash
- Add NER `eds.adicap` pipeline to identify ADICAP codes

### Changed
- Update of the `ContextualMatcher` (and all pipelines depending on it), rendering it more flexible to use
- Rename R component of score TNM as "resection_completeness"

### Fixed

- Prevent section titles from capturing surrounding tokens, causing overlaps (#113)
- Enhance existing patterns for section detection and add patterns for previously ignored sections (introduction, evolution, modalites de sortie, vaccination) .
- Fix explain mode, which was always triggered, in `eds.history` factory.
- Fix test in `eds.sections`. Previously, no check was done
- Remove SOFA scores spurious span suffixes

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
