### PR TITLE
EDSTokenizer: split on non-breaking spaces and don't split float numbers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Add nephew, niece and daughter to family qualifier patterns
+- EDSTokenizer (`spacy.blank('eds')`) now recognizes non-breaking whitespaces as spaces and does not split float numbers
 
 ## v0.7.0 (2022-09-06)
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -8,10 +8,9 @@ the `fr` tokenizer. The main differences lie in the tokenization process.
 A comparison of the two tokenization methods is demonstrated below:
 
 | Example               | FrenchLanguage             | EDSLanguage                |
-| --------------------- | -------------------------- | -------------------------- |
+| --------------------- | -------------------------- |----------------------------|
 | `ACR 5`               | [`ACR5`]                   | [`ACR`, `5`]               |
-| `26.5`                | [`26.5`]                   | [`26`, `.`, `5`]           |
-| `26.5/`               | [`26.5/`]                  | [`26`, `.`, `5`, `/`]      |
+| `26.5/`               | [`26.5/`]                  | [`26.5`, `/`]              |
 | `\n \n CONCLUSION`    | [`\n \n`, `CONCLUSION]`    | [`\n`, `\n`, `CONCLUSION`] |
 | `l'artère`            | [`l'`, `artère`]           | [`l'`, `artère`] (same)    |
 

--- a/edsnlp/language.py
+++ b/edsnlp/language.py
@@ -58,10 +58,10 @@ class EDSTokenizer(DummyTokenizer):
         """
         self.vocab = vocab
         punct = "[:punct:]" + "\"'ˊ＂〃ײ᳓″״‶˶ʺ“”˝"
-        num_like = r"[\d]+"
-        default = rf"[^\d{punct}'\n ]+(?:['ˊ](?=[[:alpha:]]))?"
+        num_like = r"\d+(?:[.,]\d+)?"
+        default = rf"[^\d{punct}'\n[[:space:]]+(?:['ˊ](?=[[:alpha:]]))?"
         self.word_regex = regex.compile(
-            rf"({num_like}|[{punct}]|\n|[ ]+|{default})([ ])?"
+            rf"({num_like}|[{punct}]|[\n\r\t]|[^\S\r\n\t]+|{default})([^\S\r\n\t])?"
         )
 
     def __call__(self, text: str) -> Doc:

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -41,3 +41,29 @@ On se donne rendez-vous pour le 23/11/1967.
 def test_eds_lex_attrs_capitals(word):
     assert like_num(word)
     assert like_num(word.upper())
+
+
+def test_eds_tokenizer_whitespace():
+    nlp = spacy.blank("eds")
+    tokenized = [(w.text, w.whitespace_) for w in nlp("Lorem\xA0Ipsum\tDolor Sit Amet")]
+    assert tokenized == [
+        ("Lorem", " "),
+        ("Ipsum", ""),
+        ("\t", ""),
+        ("Dolor", " "),
+        ("Sit", " "),
+        ("Amet", ""),
+    ]
+
+
+def test_eds_tokenizer_numbers():
+    nlp = spacy.blank("eds")
+    tokenized = [(w.text, w.whitespace_) for w in nlp("Il fait 5.3/5.4mm")]
+    assert tokenized == [
+        ("Il", " "),
+        ("fait", " "),
+        ("5.3", ""),
+        ("/", ""),
+        ("5.4", ""),
+        ("mm", ""),
+    ]


### PR DESCRIPTION
## Description

Fix to handle non breaking whitespaces and tabs as mentioned in #140, and stop splitting floating point numbers.

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
