### PR TITLE
Range measurements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,13 @@
 
 ### Added
 
+- Add range measurements (like `la tumeur fait entre 1 et 2 cm`) to `eds.measurements` matcher
 - Add `eds.spaces` (or `eds.normalizer` with `spaces=True`) to detect space tokens, and add `ignore_space_tokens` to `EDSPhraseMatcher` and `SimstringMatcher` to skip them
 - Add `ignore_space_tokens` option in most components
+
+### Fixed
+
+- Abbreviation and number tokenization issues in the `eds` tokenizer
 
 ## v0.8.0 (2023-03-09)
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 - Add range measurements (like `la tumeur fait entre 1 et 2 cm`) to `eds.measurements` matcher
 - Add `eds.spaces` (or `eds.normalizer` with `spaces=True`) to detect space tokens, and add `ignore_space_tokens` to `EDSPhraseMatcher` and `SimstringMatcher` to skip them
 - Add `ignore_space_tokens` option in most components
+- New `merge_mode` parameter in `eds.measurements` to normalize existing entities or detect
+  measures only inside existing entities
 
 ### Fixed
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -111,8 +111,8 @@ def load_model(
         pipes.append('nlp.add_pipe("eds.dates")')
 
     if measurements:
-        nlp.add_pipe("eds.measurements")
-        pipes.append('nlp.add_pipe("eds.measurements")')
+        nlp.add_pipe("eds.measurements", config={"extract_ranges": True})
+        pipes.append('nlp.add_pipe("eds.measurements", config={"extract_ranges": True}')
 
     if charlson:
         nlp.add_pipe("eds.charlson")

--- a/docs/pipelines/misc/measurements.md
+++ b/docs/pipelines/misc/measurements.md
@@ -18,7 +18,7 @@ The normalized value can then be accessed via the `span._.value` attribute and c
 The current pipeline annotates the following measurements out of the box:
 
 | Measurement name | Example                |
-| ---------------- | ---------------------- |
+|------------------|------------------------|
 | `eds.size`       | `1m50`, `1.50m`        |
 | `eds.weight`     | `12kg`, `1kg300`       |
 | `eds.bmi`        | `BMI: 24`, `24 kg.m-2` |
@@ -34,18 +34,20 @@ nlp.add_pipe(
     "eds.measurements", config=dict(measurements=["eds.size", "eds.weight", "eds.bmi"])
 )
 
-text = (
-    "Le patient est admis hier, fait 1m78 pour 76kg. "
-    "Les deux nodules bénins sont larges de 1,2 et 2.4mm. "
-    "BMI: 24 "
-)
+text = """
+Le patient est admis hier, fait 1m78 pour 76kg.
+Les deux nodules bénins sont larges de 1,2 et 2.4mm.
+BMI: 24.
+
+Le nodule fait entre 1 et 1.5 cm
+"""
 
 doc = nlp(text)
 
 measurements = doc.spans["measurements"]
 
 measurements
-# Out: [1m78, 76kg, 1,2, 2.4mm, 24]
+# Out: [1m78, 76kg, 1,2, 2.4mm, 24, entre 1 et 1.5 cm]
 
 measurements[0]
 # Out: 1m78
@@ -69,10 +71,13 @@ measurements[4]
 # Out: 24
 
 str(measurements[4]._.value)
-# Out: '24.0 kg_per_m2'
+# Out: '24 kg_per_m2'
 
 str(measurements[4]._.value.kg_per_m2)
-# Out: 24.0
+# Out: 24
+
+str(measurements[5]._.value)
+# Out: 1-1.5 cm
 ```
 
 ## Custom measurement
@@ -120,15 +125,9 @@ the `value` attribute that is a `Measurement` instance.
 
 The pipeline can be configured using the following parameters :
 
-| Parameter         | Explanation                                                                    | Default                                                              |
-| ----------------- | --------------------------------------------------------------------------     | -------------------------------------------------------------------- |
-| `measurements`    | A list or dict of the measurements to extract                                  | `["eds.size", "eds.weight", "eds.angle"]` |
-| `units_config`    | A dict describing the units with lexical patterns, dimensions, scales, ...     | ... |
-| `number_terms`    | A dict describing the textual forms of common numbers                          | ... |
-| `stopwords`       | A list of stopwords that do not matter when placed between a unitless trigger  | ... |
-| `unit_divisors`   | A list of terms used to divide two units (like: m / s)                         | ... |
-| `ignore_excluded` | Whether to ignore excluded tokens for matching                                 | `False`                                                              |
-| `attr`            | spaCy attribute to match on, eg `NORM` or `TEXT`                               | `"NORM"`                                                             |
+::: edsnlp.pipelines.misc.measurements.factory.create_component
+    options:
+        only_parameters: true
 
 ## Authors and citation
 

--- a/docs/pipelines/misc/measurements.md
+++ b/docs/pipelines/misc/measurements.md
@@ -31,7 +31,11 @@ import spacy
 
 nlp = spacy.blank("eds")
 nlp.add_pipe(
-    "eds.measurements", config=dict(measurements=["eds.size", "eds.weight", "eds.bmi"])
+    "eds.measurements",
+    config=dict(
+        measurements=["eds.size", "eds.weight", "eds.bmi"],
+        extract_ranges=True,
+    ),
 )
 
 text = """
@@ -78,6 +82,19 @@ str(measurements[4]._.value.kg_per_m2)
 
 str(measurements[5]._.value)
 # Out: 1-1.5 cm
+```
+
+To extract all sizes in centimeters, and average range measurements, you can use the following snippet:
+
+```python
+sizes = [
+    sum(item.cm for item in m._.value) / len(m._.value)
+    for m in doc.spans["measurements"]
+    if m.label_ == "eds.size"
+]
+print(sizes)
+sizes
+# Out: [178.0, 0.12, 0.24, 1.25]
 ```
 
 ## Custom measurement

--- a/docs/tokenizers.md
+++ b/docs/tokenizers.md
@@ -7,12 +7,14 @@ the `fr` language. The main differences lie in the tokenization process.
 
 A comparison of the two tokenization methods is demonstrated below:
 
-| Example            | FrenchLanguage            | EDSLanguage                  |
-|--------------------|---------------------------|------------------------------|
-| `ACR 5`            | \[`ACR5`\]                | \[`ACR`, `5`\]               |
-| `26.5/`            | \[`26.5/`\]               | \[`26.5`, `/`\]              |
-| `\n \n CONCLUSION` | \[`\n \n`, `CONCLUSION`\] | \[`\n`, `\n`, `CONCLUSION`\] |
-| `l'artère`         | \[`l'`, `artère`\]        | \[`l'`, `artère`\] (same)    |
+| Example            | FrenchLanguage            | EDSLanguage                               |
+|--------------------|---------------------------|-------------------------------------------|
+| `ACR 5`            | \[`ACR5`\]                | \[`ACR`, `5`\]                            |
+| `26.5/`            | \[`26.5/`\]               | \[`26.5`, `/`\]                           |
+| `\n \n CONCLUSION` | \[`\n \n`, `CONCLUSION`\] | \[`\n`, `\n`, `CONCLUSION`\]              |
+| `l'artère`         | \[`l'`, `artère`\]        | \[`l'`, `artère`\] (same)                 |
+| `Dr. Pichon`       | \[`Dr`, `.`, `Pichon`\]   | \[`Dr.`, `Pichon`\]                       |
+| `B.H.HP.A.7.A`     | \[`B.H.HP.A.7.A`\]        | \[`B.`, `H.`, `HP.`, `A`, `7`, `A`, `0`\] |
 
 To instantiate one of the two languages, you can call the `spacy.blank` method.
 

--- a/edsnlp/language.py
+++ b/edsnlp/language.py
@@ -60,7 +60,7 @@ class EDSTokenizer(DummyTokenizer):
         """
         self.vocab = vocab
         punct = "[:punct:]" + "\"'ˊ＂〃ײ᳓″״‶˶ʺ“”˝"
-        num_like = r"\d+(?:[.,]\d+)?"
+        num_like = r"\d+(?:[.,]\d(?![.,]?[0-9])|(?![.,]?[0-9]))?"
         sep = rf"\d{punct}'\n[:space:]"
         default = rf"[^{sep}]+(?:['ˊ](?=[[:alpha:]]|$))?"
         exceptions = "|".join(TOKENIZER_EXCEPTIONS)
@@ -71,7 +71,7 @@ class EDSTokenizer(DummyTokenizer):
             {exceptions}    # tokenizer exceptions like M., Dr., etc
             |{acronym}      # acronyms
             |{num_like}     # numbers
-            |[{punct}]        # punctuations
+            |[{punct}]      # punctuations
             |[\n\r\t]       # new lines or tabs
             |[^\S\r\n\t]+   # multi-spaces
             |{default}      # anything else: most often alpha-numerical words

--- a/edsnlp/matchers/phrase.pyx
+++ b/edsnlp/matchers/phrase.pyx
@@ -123,11 +123,13 @@ cdef class EDSPhraseMatcher(PhraseMatcher):
             SpanC ms
             void * result
         while idx < end_idx:
-            while idx < end_idx and (
+            while (
                 (0 < self.space_hash == doc.c[idx].tag)
                 or (0 < self.excluded_hash == doc.c[idx].tag)
             ):
                 idx += 1
+                if idx >= end_idx:
+                    return
             start = idx
             # look for sequences from this position
             token = Token.get_struct_attr(&doc.c[idx], self.attr)

--- a/edsnlp/pipelines/misc/measurements/factory.py
+++ b/edsnlp/pipelines/misc/measurements/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from spacy.language import Language
 
@@ -6,18 +6,24 @@ import edsnlp.pipelines.misc.measurements.patterns as patterns
 from edsnlp.pipelines.misc.measurements.measurements import (
     MeasureConfig,
     MeasurementsMatcher,
+    MergeStrategy,
     UnitConfig,
 )
 from edsnlp.utils.deprecation import deprecated_factory
 
 DEFAULT_CONFIG = dict(
     attr="NORM",
+    measurements=None,
     ignore_excluded=True,
     units_config=patterns.units_config,
     number_terms=patterns.number_terms,
     unit_divisors=patterns.unit_divisors,
-    measurements=None,
     stopwords=patterns.stopwords,
+    compose_units=True,
+    extract_ranges=False,
+    range_patterns=patterns.range_patterns,
+    as_ents=False,
+    merge_mode=MergeStrategy.union,
 )
 
 
@@ -32,15 +38,25 @@ def create_component(
     stopwords: List[str],
     unit_divisors: List[str],
     ignore_excluded: bool,
+    compose_units: bool,
     attr: str,
+    extract_ranges: bool,
+    range_patterns: List[Tuple[Optional[str], Optional[str]]],
+    as_ents: bool,
+    merge_mode: MergeStrategy,
 ):
     return MeasurementsMatcher(
         nlp,
+        measurements=measurements,
         units_config=units_config,
         number_terms=number_terms,
-        unit_divisors=unit_divisors,
-        measurements=measurements,
         stopwords=stopwords,
-        attr=attr,
+        unit_divisors=unit_divisors,
         ignore_excluded=ignore_excluded,
+        compose_units=compose_units,
+        attr=attr,
+        extract_ranges=extract_ranges,
+        range_patterns=range_patterns,
+        as_ents=as_ents,
+        merge_mode=merge_mode,
     )

--- a/edsnlp/pipelines/misc/measurements/patterns.py
+++ b/edsnlp/pipelines/misc/measurements/patterns.py
@@ -1,4 +1,11 @@
 number_terms = {
+    "0.125": ["⅛"],
+    "0.16666666": ["⅙"],
+    "0.2": ["⅕"],
+    "0.25": ["¼"],
+    "0.3333333": ["⅓"],
+    "0.5": ["½"],
+    "2.5": ["21/2"],
     "1": ["un", "une"],
     "2": ["deux"],
     "3": ["trois"],
@@ -76,6 +83,19 @@ units_config = {
         "followed_by": "cm",
     },
     # Weights
+    "µg": {
+        "dim": "mass",
+        "degree": 1,
+        "scale": 1e-1,
+        "terms": [
+            "microgramme",
+            "microgrammes",
+            "micro-gramme",
+            "microgrammes",
+            "µg",
+        ],
+        "followed_by": None,
+    },
     "mg": {
         "dim": "mass",
         "degree": 1,
@@ -137,34 +157,34 @@ units_config = {
         "dim": "time",
         "degree": 1,
         "scale": 3600,
-        "terms": ["heure", "h"],
+        "terms": ["heure", "heures", "h"],
         "followed_by": "minute",
     },
     "day": {
         "dim": "time",
         "degree": 1,
-        "scale": 3600 * 1,
+        "scale": 3600 * 24,
         "terms": ["jour", "jours", "j"],
         "followed_by": None,
     },
     "month": {
         "dim": "time",
         "degree": 1,
-        "scale": 3600 * 30.4167,
+        "scale": 3600 * 24 * 30.4167,
         "terms": ["mois"],
         "followed_by": None,
     },
     "week": {
         "dim": "time",
         "degree": 1,
-        "scale": 3600 * 7,
-        "terms": ["semaine", "semaines"],
+        "scale": 3600 * 24 * 7,
+        "terms": ["semaine", "semaines", "sem"],
         "followed_by": None,
     },
     "year": {
         "dim": "time",
         "degree": 1,
-        "scale": 3600 * 365.25,
+        "scale": 3600 * 24 * 365.25,
         "terms": ["an", "année", "ans", "années"],
         "followed_by": None,
     },
@@ -238,7 +258,7 @@ units_config = {
         "dim": "length",
         "degree": 3,
         "scale": 5e-5,
-        "terms": ["gt", "goutte"],
+        "terms": ["gt", "goutte", "gouttes"],
         "followed_by": None,
     },
     "mm3": {
@@ -574,4 +594,16 @@ common_measurements = {
 
 unit_divisors = ["/", "par"]
 
-stopwords = ["par", "sur", "de", "a", ":", ",", "et"]
+stopwords = ["par", "sur", "de", "a", ",", "et"]
+
+# Should we only make accented patterns and expect the user to use
+# `eds.normalizer` component first ?
+range_patterns = [
+    ("De", "à"),
+    ("De", "a"),
+    ("de", "à"),
+    ("de", "a"),
+    ("Entre", "et"),
+    ("entre", "et"),
+    (None, "à"),
+]

--- a/edsnlp/utils/collections.py
+++ b/edsnlp/utils/collections.py
@@ -1,0 +1,13 @@
+def dedup(sequence, key=None):
+    """
+    Deduplicate a sequence, keeping the last occurrence of each item.
+
+    Parameters
+    ----------
+    sequence : Sequence
+        Sequence to deduplicate
+    key : Callable, optional
+        Key function to use for deduplication, by default None
+    """
+    key = (lambda x: x) if key is None else key
+    return list({key(item): item for item in sequence}.values())

--- a/edsnlp/utils/filter.py
+++ b/edsnlp/utils/filter.py
@@ -297,11 +297,7 @@ def get_span_group(doclike: Union[Doc, Span], group: str) -> List[Span]:
         List of spans.
     """
     if isinstance(doclike, Doc):
-        return [
-            span
-            for span in doclike.spans.get(group, ())
-            if span.start >= doclike.start and span.end <= doclike.end
-        ]
+        return [span for span in doclike.spans.get(group, ())]
     else:
         return [
             span

--- a/tests/pipelines/misc/test_measurements.py
+++ b/tests/pipelines/misc/test_measurements.py
@@ -6,7 +6,6 @@ from spacy.language import Language
 from spacy.tokens.span import Span
 
 from edsnlp.pipelines.misc.measurements import MeasurementsMatcher
-from edsnlp.pipelines.misc.measurements.factory import DEFAULT_CONFIG
 
 text = (
     "Le patient fait 1 m 50 kg. La tumeur fait 2.0cm x 3cm. \n"
@@ -27,7 +26,7 @@ def blank_nlp():
 def matcher(blank_nlp: Language):
     return MeasurementsMatcher(
         blank_nlp,
-        **DEFAULT_CONFIG,
+        extract_ranges=True,
     )
 
 


### PR DESCRIPTION
## Description

This PR updates the measurements component:
- better number detection such as `½=0.5` or `1/2 cm`
- fixes time units
- adds range measurements detection
- allows to disable unit composition (such as `g.cm-2`)
- new `merge_mode` parameter in `eds.measurements` to normalize existing entities or detect
  measures only inside existing entities

## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
