### PR TITLE
Umls fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ jobs:
 
   Pytest:
     runs-on: ubuntu-latest
-    env:
-      UMLS_API_KEY: ${{ secrets.UMLS_API_KEY }}
     strategy:
       fail-fast: true
       matrix:
@@ -56,10 +54,14 @@ jobs:
           pip install -e .
 
       - name: Test with Pytest on Python ${{ matrix.python-version }}
+        env:
+          UMLS_API_KEY: ${{ secrets.UMLS_API_KEY }}
         run: python -m pytest --cov edsnlp --cov-report xml --ignore tests/test_docs.py
         if: matrix.python-version != '3.9'
 
       - name: Test with Pytest on Python ${{ matrix.python-version }}
+        env:
+          UMLS_API_KEY: ${{ secrets.UMLS_API_KEY }}
         run: python -m pytest --cov edsnlp --cov-report xml
         if: matrix.python-version == '3.9'
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Disable `EDSMatcher` preprocessing auto progress tracking by default
+
 ## v0.7.4 (2022-12-12)
 
 ### Added

--- a/edsnlp/matchers/phrase.pyx
+++ b/edsnlp/matchers/phrase.pyx
@@ -70,7 +70,7 @@ cdef class EDSPhraseMatcher(PhraseMatcher):
         if not Span.has_extension("normalized_variant"):
             Span.set_extension("normalized_variant", getter=get_normalized_variant)
 
-    def build_patterns(self, nlp: Language, terms: Patterns):
+    def build_patterns(self, nlp: Language, terms: Patterns, progress: bool = False):
         """
         Build patterns and adds them for matching.
         Helper function for pipelines using this matcher.
@@ -81,6 +81,8 @@ cdef class EDSPhraseMatcher(PhraseMatcher):
             The instance of the spaCy language class.
         terms : Patterns
             Dictionary of label/terms, or label/dictionary of terms/attribute.
+        progress: bool
+            Whether to track progress when preprocessing terms
         """
 
         if not terms:
@@ -95,10 +97,10 @@ cdef class EDSPhraseMatcher(PhraseMatcher):
             )
         ]
         with nlp.select_pipes(enable=token_pipelines):
-            for key, expressions in tqdm(
+            for key, expressions in (tqdm(
                 terms.items(),
                 desc="Adding terms into the pipeline"
-            ):
+            ) if progress else terms.items()):
                 if isinstance(expressions, dict):
                     attr = expressions.get("attr")
                     expressions = expressions.get("patterns")

--- a/edsnlp/matchers/simstring.py
+++ b/edsnlp/matchers/simstring.py
@@ -105,7 +105,9 @@ class SimstringMatcher:
         self.ss_reader = None
         self.syn2cuis = None
 
-    def build_patterns(self, nlp: Language, terms: Dict[str, Iterable[str]]):
+    def build_patterns(
+        self, nlp: Language, terms: Dict[str, Iterable[str]], progress: bool = False
+    ):
         """
         Build patterns and adds them for matching.
 
@@ -115,6 +117,8 @@ class SimstringMatcher:
             The instance of the spaCy language class.
         terms : Patterns
             Dictionary of label/terms, or label/dictionary of terms/attribute.
+        progress: bool
+            Whether to track progress when preprocessing terms
         """
 
         self.ss_reader = None
@@ -131,7 +135,7 @@ class SimstringMatcher:
         ]
         with nlp.select_pipes(enable=token_pipelines):
             with SimstringWriter(self.path) as ss_db:
-                for cui, synset in tqdm(terms.items()):
+                for cui, synset in tqdm(terms.items()) if progress else terms.items():
                     for term in nlp.pipe(synset):
                         norm_text = get_text(
                             term, self.attr, ignore_excluded=self.ignore_excluded

--- a/edsnlp/pipelines/core/terminology/terminology.py
+++ b/edsnlp/pipelines/core/terminology/terminology.py
@@ -92,7 +92,7 @@ class TerminologyMatcher(BaseComponent):
             ignore_excluded=ignore_excluded,
         )
 
-        self.phrase_matcher.build_patterns(nlp=nlp, terms=terms)
+        self.phrase_matcher.build_patterns(nlp=nlp, terms=terms, progress=True)
         self.regex_matcher.build_patterns(regex=regex)
 
         self.set_extensions()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pysimstring>=1.2.1
 regex<=2022.3.2  # due to dateparser bug issue 1045
 rich>=12.0.0
 scikit-learn>=1.0.0
-spacy>=3.1
+spacy>=3.1,<4.0.0
 thinc>=8.0.14
 tqdm
 umls-downloader


### PR DESCRIPTION
## Description

This PR disables EDSMatcher preprocessing auto progress tracking by default, caps spaCy version < 4.0 due to binary incompatibilities and tries to allow public forks to access the CI cache (especially UMLS resource files).

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
