### PR TITLE
fix: param sampling AdicapCode

### DIFF
--- a/edsnlp/pipelines/ner/adicap/models.py
+++ b/edsnlp/pipelines/ner/adicap/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 class AdicapCode(BaseModel):
     code: str
-    sampling: Optional[str]
+    sampling_code: Optional[str]
     technic: Optional[str]
     organ: Optional[str]
     non_tumoral_pathology: Optional[str]


### PR DESCRIPTION
Change the parameter name sampling into sampling_code in the AdicapCode model
## Description

The decode function of the Adicap class calls the model AdicapCode while using a wrong argument (sampling_mode, instead of sampling).
This fix proposes to change sampling by sampling_mode in the AdicapCode, as intented in its later uses and in the documentation.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
