### PR TITLE
feat: :sparkles: Improve `eds.history` component with `eds.dates`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## Pending...
+## Unreleased
+
 ### Added
 - Improve the `eds.history` component by taking into account the date extracted from `eds.dates` component.
 - New pop up when you click on the copy icon in the termynal.
+
 ### Fixed
 
 - Remove the warning in the ``eds.sections`` when ``eds.normalizer`` is in the pipe.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Pending...
+### Added
+- Improve the `eds.history` component by taking into account the date extracted from `eds.dates` component.
+- New pop up when you click on the copy icon in the termynal.
+### Fixed
+
+- Remove the warning in the ``eds.sections`` when ``eds.noramalizer`` is in the pipe.
+
 ## v0.7.1 (2022-10-13)
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 - New pop up when you click on the copy icon in the termynal.
 ### Fixed
 
-- Remove the warning in the ``eds.sections`` when ``eds.noramalizer`` is in the pipe.
+- Remove the warning in the ``eds.sections`` when ``eds.normalizer`` is in the pipe.
 
 ## v0.7.1 (2022-10-13)
 

--- a/docs/assets/termynal/termynal.css
+++ b/docs/assets/termynal/termynal.css
@@ -8,14 +8,14 @@
  * Modified version from https://github.com/tiangolo/typer
  */
 
- :root {
+:root {
     --color-bg: #252a33;
     --color-text: #eee;
     --color-text-subtle: #a2a2a2;
 }
 
 [data-termynal] {
-    width: 750px;
+    width: auto;
     max-width: 100%;
     background: var(--color-bg);
     color: var(--color-text);
@@ -26,7 +26,7 @@
     padding: 75px 45px 35px;
     position: relative;
     -webkit-box-sizing: border-box;
-            box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 [data-termynal]:before {
@@ -41,7 +41,7 @@
     /* A little hack to display the window buttons in one pseudo element. */
     background: #d9515d;
     -webkit-box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
-            box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
+    box-shadow: 25px 0 0 #f4c025, 50px 0 0 #3ec930;
 }
 
 [data-termynal]:after {
@@ -63,17 +63,13 @@ a[data-terminal-control] {
 [data-terminal-copy] {
     text-align: right;
     position: absolute;
-    top:5px;
-    right:5px;
+    top: 5px;
+    right: 5px;
 }
 
-[data-terminal-copy].md-clipboard {
+[data-terminal-copy].md-icon {
     color: #aebbff;
 }
-
-:hover>[data-terminal-copy].md-clipboard {
-    color: #006bb6
-   }
 
 [data-ty] {
     display: block;
@@ -106,7 +102,7 @@ a[data-terminal-control] {
     font-family: monospace;
     margin-left: 0.5em;
     -webkit-animation: blink 1s infinite;
-            animation: blink 1s infinite;
+    animation: blink 1s infinite;
 }
 
 
@@ -122,4 +118,15 @@ a[data-terminal-control] {
     50% {
         opacity: 0;
     }
+}
+
+/* tooltip */
+
+[data-md-state="open"] {
+    transform: translateY(0);
+    opacity: 1;
+    transition:
+        transform 400ms cubic-bezier(0.075, 0.85, 0.175, 1),
+        opacity 400ms;
+    pointer-events: initial;
 }

--- a/docs/pipelines/qualifiers/history.md
+++ b/docs/pipelines/qualifiers/history.md
@@ -6,9 +6,11 @@ The mere definition of an medical history is not straightforward.
 Hence, this component only tags entities that are _explicitly described as part of the medical history_,
 eg preceded by a synonym of "medical history".
 
-This component may also use the output of the [`eds.sections` pipeline](../misc/sections.md). In that case, the entire `antécédent` section is tagged as a medical history.
+This component may also use the output of:
 
-!!! warning
+- the [`eds.sections` pipeline](../misc/sections.md). In that case, the entire `antécédent` section is tagged as a medical history.
+
+!!! warning "Sections"
 
     Be careful, the `eds.sections` component may oversize the `antécédents` section. Indeed, it detects *section titles*
     and tags the entire text between a title and the next as a section. Hence, should a section title goes undetected after
@@ -16,51 +18,79 @@ This component may also use the output of the [`eds.sections` pipeline](../misc/
 
     To curb that possibility, using the output of the `eds.sections` component is deactivated by default.
 
+- the [`eds.dates` pipeline](../misc/dates.md). In that case, it will take the dates into account to tag extracted entities as a medical history or not.
+
+!!! info "Dates"
+
+    To take the most of the `eds.dates` component, you may add the ``note_datetime`` context (cf. [Adding context][using-eds-nlps-helper-functions]). It allows the pipeline to compute the duration of absolute dates (eg le 28 août 2022/August 28, 2022). The ``birth_datetime`` context allows the pipeline to exclude the birth date from the extracted dates.
+
 ## Usage
 
 The following snippet matches a simple terminology, and checks whether the extracted entities are history or not. It is complete and can be run _as is_.
 
 ```python
 import spacy
+from datetime import timedelta
 
 nlp = spacy.blank("fr")
 nlp.add_pipe("eds.sentences")
-# Dummy matcher
+nlp.add_pipe("eds.normalizer")
+nlp.add_pipe("eds.sections")
+nlp.add_pipe("eds.dates")
 nlp.add_pipe(
     "eds.matcher",
     config=dict(terms=dict(douleur="douleur", malaise="malaises")),
 )
-nlp.add_pipe("eds.history")
+nlp.add_pipe(
+    "eds.history",
+    use_sections=True,
+    use_dates=True,
+    history_limit=timedelta(14),
+)
 
 text = (
     "Le patient est admis le 23 août 2021 pour une douleur au bras. "
     "Il a des antécédents de malaises."
+    "ANTÉCÉDENTS : "
+    "- le patient a déjà eu des malaises."
+    "- le patient a eu une douleur à la jambe il y a 10 jours"
 )
 
 doc = nlp(text)
 
 doc.ents
-# Out: (douleur, malaises)
+# Out: (douleur, malaises, malaises, douleur)
 
 doc.ents[0]._.history
 # Out: False
 
 doc.ents[1]._.history
 # Out: True
+
+doc.ents[2]._.history  # (1)
+# Out: True
+
+doc.ents[3]._.history  # (2)
+# Out: False
 ```
 
+1. The entity is in the section `antécédent`.
+2. The entity is in the section `antécédent`, however the extracted `relative_date` refers to an event that took place within 14 days.
 ## Configuration
 
 The pipeline can be configured using the following parameters :
 
-| Parameter      | Explanation                                                              | Default                           |
-| -------------- | ------------------------------------------------------------------------ | --------------------------------- |
-| `attr`         | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)                 | `"NORM"`                          |
-| `history`      | History patterns                                                         | `None` (use pre-defined patterns) |
-| `termination`  | Termination patterns (for syntagma/proposition extraction)               | `None` (use pre-defined patterns) |
-| `use_sections` | Whether to use pre-annotated sections (requires the `sections` pipeline) | `False`                           |
-| `on_ents_only` | Whether to qualify pre-extracted entities only                           | `True`                            |
-| `explain`      | Whether to keep track of the cues for each entity                        | `False`                           |
+| Parameter           | Explanation                                                                                                | Default                           |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `attr`              | spaCy attribute to match on (eg `NORM`, `TEXT`, `LOWER`)                                                   | `"NORM"`                          |
+| `history`           | History patterns                                                                                           | `None` (use pre-defined patterns) |
+| `termination`       | Termination patterns (for syntagma/proposition extraction)                                                 | `None` (use pre-defined patterns) |
+| `use_sections`      | Whether to use pre-annotated sections (requires the `sections` pipeline)                                   | `False`                           |
+| `use_dates`         | Whether to use dates pipeline (requires the `dates` pipeline and ``note_datetime`` context is recommended) | `False`                           |
+| `history_limit`     | If `use_dates = True`. The time after which the event is considered as history.                            | `timedelta(14)` (2 weeks)         |
+| `exclude_birthdate` | If `use_dates = True`. Whether to exclude the birth date from history dates.                               | `True`                            |
+| `on_ents_only`      | Whether to qualify pre-extracted entities only                                                             | `True`                            |
+| `explain`           | Whether to keep track of the cues for each entity                                                          | `False`                           |
 
 ## Declared extensions
 

--- a/docs/pipelines/qualifiers/history.md
+++ b/docs/pipelines/qualifiers/history.md
@@ -43,16 +43,17 @@ nlp.add_pipe(
 )
 nlp.add_pipe(
     "eds.history",
-    use_sections=True,
-    use_dates=True,
-    history_limit=timedelta(14),
+    config=dict(
+        use_sections=True,
+        use_dates=True,
+    ),
 )
 
 text = (
     "Le patient est admis le 23 août 2021 pour une douleur au bras. "
     "Il a des antécédents de malaises."
     "ANTÉCÉDENTS : "
-    "- le patient a déjà eu des malaises."
+    "- le patient a déjà eu des malaises. "
     "- le patient a eu une douleur à la jambe il y a 10 jours"
 )
 

--- a/edsnlp/extensions.py
+++ b/edsnlp/extensions.py
@@ -5,3 +5,6 @@ if not Doc.has_extension("note_id"):
 
 if not Doc.has_extension("note_datetime"):
     Doc.set_extension("note_datetime", default=None)
+
+if not Doc.has_extension("birth_datetime"):
+    Doc.set_extension("birth_datetime", default=None)

--- a/edsnlp/pipelines/misc/sections/sections.py
+++ b/edsnlp/pipelines/misc/sections/sections.py
@@ -95,7 +95,7 @@ class Sections(GenericMatcher):
 
         self.set_extensions()
 
-        if not nlp.has_pipe("normalizer") and not not nlp.has_pipe("eds.normalizer"):
+        if not nlp.has_pipe("normalizer") and not nlp.has_pipe("eds.normalizer"):
             logger.warning("You should add pipe `eds.normalizer`")
 
     @classmethod

--- a/edsnlp/pipelines/qualifiers/history/factory.py
+++ b/edsnlp/pipelines/qualifiers/history/factory.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import List, Optional
 
 from spacy.language import Language
@@ -11,6 +12,9 @@ DEFAULT_CONFIG = dict(
     history=patterns.history,
     termination=termination,
     use_sections=False,
+    use_dates=False,
+    history_limit=timedelta(14),
+    exclude_birthdate=True,
     explain=False,
     on_ents_only=True,
 )
@@ -45,6 +49,9 @@ def create_component(
     history: Optional[List[str]],
     termination: Optional[List[str]],
     use_sections: bool,
+    use_dates: bool,
+    history_limit: timedelta,
+    exclude_birthdate: bool,
     attr: str,
     explain: bool,
     on_ents_only: bool,
@@ -55,6 +62,9 @@ def create_component(
         history=history,
         termination=termination,
         use_sections=use_sections,
+        use_dates=use_dates,
+        history_limit=history_limit,
+        exclude_birthdate=exclude_birthdate,
         explain=explain,
         on_ents_only=on_ents_only,
     )

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -119,7 +119,7 @@ class History(Qualifier):
             else:
                 logger.info(
                     "You have requested that the pipeline use date "
-                    "To take the most of the feature, "
+                    "To make the most of this feature, "
                     "make sur you provide the `note_datetime` "
                     "context. "
                 )

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -120,7 +120,7 @@ class History(Qualifier):
                 logger.info(
                     "You have requested that the pipeline use date "
                     "To make the most of this feature, "
-                    "make sur you provide the `note_datetime` "
+                    "make sure you provide the `note_datetime` "
                     "context. "
                 )
 

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -112,7 +112,7 @@ class History(Qualifier):
                 logger.info(
                     "You have requested that the pipeline use date "
                     "and exclude birth dates. "
-                    "To take the most of the feature, "
+                    "To make the most of this feature, "
                     "make sur you provide the `birth_datetime` "
                     "context and `note_datetime` context. "
                 )

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -192,10 +192,11 @@ class History(Qualifier):
                 "antecedent_",
                 getter=deprecated_getter_factory("antecedent_", "history_"),
             )
-
+        # Store history mentions responsible for the history entity's character
         if not Span.has_extension("history_cues"):
             Span.set_extension("history_cues", default=[])
 
+        # Store recent mentions responsible for the non-antecedent entity's character
         if not Span.has_extension("recent_cues"):
             Span.set_extension("recent_cues", default=[])
 

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -1,5 +1,7 @@
+from datetime import timedelta
 from typing import List, Optional
 
+import pendulum
 from loguru import logger
 from spacy.language import Language
 from spacy.tokens import Doc, Span, Token
@@ -10,7 +12,7 @@ from edsnlp.utils.deprecation import deprecated_getter_factory
 from edsnlp.utils.filter import consume_spans, filter_spans, get_spans
 from edsnlp.utils.inclusion import check_inclusion
 
-from .patterns import history
+from .patterns import history, sections_history
 
 
 class History(Qualifier):
@@ -29,6 +31,13 @@ class History(Qualifier):
         List of syntagme termination terms.
     use_sections : bool
         Whether to use section pipeline to detect medical history section.
+    use_dates : bool
+        Whether to use dates pipeline to detect if the event occurs
+         a long time before the document date.
+    history_limit : timedelta
+        The time after which the event is considered as history.
+    exclude_birthdate : bool
+        Whether to exclude the birth date from history dates.
     attr : str
         spaCy's attribute to use:
         a string with the value "TEXT" or "NORM", or a dict with the key 'term_attr'
@@ -37,7 +46,7 @@ class History(Qualifier):
         Whether to look for matches around detected entities only.
         Useful for faster inference in downstream tasks.
     regex : Optional[Dict[str, Union[List[str], str]]]
-        A dictionnary of regex patterns.
+        A dictionary of regex patterns.
     explain : bool
         Whether to keep track of cues for each entity.
     """
@@ -54,6 +63,9 @@ class History(Qualifier):
         history: Optional[List[str]],
         termination: Optional[List[str]],
         use_sections: bool,
+        use_dates: bool,
+        history_limit: timedelta,
+        exclude_birthdate: bool,
         explain: bool,
         on_ents_only: bool,
     ):
@@ -73,6 +85,9 @@ class History(Qualifier):
 
         self.set_extensions()
 
+        self.history_limit = history_limit
+        self.exclude_birthdate = exclude_birthdate
+
         self.sections = use_sections and (
             "eds.sections" in nlp.pipe_names or "sections" in nlp.pipe_names
         )
@@ -82,6 +97,32 @@ class History(Qualifier):
                 "provided by the `section` pipeline, but it was not set. "
                 "Skipping that step."
             )
+
+        self.dates = use_dates and (
+            "eds.dates" in nlp.pipe_names or "dates" in nlp.pipe_names
+        )
+        if use_dates:
+            if not self.dates:
+                logger.warning(
+                    "You have requested that the pipeline use dates "
+                    "provided by the `dates` pipeline, but it was not set. "
+                    "Skipping that step."
+                )
+            elif exclude_birthdate:
+                logger.info(
+                    "You have requested that the pipeline use date "
+                    "and exclude birth dates. "
+                    "To take the most of the feature, "
+                    "make sur you provide the `birth_datetime` "
+                    "context and `note_datetime` context. "
+                )
+            else:
+                logger.info(
+                    "You have requested that the pipeline use date "
+                    "To take the most of the feature, "
+                    "make sur you provide the `note_datetime` "
+                    "context. "
+                )
 
     @classmethod
     def set_extensions(cls) -> None:
@@ -155,6 +196,9 @@ class History(Qualifier):
         if not Span.has_extension("history_cues"):
             Span.set_extension("history_cues", default=[])
 
+        if not Span.has_extension("recent_cues"):
+            Span.set_extension("recent_cues", default=[])
+
         if not Span.has_extension("antecedents_cues"):
             Span.set_extension(
                 "antecedents_cues",
@@ -182,6 +226,24 @@ class History(Qualifier):
             spaCy Doc object, annotated for history
         """
 
+        try:
+            note_datetime = pendulum.instance(doc._.note_datetime)
+            note_datetime = note_datetime.set(tz="Europe/Paris")
+        except ValueError:
+            logger.debug(
+                "Note date time must be datetime objects. Skkipping absolut value"
+            )
+            note_datetime = None
+
+        try:
+            birth_datetime = pendulum.instance(doc._.birth_datetime)
+            birth_datetime = birth_datetime.set(tz="Europe/Paris")
+        except ValueError:
+            logger.debug(
+                "Birth date time must be datetime objects. Skkipping exclude birth date"
+            )
+            birth_datetime = None
+
         matches = self.get_matches(doc)
 
         terminations = get_spans(matches, "termination")
@@ -192,15 +254,70 @@ class History(Qualifier):
 
         entities = list(doc.ents) + list(doc.spans.get("discarded", []))
         ents = None
+        sub_sections = None
+        sub_recent_dates = None
 
         sections = []
-
         if self.sections:
             sections = [
                 Span(doc, section.start, section.end, label="ATCD")
                 for section in doc.spans["sections"]
-                if section.label_ == "antécédents"
+                if section.label_ in sections_history
             ]
+
+        history_dates = []
+        recent_dates = []
+        if self.dates:
+            for date in doc.spans["dates"]:
+                if date.label_ == "relative":
+                    if date._.date.direction.value == "CURRENT":
+                        if (
+                            (
+                                date._.date.year == 0
+                                and self.history_limit >= timedelta(365)
+                            )
+                            or (
+                                date._.date.month == 0
+                                and self.history_limit >= timedelta(30)
+                            )
+                            or (
+                                date._.date.week == 0
+                                and self.history_limit >= timedelta(7)
+                            )
+                            or (date._.date.day == 0)
+                        ):
+                            recent_dates.append(
+                                Span(doc, date.start, date.end, label="relative_date")
+                            )
+                    elif date._.date.direction.value == "PAST":
+                        if -date._.date.to_datetime() >= self.history_limit:
+                            history_dates.append(
+                                Span(doc, date.start, date.end, label="relative_date")
+                            )
+                        else:
+                            recent_dates.append(
+                                Span(doc, date.start, date.end, label="relative_date")
+                            )
+                elif date.label_ == "absolute" and doc._.note_datetime:
+                    absolute_date = date._.date.to_datetime(
+                        note_datetime=note_datetime,
+                        infer_from_context=True,
+                        tz="Europe/Paris",
+                        default_day=15,
+                    )
+                    if absolute_date:
+                        if note_datetime.diff(absolute_date) < self.history_limit:
+                            recent_dates.append(
+                                Span(doc, date.start, date.end, label="absolute_date")
+                            )
+                        elif not (
+                            self.exclude_birthdate
+                            and birth_datetime
+                            and absolute_date == birth_datetime
+                        ):
+                            history_dates.append(
+                                Span(doc, date.start, date.end, label="absolute_date")
+                            )
 
         for start, end in boundaries:
             ents, entities = consume_spans(
@@ -213,15 +330,27 @@ class History(Qualifier):
                 matches, lambda s: start <= s.start < end
             )
 
-            sub_sections, sections = consume_spans(sections, lambda s: doc[start] in s)
-
+            sub_sections, sections = consume_spans(
+                sections, lambda s: s.start < end <= s.end, sub_sections
+            )
+            sub_recent_dates, recent_dates = consume_spans(
+                recent_dates,
+                filter=lambda s: check_inclusion(s, start, end),
+            )
+            sub_history_dates, history_dates = consume_spans(
+                history_dates,
+                filter=lambda s: check_inclusion(s, start, end),
+            )
             if self.on_ents_only and not ents:
                 continue
 
-            cues = get_spans(sub_matches, "history")
-            cues += sub_sections
+            history_cues = get_spans(sub_matches, "history")
+            history_cues += sub_sections
+            history_cues += sub_history_dates
 
-            history = bool(cues)
+            recent_cues = sub_recent_dates
+
+            history = bool(history_cues) and not bool(recent_cues)
 
             if not self.on_ents_only:
                 for token in doc[start:end]:
@@ -231,7 +360,8 @@ class History(Qualifier):
                 ent._.history = ent._.history or history
 
                 if self.explain:
-                    ent._.history_cues += cues
+                    ent._.history_cues += history_cues
+                    ent._.recent_cues += recent_cues
 
                 if not self.on_ents_only and ent._.history:
                     for token in ent:

--- a/edsnlp/pipelines/qualifiers/history/patterns.py
+++ b/edsnlp/pipelines/qualifiers/history/patterns.py
@@ -5,3 +5,9 @@ history = [
     "tacds",
     "antécédent",
 ]
+
+sections_history = [
+    "antécédents",
+    "antécédents familiaux",
+    "histoire de la maladie",
+]

--- a/tests/pipelines/misc/test_reason.py
+++ b/tests/pipelines/misc/test_reason.py
@@ -1,20 +1,22 @@
 import spacy
+from pytest import mark
 
 text = """COMPTE RENDU D'HOSPITALISATION du 11/07/2018 au 12/07/2018
 MOTIF D'HOSPITALISATION
-Monsieur Dupont Jean Michel, de sexe masculin, âgée de 39 ans, née le 23/11/1978, a été
-hospitalisé du 11/08/2019 au 17/08/2019 pour attaque d'asthme.
+Monsieur Dupont Jean Michel, de sexe masculin, âgée de 39 ans, née le 23/11/1978,
+a été hospitalisé du 11/08/2019 au 17/08/2019 pour une quinte de toux.
 
 ANTÉCÉDENTS
 Antécédents médicaux :
-Premier épisode d'asthme en mai 2018."""
+Premier épisode: il a été hospitalisé pour asthme en mai 2018."""
 
 
-def test_reason(lang):
+@mark.parametrize("use_sections", [True, False])
+def test_reason(lang, use_sections):
     nlp = spacy.blank(lang)
     # Extraction d'entités nommées
     nlp.add_pipe(
-        "matcher",
+        "eds.matcher",
         config=dict(
             terms=dict(
                 respiratoire=[
@@ -25,15 +27,16 @@ def test_reason(lang):
             )
         ),
     )
-
-    nlp.add_pipe("normalizer")
-    nlp.add_pipe("reason", config=dict(use_sections=True))
+    nlp.add_pipe("eds.normalizer")
+    nlp.add_pipe("eds.reason", config=dict(use_sections=use_sections))
+    nlp.remove_pipe("eds.reason")
+    nlp.add_pipe("eds.sections")
+    nlp.add_pipe("eds.reason", config=dict(use_sections=use_sections))
 
     doc = nlp(text)
-
     reason = doc.spans["reasons"][0]
-
     entities = reason._.ents_reason
 
     assert entities[0].label_ == "respiratoire"
     assert reason._.is_reason
+    assert doc.ents[1]._.is_reason is not use_sections


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

Improve the `eds.history` component by taking into account the date extracted from `eds.dates` component:

- It removes the medical hsitory tag for extracted entity assocaited with a recent date.
- It tags extracted entity assocaited with an old date.

Note: The threshold can be set as a parameter.

<!--- Describe the changes. -->

- Add the `use_dates` configuration to the `eds.history` component.
- Small fix on the ``eds.sections`` component (remove the warning when ``eds.noramalizer`` is in the pipe).
- Improve the test for eds.reason (100% coverage.).
- Improve the termynal extention for mkdocs with a pop up indication when you click on the copy icon.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
