### PR TITLE
Bump version to 0.10.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.10.1
 
 ### Changed
 
@@ -12,7 +12,7 @@
 - We now isolate some of edsnlp components (trainable pipes that require ml dependencies)
   in a new `edsnlp_factories` entry points to prevent spacy from auto-importing them.
 - TNM scores followed by a space are now correctly detected
-- Removed various short TNM false positives (e.g., "PT" or "a   T")
+- Removed various short TNM false positives (e.g., "PT" or "a   T") and false negatives
 - The Span value extension is not more forcibly overwritten, and user assigned values are returned by `Span._.value` in priority, before the aggregated `span._.get(span.label_)` getter result (#220)
 - Enable mmap during multiprocessing model transfers
 - `RegexMatcher` now supports all alignment modes (`strict`, `expand`, `contract`) and better handles partial doc matching (#201).

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -14,7 +14,7 @@ from .core.registry import registry
 import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 BASE_DIR = Path(__file__).parent
 


### PR DESCRIPTION
## Changelog

### Changed

- Small regex matching performance improvement, up to 1.25x faster (e.g. `eds.measurements`)

### Fixed

- Microgram scale is now correctly 1/1000g and inverse meter now 1/100 inverse cm.
- We now isolate some of edsnlp components (trainable pipes that require ml dependencies)
  in a new `edsnlp_factories` entry points to prevent spacy from auto-importing them.
- TNM scores followed by a space are now correctly detected
- Removed various short TNM false positives (e.g., "PT" or "a   T") and false negatives
- The Span value extension is not more forcibly overwritten, and user assigned values are returned by `Span._.value` in priority, before the aggregated `span._.get(span.label_)` getter result (#220)
- Enable mmap during multiprocessing model transfers
- `RegexMatcher` now supports all alignment modes (`strict`, `expand`, `contract`) and better handles partial doc matching (#201).
- `on_ent_only=False/True` is now supported again in qualifier pipes (e.g., "eds.negation", "eds.hypothesis", ...)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
