### PR TITLE
Small fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,11 +5,12 @@
 ### Added
 
 - Improve the `eds.history` component by taking into account the date extracted from `eds.dates` component.
-- New pop up when you click on the copy icon in the termynal.
+- New pop up when you click on the copy icon in the termynal widget (docs).
 
 ### Fixed
 
 - Remove the warning in the ``eds.sections`` when ``eds.normalizer`` is in the pipe.
+- Fix filter_spans for strictly nested entities
 
 ## v0.7.1 (2022-10-13)
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 
 - Remove the warning in the ``eds.sections`` when ``eds.normalizer`` is in the pipe.
 - Fix filter_spans for strictly nested entities
+- Fill eds.remove-lowercase "assign" metadata to run the pipeline during EDSPhraseMatcher preprocessing
 
 ## v0.7.1 (2022-10-13)
 

--- a/edsnlp/pipelines/core/normalizer/lowercase/factory.py
+++ b/edsnlp/pipelines/core/normalizer/lowercase/factory.py
@@ -2,8 +2,8 @@ from spacy.language import Language
 from spacy.tokens import Doc
 
 
-@Language.component("remove-lowercase")
-@Language.component("eds.remove-lowercase")
+@Language.component("remove-lowercase", assigns=["token.norm"])
+@Language.component("eds.remove-lowercase", assigns=["token.norm"])
 def remove_lowercase(doc: Doc):
     """
     Add case on the `NORM` custom attribute. Should always be applied first.

--- a/edsnlp/utils/filter.py
+++ b/edsnlp/utils/filter.py
@@ -109,11 +109,12 @@ def filter_spans(
     for span in sorted_spans:
         s = span if isinstance(span, Span) else span[0]
         # Check for end - 1 here because boundaries are inclusive
-        if s.start not in seen_tokens and s.end - 1 not in seen_tokens:
+        token_range = set(range(s.start, s.end))
+        if token_range.isdisjoint(seen_tokens):
             if label_to_remove is None or s.label_ != label_to_remove:
                 result.append(span)
             if label_to_remove is None or s.label_ == label_to_remove:
-                seen_tokens.update(range(s.start, s.end))
+                seen_tokens.update(token_range)
         elif label_to_remove is None or s.label_ != label_to_remove:
             discarded.append(span)
 

--- a/tests/utils/test_filter.py
+++ b/tests/utils/test_filter.py
@@ -18,6 +18,18 @@ def test_filter_spans(doc: Doc):
     assert len(filtered[0]) == 4
 
 
+def test_filter_spans_strict_nesting(doc: Doc):
+    spans = [
+        doc[0:5],
+        doc[1:4],
+    ]
+
+    filtered = filter_spans(spans)
+
+    assert len(filtered) == 1
+    assert len(filtered[0]) == 5
+
+
 def test_label_to_remove(doc: Doc):
 
     spans = [


### PR DESCRIPTION
## Description

- Fix filter_spans for strictly nested entities
- Fill eds.remove-lowercase "assign" metadata to run the pipeline during EDSPhraseMatcher preprocessing

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
