### PR TITLE
bumping spacy to version 3.6.X

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "regex",
     "rich>=12.0.0",
     "scikit-learn>=1.0.0",
-    "spacy>=3.1,<3.5.0",
+    "spacy>=3.1,<3.7.0",
     "thinc>=8.1.10",
     "tqdm",
     "umls-downloader>=0.1.1",


### PR DESCRIPTION
Bumping latest version of spacy

## Description

Bumping spacy dependency to versions 3.6.X


## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
