### PR TITLE
add: new patterns to pollution

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 - Add patterns to `pollution` pipeline and simplifies activating or deactivating specific patterns
 
 ### Changed
+- Simplified the configuration scheme of the `pollution` pipeline
 - Update of the `ContextualMatcher` (and all pipelines depending on it), rendering it more flexible to use
 - Rename R component of score TNM as "resection_completeness"
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - Add attribute `section` to entities
 - Add new cases for separator pattern when components of the TNM score are separated by a forward slash
 - Add NER `eds.adicap` pipeline to identify ADICAP codes
+- Add pattenrs to `pollution` pipeline and simplifies activate/deactivate of specific patterns
 
 ### Changed
 - Update of the `ContextualMatcher` (and all pipelines depending on it), rendering it more flexible to use

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 - Add attribute `section` to entities
 - Add new cases for separator pattern when components of the TNM score are separated by a forward slash
 - Add NER `eds.adicap` pipeline to identify ADICAP codes
-- Add patterns to `pollution` pipeline and simplifies activate/deactivate of specific patterns
+- Add patterns to `pollution` pipeline and simplifies activating or deactivating specific patterns
 
 ### Changed
 - Update of the `ContextualMatcher` (and all pipelines depending on it), rendering it more flexible to use

--- a/docs/pipelines/core/normalisation.md
+++ b/docs/pipelines/core/normalisation.md
@@ -193,9 +193,9 @@ The two are independent: a matcher can use the `NORM` attribute but keep exclude
 
 #### Types of pollution
 
-Pollution can come in various forms  in clinical texts. We provide a small set of possible pollution, from which you can pick whichever you want to activate.
+Pollution can come in various forms in clinical texts. We provide a small set of possible pollutions patterns that can be enabled or disabled as needed.
 
-For instance, if you want to consider biology tables as pollution, you can instantiate the `normalizer` pipeline as follows:
+For instance, if we consider biology tables as pollution, we only need to instantiate the `normalizer` pipe as follows:
 
 ```python
 nlp = spacy.blank("fr")

--- a/docs/pipelines/core/normalisation.md
+++ b/docs/pipelines/core/normalisation.md
@@ -191,6 +191,33 @@ The two are independent: a matcher can use the `NORM` attribute but keep exclude
 
 ![Pollution alignment](./resources/alignment.svg)
 
+#### Types of pollution
+
+Pollution can come in various forms  in clinical texts. We provide a small set of possible pollution, from which you can pick whichever you want to activate.
+
+For instance, if you want to consider biology tables as pollution, you can instantiate the `normalizer` pipeline as follows:
+
+```python
+nlp.add_pipe(
+    "eds.normalizer",
+    config=dict(
+        pollution=dict(
+            biology=True,
+        ),
+    ),
+)
+```
+
+| Type          | Description                                                                                                               | Example                                                                                                    | Included by default |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------- |
+| `information` | Footnote present in a lot of notes, providing information to the patient about the use of its data                        | "L'AP-HP collecte vos données administratives à des fins ..."                                              | `True`              |
+| `bars`        | Barcodes wrongly parsed as text                                                                                           | "...NBNbWbWbNbWbNBNbNbWbW..."                                                                              | `True`              |
+| `biology`     | Parsed biology results table. It often contains disease names that often leads to *false positives* with NER pipelines.   | "...¦UI/L ¦20 ¦ ¦ ¦20-70 Polyarthrite rhumatoïde Facteur rhumatoide ¦UI/mL ¦ ¦<10 ¦ ¦ ¦ ¦0-14..."          | `False`             |
+| `doctors`     | List of doctor names and specialities, often found in left-side note margins. Also source of potential *false positives*. | "... Dr ABC - Diabète/Endocrino ..."                                                                       | `True`              |
+| `web`         | Webpages URL and email adresses. Also source of potential *false positives*.                                              | "... www.vascularites.fr ..."                                                                              | `True`              |
+| `coding`      | Subsection containing ICD-10 codes along with their description. Also source of potential *false positives*.              | "... (2) E112 + Oeil (2) E113 + Neuro (2) E114 Démence (2) F03 MA (2) F001+G301 DCL G22+G301 Vasc (2) ..." | `False`             |
+
+
 ## Authors and citation
 
 The `eds.normalizer` pipeline was developed by AP-HP's Data Science team.

--- a/docs/pipelines/core/normalisation.md
+++ b/docs/pipelines/core/normalisation.md
@@ -198,6 +198,7 @@ Pollution can come in various forms  in clinical texts. We provide a small set o
 For instance, if you want to consider biology tables as pollution, you can instantiate the `normalizer` pipeline as follows:
 
 ```python
+nlp = spacy.blank("fr")
 nlp.add_pipe(
     "eds.normalizer",
     config=dict(
@@ -223,6 +224,7 @@ If you want to exclude specific patterns, you can provide them as a RegEx (or a 
 For instance, to consider text between "AAA" and "ZZZ" as pollution you might use:
 
 ```python
+nlp = spacy.blank("fr")
 nlp.add_pipe(
     "eds.normalizer",
     config=dict(

--- a/docs/pipelines/core/normalisation.md
+++ b/docs/pipelines/core/normalisation.md
@@ -217,6 +217,21 @@ nlp.add_pipe(
 | `web`         | Webpages URL and email adresses. Also source of potential *false positives*.                                              | "... www.vascularites.fr ..."                                                                              | `True`              |
 | `coding`      | Subsection containing ICD-10 codes along with their description. Also source of potential *false positives*.              | "... (2) E112 + Oeil (2) E113 + Neuro (2) E114 Démence (2) F03 MA (2) F001+G301 DCL G22+G301 Vasc (2) ..." | `False`             |
 
+#### Custom pollution
+
+If you want to exclude specific patterns, you can provide them as a RegEx (or a list of Regexes).
+For instance, to consider text between "AAA" and "ZZZ" as pollution you might use:
+
+```python
+nlp.add_pipe(
+    "eds.normalizer",
+    config=dict(
+        pollution=dict(
+            custom_pollution=r"AAA.*ZZZ",
+        ),
+    ),
+)
+```
 
 ## Authors and citation
 

--- a/edsnlp/pipelines/core/normalizer/factory.py
+++ b/edsnlp/pipelines/core/normalizer/factory.py
@@ -49,11 +49,11 @@ def create_component(
         quotes = registry.get("factories", "eds.quotes")(nlp, "eds.quotes", **config)
 
     if pollution:
-        config = dict(**pollution_config)
+        config = dict(**pollution_config["pollution"])
         if isinstance(pollution, dict):
             config.update(pollution)
         pollution = registry.get("factories", "eds.pollution")(
-            nlp, "eds.pollution", **config
+            nlp, "eds.pollution", pollution=config
         )
 
     normalizer = Normalizer(

--- a/edsnlp/pipelines/core/normalizer/pollution/factory.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 from spacy.language import Language
 
@@ -25,7 +25,7 @@ DEFAULT_CONFIG = dict(
 def create_component(
     nlp: Language,
     name: str,
-    pollution: Optional[Dict[str, bool]],
+    pollution: Optional[Dict[str, Union[bool, str, List[str]]]],
 ):
     return Pollution(
         nlp,

--- a/edsnlp/pipelines/core/normalizer/pollution/factory.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, Optional
 
 from spacy.language import Language
 
@@ -7,7 +7,14 @@ from edsnlp.utils.deprecation import deprecated_factory
 from . import Pollution
 
 DEFAULT_CONFIG = dict(
-    pollution=None,
+    pollution=dict(
+        information=True,
+        bars=True,
+        biology=False,
+        doctors=True,
+        web=True,
+        coding=False,
+    ),
 )
 
 
@@ -18,7 +25,7 @@ DEFAULT_CONFIG = dict(
 def create_component(
     nlp: Language,
     name: str,
-    pollution: Optional[Dict[str, Union[str, List[str]]]],
+    pollution: Optional[Dict[str, bool]],
 ):
     return Pollution(
         nlp,

--- a/edsnlp/pipelines/core/normalizer/pollution/patterns.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/patterns.py
@@ -11,7 +11,23 @@ information = (
 # Example : NBNbWbWbNbWbNBNbNbWbWbNBNbWbNbNbWbNBNbW...
 bars = r"(?i)([nbw]|_|-|=){5,}"
 
+# Biology tables: Prone to false positive with disease names
+biology = r"(\b.*[|¦].*\n)+"
+
+# Leftside note with doctor names
+doctors = r"(?mi)(^((dr)|(pr)).*)+"
+
+# Mails or websites
+web = r"(www\.\S*)|(\S*@\S*)"
+
+# Subsection with ICD-10 Codes
+coding = r".*?[a-zA-Z]\d{2,4}.*?(\n|[a-zA-Z]\d{2,4})"
+
 pollution = dict(
     information=information,
     bars=bars,
+    biology=biology,
+    doctors=doctors,
+    web=web,
+    coding=coding,
 )

--- a/edsnlp/pipelines/core/normalizer/pollution/pollution.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/pollution.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from spacy.language import Language
 from spacy.tokens import Doc, Span
@@ -34,20 +34,20 @@ class Pollution(BaseComponent):
     def __init__(
         self,
         nlp: Language,
-        pollution: Optional[Dict[str, Union[str, List[str]]]],
+        pollution: Optional[Dict[str, bool]],
     ):
 
         self.nlp = nlp
         self.nlp.vocab.strings.add("EXCLUDED")
 
         if pollution is None:
-            pollution = patterns.pollution
+            pollution = {k: True for k in patterns.pollution.keys()}
 
-        self.pollution = pollution
-
-        for k, v in self.pollution.items():
-            if isinstance(v, str):
-                self.pollution[k] = [v]
+        self.pollution = {
+            k: [patterns.pollution[k]]
+            for k, to_include in pollution.items()
+            if to_include
+        }
 
         self.regex_matcher = RegexMatcher()
         self.build_patterns()

--- a/edsnlp/pipelines/core/normalizer/pollution/pollution.py
+++ b/edsnlp/pipelines/core/normalizer/pollution/pollution.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from spacy.language import Language
 from spacy.tokens import Doc, Span
@@ -34,7 +34,7 @@ class Pollution(BaseComponent):
     def __init__(
         self,
         nlp: Language,
-        pollution: Optional[Dict[str, bool]],
+        pollution: Optional[Dict[str, Union[bool, str, List[str]]]],
     ):
 
         self.nlp = nlp
@@ -42,13 +42,17 @@ class Pollution(BaseComponent):
 
         if pollution is None:
             pollution = {k: True for k in patterns.pollution.keys()}
+        self.pollution = dict()
 
-        self.pollution = {
-            k: [patterns.pollution[k]]
-            for k, to_include in pollution.items()
-            if to_include
-        }
+        for k, v in pollution.items():
+            if v is True:
+                self.pollution[k] = [patterns.pollution[k]]
+            elif isinstance(v, str):
+                self.pollution[k] = [v]
+            elif isinstance(v, list):
+                self.pollution[k] = v
 
+        print(self.pollution)
         self.regex_matcher = RegexMatcher()
         self.build_patterns()
 


### PR DESCRIPTION
## Description

Provide additional pollution patterns, namely:

- webpage URLs and emails
- doctor list (coming from leftside margin note)
- biology table
- coding sections

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
