### PR TITLE
Elston and Ellis

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Improve the `eds.history` component by taking into account the date extracted from `eds.dates` component.
 - New pop up when you click on the copy icon in the termynal widget (docs).
+- Add NER `eds.elston-ellis` pipeline to identify Elston Ellis scores
 
 ### Fixed
 

--- a/edsnlp/pipelines/ner/scores/__init__.py
+++ b/edsnlp/pipelines/ner/scores/__init__.py
@@ -2,5 +2,6 @@ from edsnlp.pipelines.ner.scores.base_score import Score
 
 from . import factory
 from .charlson import factory as charlson_factory
+from .elstonellis import factory as elstonellis_factory
 from .emergency.ccmu import factory as emergecy_ccmu_factory
 from .sofa import factory as sofa_factory

--- a/edsnlp/pipelines/ner/scores/elstonellis/factory.py
+++ b/edsnlp/pipelines/ner/scores/elstonellis/factory.py
@@ -1,0 +1,46 @@
+import re
+from typing import Any, Callable, List, Union
+
+from spacy.language import Language
+
+from edsnlp.pipelines.ner.scores import Score
+from edsnlp.pipelines.ner.scores.elstonellis import patterns
+
+DEFAULT_CONFIG = dict(
+    regex=patterns.regex,
+    value_extract=patterns.value_extract,
+    score_normalization=patterns.score_normalization_str,
+    attr="TEXT",
+    window=20,
+    ignore_excluded=False,
+    flags=0,
+)
+
+
+@Language.factory(
+    "eds.elston-ellis",
+    default_config=DEFAULT_CONFIG,
+    assigns=["doc.ents", "doc.spans"],
+)
+def create_component(
+    nlp: Language,
+    name: str,
+    regex: List[str],
+    value_extract: str,
+    score_normalization: Union[str, Callable[[Union[str, None]], Any]],
+    attr: str,
+    window: int,
+    ignore_excluded: bool,
+    flags: Union[re.RegexFlag, int],
+):
+    return Score(
+        nlp,
+        score_name=name,
+        regex=regex,
+        value_extract=value_extract,
+        score_normalization=score_normalization,
+        attr=attr,
+        window=window,
+        ignore_excluded=ignore_excluded,
+        flags=flags,
+    )

--- a/edsnlp/pipelines/ner/scores/elstonellis/patterns.py
+++ b/edsnlp/pipelines/ner/scores/elstonellis/patterns.py
@@ -1,0 +1,36 @@
+import re
+from typing import Union
+
+import spacy
+
+regex = [r"[Ee]lston (& |et |and )?[Ee]llis", r"\b[Ee]{2}\b"]
+
+pattern1 = r"[^\d\(\)]*[0-3]"
+pattern2 = r".{0,2}[\+,]"
+value_extract = rf"(?s).(\({pattern1}{pattern2}{pattern1}{pattern2}{pattern1}\))"
+
+score_normalization_str = "score_normalization.elstonellis"
+
+
+@spacy.registry.misc(score_normalization_str)
+def score_normalization(extracted_score: Union[str, None]):
+    """
+    Elston and Ellis score normalization.
+    If available, returns the integer value of the Elston and Ellis score.
+    """
+    try:
+        x = 0
+        for i in re.findall(r"[0-3]", extracted_score):
+            x += int(i)
+
+        if x <= 5:
+            return 1
+
+        elif x <= 7:
+            return 2
+
+        else:
+            return 3
+
+    except ValueError:
+        return None

--- a/tests/pipelines/ner/test_score.py
+++ b/tests/pipelines/ner/test_score.py
@@ -25,6 +25,12 @@ PRIORITE: <ent score_name=emergency.priority score_value=2>2</ent>: 2 - Urgence 
 GEMSA: (<ent score_name=emergency.gemsa score_value=2>2</ent>) Patient non convoque sortant apres consultation
 CCMU: Etat clinique jugé stable avec actes diag ou thérapeutiques ( <ent score_name=emergency.ccmu score_value=2>2</ent> )
 
+
+CONCLUSION
+
+La patiente est atteinte d'un carcinome mammaire infiltrant de type non spécifique, de grade 2 de malignité selon Elston et Ellis
+<ent score_name=eds.elston-ellis score_value=2>(architecture : 3 + noyaux : 3 + mitoses : 1)</ent>.
+
 """  # noqa: E501
 
 
@@ -55,6 +61,7 @@ def test_scores(blank_nlp):
 
     blank_nlp.add_pipe("charlson")
     blank_nlp.add_pipe("SOFA")
+    blank_nlp.add_pipe("eds.elston-ellis")
     blank_nlp.add_pipe("emergency.priority")
     blank_nlp.add_pipe("emergency.ccmu")
     blank_nlp.add_pipe("emergency.gemsa")


### PR DESCRIPTION
Added the Elston and Ellis score ner.

## Description

The Elston and Ellis grading score is used in Anapathological reports to characterise the structure of a cancerous prelevement and serve as a prognostic value for the disease.

The changes were made using the Score factory pattern.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
