### PR TITLE
CI fail exploration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: detect-private-key
       - id: requirements-txt-fixer
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.0
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)

--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -1,3 +1,3 @@
-mlconjug3<3.10.0
+mlconjug3<3.9.0
 numpy
 typer

--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -1,3 +1,3 @@
-mlconjug3
+mlconjug3<3.10.0
 numpy
 typer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator
 loguru
-numpy>=1.15.0
+numpy>=1.15.0,<=1.22.4
 pandas
 pendulum
 pydantic>=1.8.2,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 decorator
 loguru
-numpy>=1.15.0,<=1.22.4
+numpy>=1.15.0,<1.24.0
 pandas
 pendulum
 pydantic>=1.8.2,<2.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Describe the changes. -->

- numpy: since [1.24.0](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations), the aliases np.object, np.bool, np.float, np.complex, np.str, and np.int are not  supported anymore, which breaks koalas
- mlconjug3: seems like version 3.9.0 and forward is the problem.
- isort: bump to rev 5.11.5 in pre-commit

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
