### PR TITLE
Allow newlines in dates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Add nephew, niece and daughter to family qualifier patterns
 - EDSTokenizer (`spacy.blank('eds')`) now recognizes non-breaking whitespaces as spaces and does not split float numbers
+- `eds.dates` pipeline now allows new lines as space separators in dates
 
 ## v0.7.0 (2022-09-06)
 

--- a/edsnlp/pipelines/misc/dates/patterns/atomic/delimiters.py
+++ b/edsnlp/pipelines/misc/dates/patterns/atomic/delimiters.py
@@ -1,10 +1,10 @@
 from edsnlp.utils.regex import make_pattern
 
 raw_delimiters = [r"\/", r"\-"]
-delimiters = raw_delimiters + [r"\.", r"[^\S\r\n]+"]
+delimiters = raw_delimiters + [r"\.", r"[^\S]+"]
 
 raw_delimiter_pattern = make_pattern(raw_delimiters)
-raw_delimiter_with_spaces_pattern = make_pattern(raw_delimiters + [r"[^\S\r\n]+"])
+raw_delimiter_with_spaces_pattern = make_pattern(raw_delimiters + [r"[^\S]+"])
 delimiter_pattern = make_pattern(delimiters)
 
 ante_num_pattern = f"(?<!.(?:{raw_delimiter_pattern})|[0-9][.,])"

--- a/edsnlp/utils/examples.py
+++ b/edsnlp/utils/examples.py
@@ -33,11 +33,12 @@ class Entity(BaseModel):
     modifiers: List[Modifier]
 
 
-entity_pattern = re.compile(r"(<ent[^<>]*>[^<>]+</ent>)")
-text_pattern = re.compile(r"<ent.*>(.+)</ent>")
-modifiers_pattern = re.compile((r"<ent\s?(.*)>.+</ent>"))
+entity_pattern = re.compile(r"(<ent[^<>]*>[^<>]+</ent>)", flags=re.DOTALL)
+text_pattern = re.compile(r"<ent.*>(.+)</ent>", flags=re.DOTALL)
+modifiers_pattern = re.compile(r"<ent\s?(.*)>.+</ent>", flags=re.DOTALL)
 single_modifiers_pattern = regex.compile(
-    (r"(?P<key>[^\s]+?)=((?P<value>{.*?})|(?P<value>[^\s']+)|'(?P<value>.+?)')")
+    r"(?P<key>[^\s]+?)=((?P<value>{.*?})|(?P<value>[^\s']+)|'(?P<value>.+?)')",
+    flags=regex.DOTALL,
 )
 
 

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -66,6 +66,7 @@ examples = [
     "Il est venu en <ent norm='????-08-??' month=8>août</ent>.",
     "Il est venu <ent norm='~0 day' day=0 direction=CURRENT>ce jour</ent>.",
     "CS le <ent norm='2017-01-11' day=11 month=1 year=2017>11-01-2017</ent> 1/3",
+    "Vu le <ent norm='2017-01-11' day=11 month=1 year=2017>11 janvier\n2017</ent> .",
 ]
 
 


### PR DESCRIPTION
## Description

This pull request now allows the `eds.dates` component to detect dates with line breaks between words.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
