### PR TITLE
Fix for (#242): connectors not working brat json training issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 
 - Measurements now correctly match "0.X", "0.XX", ... numbers
 - Typo in "celsius" measurement unit
+- Spaces and digits are now supported in BRAT entity labels
 
 ## v0.10.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- By default, `edsnlp.data.write_json` will infer if the data should be written as a single JSONL
+  file or as a directory of JSON files, based on the `path` argument being a file or not.
+
 ### Fixed
 
 - Measurements now correctly match "0.X", "0.XX", ... numbers

--- a/docs/tutorials/make-a-training-script.md
+++ b/docs/tutorials/make-a-training-script.md
@@ -167,7 +167,7 @@ training loop
     with nlp.cache():
         loss = torch.zeros((), device="cpu")
         for name, component in nlp.torch_components():
-            output = component.module_forward(batch[component.name])  # (1)
+            output = component.module_forward(batch[name])  # (1)
             if "loss" in output:
                 loss += output["loss"]
 
@@ -194,13 +194,13 @@ scorer = create_ner_exact_scorer(nlp.get_pipe('ner').target_span_getter)
         with nlp.select_pipes(enable=["ner"]):  # (1)
             print(scorer(val_docs, nlp.pipe(deepcopy(val_docs))))  # (2)
 
-    nlp.save("model")  # (3)
+    nlp.to_disk("model")  # (3)
 ```
 
 1. In the case we have multiple pipes in our model, we may want to selectively evaluate each pipe, thus we use the `select_pipes` method to disable every pipe except "ner".
 2. We use the `pipe` method to run the "ner" component on the validation dataset. This method is similar to the `__call__` method of EDS-NLP components, but it is used to run a component on a list of
    spaCy Docs.
-3. We could also have saved the model with `torch.save(model, "model.pt")`, but `nlp.save` avoids pickling and allows to inspect the model's files by saving them into a structured directory.
+3. We could also have saved the model with `torch.save(model, "model.pt")`, but `nlp.to_disk` avoids pickling and allows to inspect the model's files by saving them into a structured directory.
 
 ## Full example
 
@@ -298,7 +298,7 @@ Let's wrap the training code in a function, and make it callable from the comman
             loss = torch.zeros((), device="cpu")
             with nlp.cache():
                 for name, component in nlp.torch_components():
-                    output = component.module_forward(batch[component.name])
+                    output = component.module_forward(batch[name])
                     if "loss" in output:
                         loss += output["loss"]
 

--- a/edsnlp/connectors/brat.py
+++ b/edsnlp/connectors/brat.py
@@ -45,6 +45,7 @@ class BratConnector(object):
         directory: Union[str, Path],
         n_jobs: int = 1,
         attributes: Optional[AttributesMappingArg] = None,
+        bool_attributes: Optional[List[str]] = [],
         span_groups: SpanSetterArg = ["ents", "*"],
         keep_raw_attribute_values: bool = False,
     ):
@@ -57,6 +58,7 @@ class BratConnector(object):
         self.attr_map = attributes
         self.span_setter = validate_span_setter(span_groups)
         self.keep_raw_attribute_values = keep_raw_attribute_values
+        self.bool_attributes = list(bool_attributes)
 
     def brat2docs(self, nlp: PipelineProtocol, run_pipe=False) -> List[Doc]:
         res = read_standoff(
@@ -66,7 +68,7 @@ class BratConnector(object):
             span_attributes=self.attr_map,
             span_setter=self.span_setter,
             keep_raw_attribute_values=self.keep_raw_attribute_values,
-            bool_attributes=[],
+            bool_attributes=self.bool_attributes,
         )
         return list(nlp.pipe(res) if run_pipe else res)
 

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -179,7 +179,7 @@ class StandoffDict2DocConverter:
     ):
         self.tokenizer = tokenizer or (nlp.tokenizer if nlp is not None else None)
         self.span_setter = span_setter
-        self.span_attributes = span_attributes
+        self.span_attributes = span_attributes  # type: ignore
         self.keep_raw_attribute_values = keep_raw_attribute_values
         self.bool_attributes = bool_attributes
 
@@ -190,10 +190,12 @@ class StandoffDict2DocConverter:
 
         spans = []
 
-        if self.span_attributes is not None:
-            for dst in self.span_attributes.values():
-                if not Span.has_extension(dst):
-                    Span.set_extension(dst, default=None)
+        for dst in (
+            *(() if self.span_attributes is None else self.span_attributes.values()),
+            *self.bool_attributes,
+        ):
+            if not Span.has_extension(dst):
+                Span.set_extension(dst, default=None)
 
         for ent in obj.get("entities") or ():
             for fragment in ent["fragments"]:
@@ -351,10 +353,12 @@ class OmopDict2DocConverter:
 
         spans = []
 
-        if self.span_attributes is not None:
-            for dst in self.span_attributes.values():
-                if not Span.has_extension(dst):
-                    Span.set_extension(dst, default=None)
+        for dst in (
+            *(() if self.span_attributes is None else self.span_attributes.values()),
+            *self.bool_attributes,
+        ):
+            if not Span.has_extension(dst):
+                Span.set_extension(dst, default=None)
 
         for ent in obj.get("entities") or ():
             ent = dict(ent)

--- a/edsnlp/data/standoff.py
+++ b/edsnlp/data/standoff.py
@@ -29,10 +29,10 @@ from edsnlp.data.converters import (
 from edsnlp.utils.collections import flatten_once
 from edsnlp.utils.span_getters import SpanSetterArg
 
-REGEX_ENTITY = re.compile(r"^(T\d+)\t(\S+)([^\t]+)\t(.*)$")
+REGEX_ENTITY = re.compile(r"^(T\d+)\t(.*) (\d+ \d+(?:;\d+ \d+)*)\t(.*)$")
 REGEX_NOTE = re.compile(r"^(#\d+)\tAnnotatorNotes ([^\t]+)\t(.*)$")
 REGEX_RELATION = re.compile(r"^(R\d+)\t(\S+) Arg1:(\S+) Arg2:(\S+)")
-REGEX_ATTRIBUTE = re.compile(r"^([AM]\d+)\t(.+)$")
+REGEX_ATTRIBUTE = re.compile(r"^([AM]\d+)\t(.+?) ([TE]\d+)(?: (.+))?$")
 REGEX_EVENT = re.compile(r"^(E\d+)\t(.+)$")
 REGEX_EVENT_PART = re.compile(r"(\S+):([TE]\d+)")
 
@@ -131,19 +131,14 @@ def parse_standoff_file(path: str, merge_spaced_fragments: bool = True) -> Dict:
                         match = REGEX_ATTRIBUTE.match(line)
                         if match is None:
                             raise BratParsingError(ann_file, line)
-                        parts = match.group(2).split(" ")
-                        if len(parts) >= 3:
-                            entity, entity_id, value = parts
-                        elif len(parts) == 2:
-                            entity, entity_id = parts
-                            value = None
-                        else:
+                        _, attr_name, entity_id, value = match.groups()
+                        if attr_name is None:
                             raise BratParsingError(ann_file, line)
                         (
                             entities[entity_id]
                             if entity_id.startswith("T")
                             else events[entity_id]
-                        )["attributes"][entity] = value
+                        )["attributes"][attr_name] = value
                     elif line.startswith("R"):
                         match = REGEX_RELATION.match(line)
                         if match is None:

--- a/tests/data/test_json.py
+++ b/tests/data/test_json.py
@@ -220,6 +220,16 @@ def test_read_to_json(blank_nlp, tmpdir):
         lines=True,
     )
 
+    with pytest.raises(FileExistsError):
+        edsnlp.data.write_json(
+            [doc],
+            output_dir / "docs.jsonl",
+            converter="omop",
+            doc_attributes=["context_var"],
+            span_attributes=["etat", "assertion"],
+            span_getter=["ents", "sosy", "localisation", "anatomie", "pathologie"],
+        )
+
     with open(output_dir / "docs.jsonl") as f:
         exported_obj = json.loads(f.readlines()[0])
     assert_doc_write(exported_obj)

--- a/tests/resources/brat_data/subfolder/doc-1.ann
+++ b/tests/resources/brat_data/subfolder/doc-1.ann
@@ -4,6 +4,7 @@ T2	localisation 39 57	dans le bras droit
 T3	anatomie 47 57	bras droit
 T4	pathologie 75 83;85 98	problème de locomotion
 A1	assertion T4 absent
+A9	bool flag 0 T4
 T5	pathologie 114 117	AVC
 A2	etat T5 passé
 A3	assertion T5 non-associé
@@ -22,3 +23,4 @@ R2	lieu Arg1:T1 Arg2:T2
 A8	assertion T11 absent
 E1	MyArg1:T3 MyArg2:T1
 E2	MyArg1:T1 MyArg2:E1
+T12	test label 0 378 386	anomalie


### PR DESCRIPTION
## Description

This should mostly fix #242.

- Fixes various errors in the docs
- Add an explanation for BRAT boolean attributes issue 
- Makes `edsnlp.data.write_json` more verbose and smarter : when `lines` is left to None, it will now infer if the data should be written as a single JSONL file or as a directory of JSON files by default, based on the `path` argument being a file or not.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
