### PR TITLE
Fix negations

### DIFF
--- a/edsnlp/pipelines/misc/dates/dates.py
+++ b/edsnlp/pipelines/misc/dates/dates.py
@@ -168,7 +168,7 @@ class DatesMatcher(BaseNERComponent):
         relative: Optional[List[str]] = None,
         duration: Optional[List[str]] = None,
         false_positive: Optional[List[str]] = None,
-        on_ents_only: Union[bool, str, Iterable[str]] = False,
+        on_ents_only: Union[bool, str, Iterable[str]] = None,
         span_getter: Optional[SpanGetterArg] = None,
         merge_mode: Literal["intersect", "align"] = "intersect",
         detect_periods: bool = False,
@@ -226,6 +226,9 @@ class DatesMatcher(BaseNERComponent):
             relative = [duration]
         if isinstance(false_positive, str):
             false_positive = [false_positive]
+
+        if on_ents_only is None and span_getter is None:
+            on_ents_only = False
 
         if on_ents_only:
             assert span_getter is None, (

--- a/edsnlp/pipelines/ner/behaviors/alcohol/patterns.py
+++ b/edsnlp/pipelines/ner/behaviors/alcohol/patterns.py
@@ -33,7 +33,7 @@ default_patterns = dict(
         ),
         dict(
             name="zero_after",
-            regex=r"^[a-z]*\s*:?[\s-]*(0|oui|non(?! sevr))",
+            regex=r"(?=^[a-z]*\s*:?[\s-]*(0|oui|non(?! sevr)))",
             window=6,
         ),
     ],

--- a/edsnlp/pipelines/ner/behaviors/tobacco/patterns.py
+++ b/edsnlp/pipelines/ner/behaviors/tobacco/patterns.py
@@ -32,7 +32,7 @@ default_patterns = [
             ),
             dict(
                 name="zero_after",
-                regex=r"^[a-z]*\s*:?[\s-]*(0|non(?! sevr))",
+                regex=r"(?=^[a-z]*\s*:?[\s-]*(0|non(?! sevr)))",
                 window=6,
             ),
             dict(

--- a/edsnlp/pipelines/ner/disorders/base.py
+++ b/edsnlp/pipelines/ner/disorders/base.py
@@ -86,6 +86,17 @@ class DisorderMatcher(ContextualMatcher):
                 "detailled_status",
                 getter=deprecated_getter_factory("detailed_status", "detailed_status"),
             )
+        if not Span.has_extension("negation"):
+            Span.set_extension("negation", default=None)
+        if not Span.has_extension("negation_"):
+            Span.set_extension(
+                "negation_",
+                getter=lambda item: "NEG"
+                if item._.negation is True
+                else "AFF"
+                if item._.negation is False
+                else None,
+            )
 
     def __call__(self, doc: Doc) -> Doc:
         """
@@ -104,6 +115,8 @@ class DisorderMatcher(ContextualMatcher):
         spans = list(self.process(doc))
         for span in spans:
             span._.detailed_status = self.detailed_status_mapping[span._.status]
+            if span._.status == 0:
+                span._.negation = True
 
         self.set_spans(doc, filter_spans(spans))
 

--- a/edsnlp/pipelines/qualifiers/hypothesis/patterns.py
+++ b/edsnlp/pipelines/qualifiers/hypothesis/patterns.py
@@ -1,6 +1,4 @@
-from typing import List
-
-pseudo: List[str] = [
+pseudo = [
     "aucun doute",
     "même si",
     "pas de condition",
@@ -10,7 +8,7 @@ pseudo: List[str] = [
     "sans risque",
 ]
 
-confirmation: List[str] = [
+confirmation = [
     "certain",
     "certaine",
     "certainement",
@@ -24,7 +22,7 @@ confirmation: List[str] = [
     "visiblement",
 ]
 
-preceding: List[str] = [
+preceding = [
     "à condition",
     "à la condition que",
     "à moins que",
@@ -75,7 +73,7 @@ preceding: List[str] = [
     "suspicion",
 ]
 
-following: List[str] = [
+following = [
     "?",
     "envisageable",
     "envisageables",
@@ -103,7 +101,7 @@ following: List[str] = [
     "probables",
 ]
 
-verbs_hyp: List[str] = [
+verbs_hyp = [
     "douter",
     "envisager",
     "explorer",
@@ -115,7 +113,7 @@ verbs_hyp: List[str] = [
     "suspecter",
 ]
 
-verbs_eds: List[str] = [
+verbs_eds = [
     "abandonner",
     "abolir",
     "aborder",

--- a/edsnlp/pipelines/qualifiers/negation/factory.py
+++ b/edsnlp/pipelines/qualifiers/negation/factory.py
@@ -7,6 +7,7 @@ from .negation import NegationQualifier
 DEFAULT_CONFIG = dict(
     pseudo=None,
     preceding=None,
+    preceding_regex=None,
     following=None,
     verbs=None,
     termination=None,

--- a/edsnlp/pipelines/qualifiers/negation/patterns.py
+++ b/edsnlp/pipelines/qualifiers/negation/patterns.py
@@ -83,6 +83,11 @@ preceding: List[str] = [
     "symptôme atypique",
 ]
 
+preceding_regex = [
+    # ne (up to 3 words separated by spaces or newlines) pas/point/...
+    r"ne(?=[ \n]*(?:\w*[ \n]*){3}(?:pas|point|ni|aucun|jamais|rien))"
+]
+
 following: List[str] = [
     ":0",
     ": 0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "regex",
     "rich>=12.0.0",
     "scikit-learn>=1.0.0",
-    "spacy>=3.1,<3.5.0",
+    "spacy>=3.1,<4.0.0",
     "thinc>=8.1.10",
     "tqdm",
     "umls-downloader>=0.1.1",

--- a/tests/pipelines/ner/disorders/test_all.py
+++ b/tests/pipelines/ner/disorders/test_all.py
@@ -113,3 +113,26 @@ def test_disorder(normalized_nlp, disorder):
     )
 
     expect.check()
+
+
+def test_behavior_negation(blank_nlp):
+    blank_nlp.add_pipe("eds.normalizer")
+    blank_nlp.add_pipe("eds.tobacco")
+    blank_nlp.add_pipe("eds.alcohol")
+    blank_nlp.add_pipe("eds.negation")
+
+    negated_texts = [
+        "Le patient ne fume aucun truc.",
+        "Le patient fume 0 PA.",
+        "Il ne boit pas d'alcool." "Boit très rarement de l'alcool.",
+    ]
+
+    positive_texts = ["Le patient ne fume que le soir.", "Il ne boit plus d'alcool."]
+
+    for text in negated_texts:
+        doc = blank_nlp(text)
+        assert doc.ents[0]._.negation is True, text
+
+    for text in positive_texts:
+        doc = blank_nlp(text)
+        assert doc.ents[0]._.negation is False, text

--- a/tests/pipelines/qualifiers/test_negation.py
+++ b/tests/pipelines/qualifiers/test_negation.py
@@ -24,6 +24,9 @@ negation_examples: List[str] = [
     "il n'y a pas d'<ent polarity_=NEG>métastases</ent>",
     "il n'y a pas d'amélioration de la <ent negated=false>maladie</ent>",
     "<ent negated=true>maladie écartée",
+    "Le patient ne <ent negated=true>fume</ent> pas.",
+    "Le patient ne <ent negated=true>fume vraiment vraiment</ent> pas.",
+    "Le patient ne <ent negated=false>fume</ent> que des cigares.",
 ]
 
 


### PR DESCRIPTION
## Description

- match 'ne ... pas/point/aucun/...' as negation
- set `negation = True` when disorder / behavior status is "ABSENT"
- default "ent._.negation/family/hypothesis/history/reported_speech" to None

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
