### PR TITLE
Improve dates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - Add `QuickExample` object to quickly try a pipeline.
 - Add UMLS terminology matcher `eds.umls`
 - New `RegexMatcher` method to create spans from groupdicts
+- New `eds.dates` option to disable time detection
 
 ### Changed
 
@@ -46,7 +47,7 @@
 
 - Add new patterns (footer, web entities, biology tables, coding sections) to pipeline normalisation (pollution)
 
-## Changed
+### Changed
 
 - Improved TNM detection algorithm
 - Account for more modifiers in ADICAP codes detection

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,11 @@
 - Improve patterns in the `eds.pollution` component to account for multiline footers
 - Add `QuickExample` object to quickly try a pipeline.
 - Add UMLS terminology matcher `eds.umls`
+- New `RegexMatcher` method to create spans from groupdicts
+
+### Changed
+
+- Improve date detection by removing false positives
 
 ### Fixed
 

--- a/docs/pipelines/misc/dates.md
+++ b/docs/pipelines/misc/dates.md
@@ -67,12 +67,13 @@ The `eds.dates` pipeline declares one [spaCy extension](https://spacy.io/usage/p
 The pipeline can be configured using the following parameters :
 
 | Parameter        | Explanation                                      | Default                           |
-| ---------------- | ------------------------------------------------ | --------------------------------- |
+|------------------|--------------------------------------------------|-----------------------------------|
 | `absolute`       | Absolute date patterns, eg `le 5 août 2020`      | `None` (use pre-defined patterns) |
 | `relative`       | Relative date patterns, eg `hier`)               | `None` (use pre-defined patterns) |
 | `durations`      | Duration patterns, eg `pendant trois mois`)      | `None` (use pre-defined patterns) |
 | `false_positive` | Some false positive patterns to exclude          | `None` (use pre-defined patterns) |
-| `detect_periods` | Whether to look for dates around entities only   | `False`                           |
+| `detect_periods` | Whether to look for periods                      | `False`                           |
+| `detect_time`    | Whether to look for time around dates            | `True`                            |
 | `on_ents_only`   | Whether to look for dates around entities only   | `False`                           |
 | `as_ents`        | Whether to save detected dates as entities       | `False`                           |
 | `attr`           | spaCy attribute to match on, eg `NORM` or `TEXT` | `"NORM"`                          |

--- a/edsnlp/pipelines/misc/dates/dates.py
+++ b/edsnlp/pipelines/misc/dates/dates.py
@@ -65,6 +65,7 @@ class Dates(BaseComponent):
         false_positive: Optional[List[str]],
         on_ents_only: Union[bool, List[str]],
         detect_periods: bool,
+        detect_time: bool,
         as_ents: bool,
         attr: str,
     ):
@@ -72,7 +73,10 @@ class Dates(BaseComponent):
         self.nlp = nlp
 
         if absolute is None:
-            absolute = patterns.absolute_pattern
+            if detect_time:
+                absolute = patterns.absolute_pattern_with_time
+            else:
+                absolute = patterns.absolute_pattern
         if relative is None:
             relative = patterns.relative_pattern
         if duration is None:

--- a/edsnlp/pipelines/misc/dates/factory.py
+++ b/edsnlp/pipelines/misc/dates/factory.py
@@ -12,6 +12,7 @@ DEFAULT_CONFIG = dict(
     duration=None,
     false_positive=None,
     detect_periods=False,
+    detect_time=True,
     on_ents_only=False,
     as_ents=False,
     attr="LOWER",
@@ -31,6 +32,7 @@ def create_component(
     false_positive: Optional[List[str]],
     on_ents_only: Union[bool, List[str]],
     detect_periods: bool,
+    detect_time: bool,
     as_ents: bool,
     attr: str,
 ):
@@ -42,6 +44,7 @@ def create_component(
         false_positive=false_positive,
         on_ents_only=on_ents_only,
         detect_periods=detect_periods,
+        detect_time=detect_time,
         as_ents=as_ents,
         attr=attr,
     )

--- a/edsnlp/pipelines/misc/dates/patterns/__init__.py
+++ b/edsnlp/pipelines/misc/dates/patterns/__init__.py
@@ -1,4 +1,4 @@
-from .absolute import absolute_pattern
+from .absolute import absolute_pattern, absolute_pattern_with_time
 from .current import current_pattern
 from .duration import duration_pattern
 from .false_positive import false_positive_pattern

--- a/edsnlp/pipelines/misc/dates/patterns/absolute.py
+++ b/edsnlp/pipelines/misc/dates/patterns/absolute.py
@@ -7,7 +7,9 @@ from .atomic.delimiters import (
     ante_num_pattern,
     delimiters,
     post_num_pattern,
+    post_num_with_letter_pattern,
     raw_delimiter_with_spaces_pattern,
+    raw_delimiters,
 )
 from .atomic.modes import mode_pattern
 from .atomic.months import (
@@ -53,20 +55,30 @@ for time in [True, False]:
         + (time_pattern if time else "")
         + post_num_pattern
         for day in [ante_num_pattern + numeric_day_pattern, letter_day_pattern]
-        for month in [numeric_month_pattern + post_num_pattern, letter_month_pattern]
+        for month in [letter_month_pattern]
     ]
+    no_year_pattern.extend(
+        [
+            ante_num_pattern
+            + numeric_day_pattern
+            + d
+            + numeric_month_pattern
+            + post_num_pattern
+            for d in raw_delimiters
+        ]
+    )
     pattern.extend(no_year_pattern)
 
     no_day_pattern = [
         letter_month_pattern
         + raw_delimiter_with_spaces_pattern
         + year_pattern
-        + post_num_pattern,
+        + post_num_with_letter_pattern,
         ante_num_pattern
         + lz_numeric_month_pattern
-        + raw_delimiter_with_spaces_pattern
+        + "/"
         + year_pattern
-        + post_num_pattern,
+        + post_num_with_letter_pattern,
     ]
     pattern.extend(no_day_pattern)
 

--- a/edsnlp/pipelines/misc/dates/patterns/absolute.py
+++ b/edsnlp/pipelines/misc/dates/patterns/absolute.py
@@ -20,55 +20,68 @@ from .atomic.time import time_pattern
 from .atomic.years import full_year_pattern as fy_pattern
 from .atomic.years import year_pattern
 
-absolute_pattern = [
-    ante_num_pattern
-    + day_pattern
-    + d
-    + month_pattern
-    + d
-    + year_pattern
-    + time_pattern
-    + post_num_pattern
-    for d in delimiters
-] + [
-    ante_num_pattern
-    + year_pattern
-    + d
-    + numeric_month_pattern
-    + d
-    + numeric_day_pattern
-    + time_pattern
-    + post_num_pattern
-    for d in delimiters
-]
+absolute_pattern = []
+absolute_pattern_with_time = []
 
-no_year_pattern = [
-    day + raw_delimiter_with_spaces_pattern + month + time_pattern + post_num_pattern
-    for day in [ante_num_pattern + numeric_day_pattern, letter_day_pattern]
-    for month in [numeric_month_pattern + post_num_pattern, letter_month_pattern]
-]
-absolute_pattern.extend(no_year_pattern)
+for time in [True, False]:
+    pattern = [
+        ante_num_pattern
+        + day_pattern
+        + d
+        + month_pattern
+        + d
+        + year_pattern
+        + (time_pattern if time else "")
+        + post_num_pattern
+        for d in delimiters
+    ] + [
+        ante_num_pattern
+        + year_pattern
+        + d
+        + numeric_month_pattern
+        + d
+        + numeric_day_pattern
+        + (time_pattern if time else "")
+        + post_num_pattern
+        for d in delimiters
+    ]
 
-no_day_pattern = [
-    letter_month_pattern
-    + raw_delimiter_with_spaces_pattern
-    + year_pattern
-    + post_num_pattern,
-    ante_num_pattern
-    + lz_numeric_month_pattern
-    + raw_delimiter_with_spaces_pattern
-    + year_pattern
-    + post_num_pattern,
-]
-absolute_pattern.extend(no_day_pattern)
+    no_year_pattern = [
+        day
+        + raw_delimiter_with_spaces_pattern
+        + month
+        + (time_pattern if time else "")
+        + post_num_pattern
+        for day in [ante_num_pattern + numeric_day_pattern, letter_day_pattern]
+        for month in [numeric_month_pattern + post_num_pattern, letter_month_pattern]
+    ]
+    pattern.extend(no_year_pattern)
 
-no_day_no_year_pattern = [
-    letter_month_pattern,
-]
-absolute_pattern.extend(no_day_no_year_pattern)
+    no_day_pattern = [
+        letter_month_pattern
+        + raw_delimiter_with_spaces_pattern
+        + year_pattern
+        + post_num_pattern,
+        ante_num_pattern
+        + lz_numeric_month_pattern
+        + raw_delimiter_with_spaces_pattern
+        + year_pattern
+        + post_num_pattern,
+    ]
+    pattern.extend(no_day_pattern)
 
-full_year_pattern = ante_num_pattern + fy_pattern + post_num_pattern
+    no_day_no_year_pattern = [
+        letter_month_pattern,
+    ]
+    pattern.extend(no_day_no_year_pattern)
 
-absolute_pattern.append(full_year_pattern)
+    full_year_pattern = ante_num_pattern + fy_pattern + post_num_pattern
 
-absolute_pattern = [r"(?<=" + mode_pattern + r".{,3})?" + p for p in absolute_pattern]
+    pattern.append(full_year_pattern)
+
+    pattern = [r"(?<=" + mode_pattern + r".{,3})?" + p for p in pattern]
+
+    if time:
+        absolute_pattern_with_time[:] = pattern
+    else:
+        absolute_pattern[:] = pattern

--- a/edsnlp/pipelines/misc/dates/patterns/atomic/delimiters.py
+++ b/edsnlp/pipelines/misc/dates/patterns/atomic/delimiters.py
@@ -1,11 +1,16 @@
 from edsnlp.utils.regex import make_pattern
 
-raw_delimiters = [r"\/", r"\-"]
+raw_delimiters = [r"\/", r"[-−]"]
 delimiters = raw_delimiters + [r"\.", r"[^\S]+"]
 
 raw_delimiter_pattern = make_pattern(raw_delimiters)
 raw_delimiter_with_spaces_pattern = make_pattern(raw_delimiters + [r"[^\S]+"])
 delimiter_pattern = make_pattern(delimiters)
 
-ante_num_pattern = f"(?<!.(?:{raw_delimiter_pattern})|[0-9][.,])"
-post_num_pattern = f"(?!{raw_delimiter_pattern})"
+ante_num_pattern = (
+    f"(?<!.(?:{raw_delimiter_pattern})|[.:%a-zA-Z]|[0-9][.:%][ ]?|[0-9][,]?)"
+)
+post_num_pattern = f"(?!{raw_delimiter_pattern}|[%a-zA-Z]|[ ]?[.:%][0-9]|[.,:]?[0-9])"
+
+ante_num_with_letter_pattern = "(?<!/|[.:%]|[0-9][-−.:%][ ]?|[0-9][,]?)"
+post_num_with_letter_pattern = "(?!/|[%]|[ ]?[-−.:%][0-9]|[.,:]?[0-9])"

--- a/edsnlp/pipelines/misc/measurements/measurements.py
+++ b/edsnlp/pipelines/misc/measurements/measurements.py
@@ -268,9 +268,13 @@ class MeasurementsMatcher:
             self.unit_part_label_hashes.add(nlp.vocab.strings[unit_name])
 
         self.unit_part_label_hashes.add(nlp.vocab.strings["per"])
-        self.term_matcher.build_patterns(nlp, {"per": unit_divisors})
-
-        self.term_matcher.add("stopword", list(nlp.pipe(stopwords)))
+        self.term_matcher.build_patterns(
+            nlp,
+            {
+                "per": unit_divisors,
+                "stopword": stopwords,
+            },
+        )
 
         # MEASURES
         for name, measure_config in measurements.items():
@@ -279,8 +283,11 @@ class MeasurementsMatcher:
             if "unitless_patterns" in measure_config:
                 for pattern in measure_config["unitless_patterns"]:
                     pattern_name = f"unitless_{len(self.unitless_patterns)}"
-                    self.term_matcher.add(
-                        pattern_name, list(nlp.pipe(pattern["terms"]))
+                    self.term_matcher.build_patterns(
+                        nlp,
+                        terms={
+                            pattern_name: pattern["terms"],
+                        },
                     )
                     self.unitless_label_hashes.add(nlp.vocab.strings[pattern_name])
                     self.unitless_patterns[pattern_name] = {"name": name, **pattern}

--- a/edsnlp/pipelines/qualifiers/history/history.py
+++ b/edsnlp/pipelines/qualifiers/history/history.py
@@ -231,23 +231,27 @@ class History(Qualifier):
             spaCy Doc object, annotated for history
         """
 
-        try:
-            note_datetime = pendulum.instance(doc._.note_datetime)
-            note_datetime = note_datetime.set(tz="Europe/Paris")
-        except ValueError:
-            logger.debug(
-                "Note date time must be datetime objects. Skkipping absolute value"
-            )
-            note_datetime = None
+        if doc._.note_datetime is not None:
+            try:
+                note_datetime = pendulum.instance(doc._.note_datetime)
+                note_datetime = note_datetime.set(tz="Europe/Paris")
+            except ValueError:
+                logger.debug(
+                    "note_datetime must be a datetime objects. "
+                    "Skipping history qualification from note_datetime."
+                )
+                note_datetime = None
 
-        try:
-            birth_datetime = pendulum.instance(doc._.birth_datetime)
-            birth_datetime = birth_datetime.set(tz="Europe/Paris")
-        except ValueError:
-            logger.debug(
-                "Birth date time must be datetime objects. Skkipping exclude birth date"
-            )
-            birth_datetime = None
+        if doc._.birth_datetime is not None:
+            try:
+                birth_datetime = pendulum.instance(doc._.birth_datetime)
+                birth_datetime = birth_datetime.set(tz="Europe/Paris")
+            except ValueError:
+                logger.debug(
+                    "birth_datetime must be a datetime objects. "
+                    "Skipping history qualification from birth date."
+                )
+                birth_datetime = None
 
         matches = self.get_matches(doc)
 

--- a/tests/matchers/test_regex.py
+++ b/tests/matchers/test_regex.py
@@ -218,3 +218,15 @@ def test_wrong_extraction(
 
     clean = get_text(doc.ents[0], attr="NORM", ignore_excluded=True)
     assert clean == "transplantation cardiaque"
+
+
+def test_groupdict_as_spans(doc):
+    matcher = RegexMatcher()
+
+    matcher.add("test", [r"patient(?i:(?=.*(?P<cause>douleurs))?)"])
+
+    [(span0, gd0), (span1, gd1)] = list(matcher.match_with_groupdict_as_spans(doc))
+    assert span0.text == "patient"
+    assert span1.text == "patient"
+    assert len(gd0) == 1 and gd0["cause"].text == "douleurs"
+    assert len(gd1) == 0


### PR DESCRIPTION
## Description

This PR:
- improves the date component (`eds.dates`) retrieval performance.
- adds a new function to the RegexMatcher to convert groupdicts's groups into spaCy spans.
- adds a new option in eds.dates to disable time detection

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
