### PR TITLE
Bump version to 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.7.2
+pip install edsnlp==0.7.3
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.7.3 (2022-11-25)
 
 ### Added
 - `eds.history` : Add the option to consider only the closest dates in the sentence (dates inside the boundaries and if there is not, it takes the closest date in the entire sentence).

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ color:green Successfully installed!
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.7.2
+pip install edsnlp==0.7.3
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -8,6 +8,6 @@ from pathlib import Path
 from . import extensions
 from .language import *
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
## Description

New version 0.7.3.

### Added
- `eds.history` : Add the option to consider only the closest dates in the sentence (dates inside the boundaries and if there is not, it takes the closest date in the entire sentence).
- `eds.negation` : It takes into account following past participates and preceding infinitives.
- `eds.hypothesis`: It takes into account following past participates hypothesis verbs.
- `eds.negation` & `eds.hypothesis` : Introduce new patterns and remove unnecessary patterns.
- `eds.dates` : Add a pattern for preceding relative dates (ex: l'embolie qui est survenue **à 10 jours**).
- Improve patterns in the `eds.pollution` component to account for multiline footers
- Add UMLS terminology matcher `eds.umls`

### Fixed

- `eds.hypothesis` : Remove too generic patterns.
- `EDSTokenizer` : It now tokenizes `"rechereche d'"` as `["recherche", "d'"]`, instead of `["recherche", "d", "'"]`.
- Fix small typos in the documentation and in the docstring.
- Harmonize processing utils (distributed custom_pipe) to have the same API for Pandas and Pyspark

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
