### PR TITLE
feat: allow Qualifiers to match on spangroups

### DIFF
--- a/edsnlp/pipelines/factories.py
+++ b/edsnlp/pipelines/factories.py
@@ -17,6 +17,7 @@ from .misc.reason.factory import create_component as reason
 from .misc.sections.factory import create_component as sections
 from .ner.adicap.factory import create_component as adicap
 from .ner.cim10.factory import create_component as cim10
+from .ner.comorbidities.diabetes.factory import create_component as diabetes
 from .ner.covid.factory import create_component as covid
 from .ner.drugs.factory import create_component as drugs
 from .ner.scores.charlson.factory import create_component as charlson

--- a/edsnlp/pipelines/factories.py
+++ b/edsnlp/pipelines/factories.py
@@ -17,7 +17,6 @@ from .misc.reason.factory import create_component as reason
 from .misc.sections.factory import create_component as sections
 from .ner.adicap.factory import create_component as adicap
 from .ner.cim10.factory import create_component as cim10
-from .ner.comorbidities.diabetes.factory import create_component as diabetes
 from .ner.covid.factory import create_component as covid
 from .ner.drugs.factory import create_component as drugs
 from .ner.scores.charlson.factory import create_component as charlson

--- a/edsnlp/pipelines/misc/dates/dates.py
+++ b/edsnlp/pipelines/misc/dates/dates.py
@@ -63,7 +63,7 @@ class Dates(BaseComponent):
         relative: Optional[List[str]],
         duration: Optional[List[str]],
         false_positive: Optional[List[str]],
-        on_ents_only: Union[bool, List[str]],
+        on_ents_only: Union[bool, str, List[str]],
         detect_periods: bool,
         as_ents: bool,
         attr: str,

--- a/edsnlp/pipelines/misc/dates/dates.py
+++ b/edsnlp/pipelines/misc/dates/dates.py
@@ -1,7 +1,7 @@
 """`eds.dates` pipeline."""
 
 from itertools import chain
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from loguru import logger
 from spacy.language import Language
@@ -40,7 +40,7 @@ class Dates(BaseComponent):
         (eg `pendant trois mois`).
     false_positive : Union[List[str], str]
         List of regular expressions for false positive (eg phone numbers, etc).
-    on_ents_only : Union[bool, str, List[str]]
+    on_ents_only : Union[bool, str, List[str], Set[str]]
         Wether to look on dates in the whole document or in specific sentences:
 
         - If `True`: Only look in the sentences of each entity in doc.ents
@@ -63,7 +63,7 @@ class Dates(BaseComponent):
         relative: Optional[List[str]],
         duration: Optional[List[str]],
         false_positive: Optional[List[str]],
-        on_ents_only: Union[bool, str, List[str]],
+        on_ents_only: Union[bool, str, List[str], Set[str]],
         detect_periods: bool,
         as_ents: bool,
         attr: str,
@@ -137,18 +137,8 @@ class Dates(BaseComponent):
         """
 
         if self.on_ents_only:
-
-            if type(self.on_ents_only) == bool:
-                ents = doc.ents
-            else:
-                if type(self.on_ents_only) == str:
-                    self.on_ents_only = [self.on_ents_only]
-                ents = []
-                for key in self.on_ents_only:
-                    ents.extend(list(doc.spans[key]))
-
             dates = []
-            for sent in set([ent.sent for ent in ents]):
+            for sent in set([ent.sent for ent in self.get_spans(doc)]):
                 dates = chain(
                     dates,
                     self.regex_matcher(

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 
@@ -29,7 +29,7 @@ def create_component(
     relative: Optional[List[str]],
     duration: Optional[List[str]],
     false_positive: Optional[List[str]],
-    on_ents_only: Union[bool, str, List[str]],
+    on_ents_only: Union[bool, str, List[str], Set[str]],
     detect_periods: bool,
     as_ents: bool,
     attr: str,

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -29,7 +29,7 @@ def create_component(
     relative: Optional[List[str]],
     duration: Optional[List[str]],
     false_positive: Optional[List[str]],
-    on_ents_only: Union[bool, List[str]],
+    on_ents_only: Union[bool, str, List[str]],
     detect_periods: bool,
     as_ents: bool,
     attr: str,

--- a/edsnlp/pipelines/qualifiers/base.py
+++ b/edsnlp/pipelines/qualifiers/base.py
@@ -1,5 +1,4 @@
 from itertools import chain
-from operator import attrgetter
 from typing import Dict, List, Optional, Set, Union
 
 from loguru import logger
@@ -78,9 +77,10 @@ class Qualifier(BaseComponent):
 
         self.on_ents_only = on_ents_only
 
-        assert isinstance(
-            on_ents_only, (list, str, set, bool)
-        ), "The `on_ents_only` argument should be a string, a bool, a list or a set of string"
+        assert isinstance(on_ents_only, (list, str, set, bool)), (
+            "The `on_ents_only` argument should be a "
+            "string, a bool, a list or a set of string"
+        )
 
         if isinstance(on_ents_only, list):
             on_ents_only = set(on_ents_only)
@@ -108,18 +108,6 @@ class Qualifier(BaseComponent):
         terms.update(kwargs)
 
         return terms
-
-    def get_spans(self, doc: Doc):
-        """
-        Returns spans of interest depending on the `on_ents_only` value
-        """
-        ents = list(doc.ents) + list(doc.spans.get("discarded", []))
-
-        if isinstance(self.on_ents_only, set):
-            for spankey in self.on_ents_only & set(doc.spans.keys()):
-                ents.extend(doc.spans.get(spankey, []))
-
-        return sorted(list(set(ents)), key=(attrgetter("start", "end")))
 
     def get_matches(self, doc: Doc) -> List[Span]:
         """

--- a/edsnlp/pipelines/qualifiers/family/factory.py
+++ b/edsnlp/pipelines/qualifiers/family/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 
@@ -33,7 +33,7 @@ def create_component(
     termination: Optional[List[str]],
     attr: str,
     explain: bool,
-    on_ents_only: bool,
+    on_ents_only: Union[bool, str, List[str], Set[str]],
     use_sections: bool,
 ):
     return FamilyContext(

--- a/edsnlp/pipelines/qualifiers/family/family.py
+++ b/edsnlp/pipelines/qualifiers/family/family.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from loguru import logger
 from spacy.language import Language
@@ -30,9 +30,13 @@ class FamilyContext(Qualifier):
         spaCy's attribute to use:
         a string with the value "TEXT" or "NORM", or a dict with the key 'term_attr'
         we can also add a key for each regex.
-    on_ents_only : bool
+    on_ents_only : Union[bool, str, List[str], Set[str]]
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
+
+        - If True, will look in all ents located in `doc.ents` only
+        - If an iterable of string is passed, will additionally look in `doc.spans[key]`
+        for each key in the iterable
     regex : Optional[Dict[str, Union[List[str], str]]]
         A dictionnary of regex patterns.
     explain : bool
@@ -54,7 +58,7 @@ class FamilyContext(Qualifier):
         termination: Optional[List[str]],
         use_sections: bool,
         explain: bool,
-        on_ents_only: bool,
+        on_ents_only: Union[bool, str, List[str], Set[str]],
     ):
 
         terms = self.get_defaults(
@@ -128,7 +132,7 @@ class FamilyContext(Qualifier):
         # Removes duplicate matches and pseudo-expressions in one statement
         matches = filter_spans(matches, label_to_remove="pseudo")
 
-        entities = list(doc.ents) + list(doc.spans.get("discarded", []))
+        entities = list(self.get_spans(doc))
         ents = None
 
         sections = []

--- a/edsnlp/pipelines/qualifiers/history/factory.py
+++ b/edsnlp/pipelines/qualifiers/history/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 
@@ -47,7 +47,7 @@ def create_component(
     use_sections: bool,
     attr: str,
     explain: bool,
-    on_ents_only: bool,
+    on_ents_only: Union[bool, str, List[str], Set[str]],
 ):
     return History(
         nlp,

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from loguru import logger
 from spacy.language import Language
@@ -33,9 +33,13 @@ class History(Qualifier):
         spaCy's attribute to use:
         a string with the value "TEXT" or "NORM", or a dict with the key 'term_attr'
         we can also add a key for each regex.
-    on_ents_only : bool
+    on_ents_only : Union[bool, str, List[str], Set[str]]
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
+
+        - If True, will look in all ents located in `doc.ents` only
+        - If an iterable of string is passed, will additionally look in `doc.spans[key]`
+        for each key in the iterable
     regex : Optional[Dict[str, Union[List[str], str]]]
         A dictionnary of regex patterns.
     explain : bool
@@ -55,7 +59,7 @@ class History(Qualifier):
         termination: Optional[List[str]],
         use_sections: bool,
         explain: bool,
-        on_ents_only: bool,
+        on_ents_only: Union[bool, str, List[str], Set[str]],
     ):
 
         terms = self.get_defaults(
@@ -190,7 +194,7 @@ class History(Qualifier):
         # Removes duplicate matches and pseudo-expressions in one statement
         matches = filter_spans(matches, label_to_remove="pseudo")
 
-        entities = list(doc.ents) + list(doc.spans.get("discarded", []))
+        entities = self.get_spans(doc)
         ents = None
 
         sections = []

--- a/edsnlp/pipelines/qualifiers/hypothesis/factory.py
+++ b/edsnlp/pipelines/qualifiers/hypothesis/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 
@@ -40,7 +40,7 @@ def create_component(
     termination: Optional[List[str]],
     verbs_eds: Optional[List[str]],
     verbs_hyp: Optional[List[str]],
-    on_ents_only: bool,
+    on_ents_only: Union[bool, str, List[str], Set[str]],
     within_ents: bool,
     explain: bool,
 ):

--- a/edsnlp/pipelines/qualifiers/hypothesis/hypothesis.py
+++ b/edsnlp/pipelines/qualifiers/hypothesis/hypothesis.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 from spacy.tokens import Doc, Span, Token
@@ -45,9 +45,13 @@ class Hypothesis(Qualifier):
         spaCy's attribute to use:
         a string with the value "TEXT" or "NORM", or a dict with the key 'term_attr'
         we can also add a key for each regex.
-    on_ents_only : bool
+    on_ents_only : Union[bool, str, List[str], Set[str]]
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
+
+        - If True, will look in all ents located in `doc.ents` only
+        - If an iterable of string is passed, will additionally look in `doc.spans[key]`
+        for each key in the iterable
     within_ents : bool
         Whether to consider cues within entities.
     explain : bool
@@ -75,7 +79,7 @@ class Hypothesis(Qualifier):
         termination: Optional[List[str]],
         verbs_eds: Optional[List[str]],
         verbs_hyp: Optional[List[str]],
-        on_ents_only: bool,
+        on_ents_only: Union[bool, str, List[str], Set[str]],
         within_ents: bool,
         explain: bool,
     ):

--- a/edsnlp/pipelines/qualifiers/negation/factory.py
+++ b/edsnlp/pipelines/qualifiers/negation/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 
@@ -38,7 +38,7 @@ def create_component(
     following: Optional[List[str]],
     termination: Optional[List[str]],
     verbs: Optional[List[str]],
-    on_ents_only: bool,
+    on_ents_only: Union[bool, str, List[str], Set[str]],
     within_ents: bool,
     explain: bool,
 ):

--- a/edsnlp/pipelines/qualifiers/negation/negation.py
+++ b/edsnlp/pipelines/qualifiers/negation/negation.py
@@ -47,9 +47,13 @@ class Negation(Qualifier):
         List of termination terms.
     verbs : Optional[List[str]]
         List of negation verbs.
-    on_ents_only : bool
+    on_ents_only : Union[bool, str, List[str], Set[str]]
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
+
+        - If True, will look in all ents located in `doc.ents` only
+        - If an iterable of string is passed, will additionally look in `doc.spans[key]`
+        for each key in the iterable
     within_ents : bool
         Whether to consider cues within entities.
     explain : bool
@@ -226,7 +230,8 @@ class Negation(Qualifier):
         terminations = get_spans(matches, "termination")
         boundaries = self._boundaries(doc, terminations)
 
-        entities = list(doc.ents) + list(doc.spans.get("discarded", []))
+        entities = list(self.get_spans(doc))
+
         ents = None
 
         # Removes duplicate matches and pseudo-expressions in one statement

--- a/edsnlp/pipelines/qualifiers/negation/negation.py
+++ b/edsnlp/pipelines/qualifiers/negation/negation.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 from spacy.tokens import Doc, Span, Token
@@ -77,7 +77,7 @@ class Negation(Qualifier):
         following: Optional[List[str]],
         termination: Optional[List[str]],
         verbs: Optional[List[str]],
-        on_ents_only: bool,
+        on_ents_only: Union[bool, str, List[str], Set[str]],
         within_ents: bool,
         explain: bool,
     ):
@@ -230,12 +230,11 @@ class Negation(Qualifier):
         terminations = get_spans(matches, "termination")
         boundaries = self._boundaries(doc, terminations)
 
-        entities = list(self.get_spans(doc))
-
-        ents = None
-
         # Removes duplicate matches and pseudo-expressions in one statement
         matches = filter_spans(matches, label_to_remove="pseudo")
+
+        entities = list(self.get_spans(doc))
+        ents = None
 
         for start, end in boundaries:
 

--- a/edsnlp/pipelines/qualifiers/reported_speech/factory.py
+++ b/edsnlp/pipelines/qualifiers/reported_speech/factory.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 
@@ -44,7 +44,7 @@ def create_component(
     following: Optional[List[str]],
     quotation: Optional[List[str]],
     verbs: Optional[List[str]],
-    on_ents_only: bool,
+    on_ents_only: Union[bool, str, List[str], Set[str]],
     within_ents: bool,
     explain: bool,
 ):

--- a/edsnlp/pipelines/qualifiers/reported_speech/reported_speech.py
+++ b/edsnlp/pipelines/qualifiers/reported_speech/reported_speech.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Set, Union
 
 from spacy.language import Language
 from spacy.tokens import Doc, Span, Token
@@ -38,9 +38,13 @@ class ReportedSpeech(Qualifier):
         a string with the value "TEXT" or "NORM",
         or a dict with the key 'term_attr'
         we can also add a key for each regex.
-    on_ents_only : bool
+    on_ents_only : Union[bool, str, List[str], Set[str]]
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
+
+        - If True, will look in all ents located in `doc.ents` only
+        - If an iterable of string is passed, will additionally look in `doc.spans[key]`
+        for each key in the iterable
     within_ents : bool
         Whether to consider cues within entities.
     explain : bool
@@ -63,7 +67,7 @@ class ReportedSpeech(Qualifier):
         following: Optional[List[str]],
         quotation: Optional[List[str]],
         verbs: Optional[List[str]],
-        on_ents_only: bool,
+        on_ents_only: Union[bool, str, List[str], Set[str]],
         within_ents: bool,
         explain: bool,
     ):
@@ -170,7 +174,7 @@ class ReportedSpeech(Qualifier):
 
         boundaries = self._boundaries(doc)
 
-        entities = list(doc.ents) + list(doc.spans.get("discarded", []))
+        entities = self.get_spans(doc)
         ents = None
 
         # Removes duplicate matches and pseudo-expressions in one statement

--- a/edsnlp/processing/distributed.py
+++ b/edsnlp/processing/distributed.py
@@ -10,13 +10,13 @@ from spacy import Language
 from spacy.tokens import Doc
 
 from edsnlp.pipelines.base import BaseComponent
+from edsnlp.utils.extensions import rgetattr
 
 from .helpers import (
     DataFrameModules,
     DataFrames,
     check_spacy_version_for_context,
     get_module,
-    rgetattr,
     slugify,
 )
 

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -6,7 +6,9 @@ from spacy import Language
 from spacy.tokens import Doc, Span
 from tqdm import tqdm
 
-from .helpers import check_spacy_version_for_context, rgetattr, slugify
+from edsnlp.utils.extensions import rgetattr
+
+from .helpers import check_spacy_version_for_context, slugify
 
 nlp = spacy.blank("eds")
 

--- a/edsnlp/utils/extensions.py
+++ b/edsnlp/utils/extensions.py
@@ -1,0 +1,21 @@
+from typing import Any, List
+
+import functools
+
+
+def rgetattr(obj: Any, attr: str, *args: List[Any]) -> Any:
+    """
+    Get attribute recursively
+
+    Parameters
+    ----------
+    obj : Any
+        An object
+    attr : str
+        The name of the attribute to get. Can contain dots.
+    """
+
+    def _getattr(obj, attr):
+        return None if obj is None else getattr(obj, attr, *args)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))

--- a/edsnlp/utils/extensions.py
+++ b/edsnlp/utils/extensions.py
@@ -1,6 +1,5 @@
-from typing import Any, List
-
 import functools
+from typing import Any, List
 
 
 def rgetattr(obj: Any, attr: str, *args: List[Any]) -> Any:

--- a/tests/pipelines/core/test_contextual_matcher.py
+++ b/tests/pipelines/core/test_contextual_matcher.py
@@ -1,7 +1,7 @@
 import pytest
 
-from edsnlp.processing.helpers import rgetattr
 from edsnlp.utils.examples import parse_example
+from edsnlp.utils.extensions import rgetattr
 
 EXAMPLES = [
     """


### PR DESCRIPTION
## Description

Proposition for allowing `Qualifiers` to look for matches in sentences present in `doc.spans[key]`.
It would extend the current `on_ents_only` argument by adding another `on_spangroups` argument

Another way of doing this could be to be more general with, e.g. a `on` parameter that could be set to tell the Qualifiers to match on
- everything
- all entities
- entities present in spangroups
- entities present in a subset of spangoups

However, this approach would induce many API breaking changes, so maybe the first approach is preferable

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
