### PR TITLE
Bump version to 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.7.0
+pip install edsnlp==0.7.1
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## Unreleased
+## v0.7.1 (2022-10-13)
+
+### Added
+- Add new pattern (footer) to pipeline normalisation (pollution)
 
 ### Fixed
 
 - Add nephew, niece and daughter to family qualifier patterns
 - EDSTokenizer (`spacy.blank('eds')`) now recognizes non-breaking whitespaces as spaces and does not split float numbers
 - `eds.dates` pipeline now allows new lines as space separators in dates
-
-### Added
-- Add new pattern (footer) to pipeline normalisation (pollution)
 
 ## v0.7.0 (2022-09-06)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ color:green Successfully installed!
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.7.0
+pip install edsnlp==0.7.1
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -7,6 +7,6 @@ from pathlib import Path
 from . import extensions
 from .language import *
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
## Changelog

### Added
- Add new pattern (footer) to pipeline normalisation (pollution)

### Fixed

- Add nephew, niece and daughter to family qualifier patterns
- EDSTokenizer (`spacy.blank('eds')`) now recognizes non-breaking whitespaces as spaces and does not split float numbers
- `eds.dates` pipeline now allows new lines as space separators in dates

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
