### PR TITLE
Isolate edsnlp entry points to prevent auto-import by spacy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Microgram scale is now correctly 1/1000g and inverse meter now 1/100 inverse cm.
+- We now isolate some of edsnlp components (trainable pipes that require ml dependencies)
+  in a new `edsnlp_factories` entry points to prevent spacy from auto-importing them.
 
 ## v0.10.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,14 +170,6 @@ where = ["."]
 "eds.sections"                    = "edsnlp.pipes.misc.sections.factory:create_component"
 "eds.tables"                      = "edsnlp.pipes.misc.tables.factory:create_component"
 
-# Trainable
-"eds.transformer"                 = "edsnlp.pipes.trainable.embeddings.transformer.factory:create_component"
-"eds.text_cnn"                    = "edsnlp.pipes.trainable.embeddings.text_cnn.factory:create_component"
-"eds.span_pooler"                 = "edsnlp.pipes.trainable.embeddings.span_pooler.factory:create_component"
-"eds.ner_crf"                     = "edsnlp.pipes.trainable.ner_crf.factory:create_component"
-"eds.nested_ner"                  = "edsnlp.pipes.trainable.ner_crf.factory:create_component"
-"eds.span_qualifier"               = "edsnlp.pipes.trainable.span_qualifier.factory:create_component"
-
 # Deprecated (links to the same factories as above)
 "SOFA"                   = "edsnlp.pipes.ner.scores.sofa.factory:create_component"
 "accents"                = "edsnlp.pipes.core.normalizer.accents.factory:create_component"
@@ -219,6 +211,20 @@ where = ["."]
 "spaces"                 = "edsnlp.pipes.core.normalizer.spaces.factory:create_component"
 "tables"                 = "edsnlp.pipes.misc.tables.factory:create_component"
 "terminology"            = "edsnlp.pipes.core.terminology.factory:create_component"
+
+# We could use spacy_factories in principle, but spacy auto-imports all entry points
+# by default, when some of ours require optional dependencies (on the other hand,
+# edsnlp only import an entrypoint if it is requested). By splitting our pipes between
+# spacy_factories and edsnlp_factories, spacy will only look in the dict above and
+# edsnlp will look both in the above dict and in the one below.
+[project.entry-points."edsnlp_factories"]
+# Trainable
+"eds.transformer"                 = "edsnlp.pipes.trainable.embeddings.transformer.factory:create_component"
+"eds.text_cnn"                    = "edsnlp.pipes.trainable.embeddings.text_cnn.factory:create_component"
+"eds.span_pooler"                 = "edsnlp.pipes.trainable.embeddings.span_pooler.factory:create_component"
+"eds.ner_crf"                     = "edsnlp.pipes.trainable.ner_crf.factory:create_component"
+"eds.nested_ner"                  = "edsnlp.pipes.trainable.ner_crf.factory:create_component"
+"eds.span_qualifier"               = "edsnlp.pipes.trainable.span_qualifier.factory:create_component"
 
 [project.entry-points."spacy_scorers"]
 "eds.ner_exact_scorer"           = "edsnlp.scorers.ner:create_ner_exact_scorer"


### PR DESCRIPTION
## Description

Fixes #234 

Since edsnlp 0.10.0, some of our components require optional dependencies (torch, transformers, etc).
By default, `pip install edsnlp` does not install these, so importing one of these components (e.g., `eds.transformer`) will fail.

It is not an issue when building a pipeline via `edsnlp.blank(...)` since we only load entry points when required, so a user that does not add these components will face no issue. However, as demonstrated by #234, when using `spacy.blank` or `spacy.load` spacy will look into all spacy_factories entry point and try to load them all, and fail when encountering one of the components mentioned previously.

To solve that,  we split our components between two namespaces, `spacy_factories` and a new `edsnlp_factories` namespace : now spacy will only look in the first namespace, while edsnlp will look in both.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
