### PR TITLE
Enable mmap during multiprocessing model transfers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - TNM scores followed by a space are now correctly detected
 - Removed various short TNM false positives (e.g., "PT" or "a   T")
 - The Span value extension is not more forcibly overwritten, and user assigned values are returned by `Span._.value` in priority, before the aggregated `span._.get(span.label_)` getter result (#220)
+- Enable mmap during multiprocessing model transfers
 
 ## v0.10.0
 

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -126,7 +126,7 @@ if (
 ):
     replace_pickler()
 
-DEBUG = False
+DEBUG = True
 
 debug = (
     (lambda *args, flush=False, **kwargs: print(*args, **kwargs, flush=True))
@@ -177,7 +177,7 @@ try:
     def load(*args, map_location=None, **kwargs):
         global MAP_LOCATION
         MAP_LOCATION = map_location
-        if torch.__version__ >= "2.1.2":
+        if torch.__version__ >= "2.1" and isinstance(args[0], str):
             kwargs["mmap"] = True
         result = torch.load(
             *args,
@@ -329,8 +329,7 @@ class CPUWorker:
                 else:
                     yield stage, task
 
-        with open(self.lazy_collection_path, "rb") as f:
-            lc = load(f, map_location=self.device)
+        lc = load(self.lazy_collection_path, map_location=self.device)
         # for name, pipe, *rest in lc.pipeline:
         #    move_to_device(pipe, self.device)
 
@@ -442,8 +441,7 @@ class GPUWorker:
         # mp._prctl_pr_set_pdeathsig(signal.SIGINT)
         had_error = False
 
-        with open(self.lazy_collection_path, "rb") as f:
-            lc = load(f, map_location=self.device)
+        lc = load(self.lazy_collection_path, map_location=self.device)
         stage_components = [
             pipe
             # move_to_device(pipe, self.device)


### PR DESCRIPTION
## Description

Torch 2.1.2 allowed us to detect that we didn't use mmap when loading the model to run in multiprocessing. This PR fixes this.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
