### PR TITLE
Chore: bump version to 0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install edsnlp
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.9.0
+pip install edsnlp==0.9.1
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.9.1
+
+## Changed
+
+- Improve negation patterns
+- Abstent disorders now set the negation to True when matched as `ABSENT`
+- Default qualifier is now `None` instead of `False` (empty string)
+
+### Fixed
+
+- `span_getter` is not incompatible with on_ents_only anymore
+- `ContextualMatcher` now supports empty matches (e.g. lookahead/lookbehind) in `assign` patterns
+
 ## v0.9.0
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ color:green Successfully installed!
 We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```
-pip install edsnlp==0.9.0
+pip install edsnlp==0.9.1
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -8,6 +8,6 @@ from pathlib import Path
 from . import extensions
 from .language import *
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 BASE_DIR = Path(__file__).parent


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

## Changed

- Improve negation patterns
- Abstent disorders now set the negation to True when matched as `ABSENT`
- Default qualifier is now `None` instead of `False` (empty string)

### Fixed

- `span_getter` is not incompatible with on_ents_only anymore
- `ContextualMatcher` now supports empty matches (e.g. lookahead/lookbehind) in `assign` patterns

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
