### PR TITLE
Bump version to 0.10.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.10.4
 
 ### Changed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.10.3
+pip install edsnlp==0.10.4
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.10.3"
+pip install "edsnlp[ml]==0.10.4"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -14,7 +14,7 @@ from .core.registries import registry
 import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 
 BASE_DIR = Path(__file__).parent
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Changed

- Assigning `doc._.note_datetime` will now automatically cast the value to a `pendulum.DateTime` object

### Added

- Support loading model from package name (e.g., `edsnlp.load("eds_pseudo_aphp")`)
- Support filesystem parameter in `edsnlp.data.read_parquet` and `edsnlp.data.write_parquet`

### Fixed

- Support doc -> list converters with parquet files writer
- Fixed some OOM errors when writing many outputs to parquet files
- Both edsnlp & spacy factories are now listed when a factory lookup fails
- Fixed some GPU OOM errors with the `eds.transformer` pipe when processing really long documents

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
