### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -5,7 +5,7 @@
 name: Test Build
 
 on:
-  push:
+  pull_request:
     branches:
       - v*.*.*
       - build-*

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.8.1
+pip install edsnlp==0.9.0
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.9.0
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ color:green Successfully installed!
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.8.1
+pip install edsnlp==0.9.0
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -8,6 +8,6 @@ from pathlib import Path
 from . import extensions
 from .language import *
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- New `to_duration` method to convert an absolute date into a date relative to the note_datetime (or None)

### Changes

- Input and output of components are now specified by `span_getter` and `span_setter` arguments.
- :boom: Score / disorders / behaviors entities now have a fixed label (passed as an argument), instead of being dynamically set from the component name. The following scores may have a different label than the current one in your pipelines:
  * `eds.emergency.gemsa` → `emergency_gemsa`
  * `eds.emergency.ccmu` → `emergency_ccmu`
  * `eds.emergency.priority` → `emergency_priority`
  * `eds.charlson` → `charlson`
  * `eds.elston_ellis` → `elston_ellis`
  * `eds.SOFA` → `sofa`
  * `eds.adicap` → `adicap`
  * `eds.measuremets` → `size`, `weight`, ... instead of `eds.size`, `eds.weight`, ...
- `eds.dates` now separate dates from durations. Each entity has its own label:
  * `spans["dates"]` → entities labelled as `date` with a `span._.date` parsed object
  * `spans["durations"]` → entities labelled as `duration` with a `span._.duration` parsed object
- the "relative" / "absolute" / "duration" mode of the time entity is now stored in
  the `mode` attribute of the `span._.date/duration`
- the "from" / "until" period bound, if any, is now stored in the `span._.date.bound` attribute
- `to_datetime` now only return absolute dates, converts relative dates into absolute if `doc._.note_datetime` is given, and None otherwise

### Fixed
- `export_to_brat` issue with spans of entities on multiple lines.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
