### PR TITLE
Multi head ml

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,7 @@
 name: Documentation
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests and Linting
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [master]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `batch_by`, `split_into_batches_after`, `sort_chunks`, `chunk_size`, `disable_implicit_parallelism` parameters to processing (`simple` and `multiprocessing`) backends to improve performance and memory usage. Sorting chunks can improve yield up to **twice the speed** in some cases.
+- The deep learning cache mechanism now supports multitask models with weight sharing in multiprocessing mode.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@
 - Added `batch_by`, `split_into_batches_after`, `sort_chunks`, `chunk_size`, `disable_implicit_parallelism` parameters to processing (`simple` and `multiprocessing`) backends to improve performance and memory usage. Sorting chunks can improve yield up to **twice the speed** in some cases.
 - The deep learning cache mechanism now supports multitask models with weight sharing in multiprocessing mode.
 
+### Changed
+
+- Improved speed and memory usage of the `eds.text_cnn` pipe by running the CNN on a non-padded version of its input: expect a speedup up to 1.3x in real-world use cases.
+
 ### Fixed
 
 - Improved error handling in `multiprocessing` backend (e.g., no more deadlock)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added `batch_by`, `split_into_batches_after`, `sort_chunks`, `chunk_size`, `disable_implicit_parallelism` parameters to processing (`simple` and `multiprocessing`) backends to improve performance and memory usage. Sorting chunks can improve yield up to **twice the speed** in some cases.
+
+### Fixed
+
+- Improved error handling in `multiprocessing` backend (e.g., no more deadlock)
+
 ## v0.10.5
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Added `batch_by`, `split_into_batches_after`, `sort_chunks`, `chunk_size`, `disable_implicit_parallelism` parameters to processing (`simple` and `multiprocessing`) backends to improve performance and memory usage. Sorting chunks can improve yield up to **twice the speed** in some cases.
 - The deep learning cache mechanism now supports multitask models with weight sharing in multiprocessing mode.
+- Added `max_tokens_per_device="auto"` parameter to `eds.transformer` to estimate memory usage and automatically split the input into chunks that fit into the GPU.
 
 ### Changed
 

--- a/docs/concepts/inference.md
+++ b/docs/concepts/inference.md
@@ -70,6 +70,16 @@ data = data.set_processing(
     num_cpu_workers=4,
     # 2 GPUs to accelerate deep-learning pipes
     num_gpu_workers=2,
+
+    # Below are further options to finetune the inference throughput:
+    # Read chunks of 1024 documents before splitting them into batches
+    chunk_size=1024,
+    # Sort the documents by length before splitting them into batches
+    sort_chunks=True,
+    # Split batches such that each contains at most 100 000 padded words
+    # (padded_words = max doc size in batch * batch size)
+    batch_size=100_000,
+    batch_by="padded_words",
 )
 
 # Write the result, this will execute the lazy collection

--- a/edsnlp/core/lazy_collection.py
+++ b/edsnlp/core/lazy_collection.py
@@ -340,6 +340,36 @@ class LazyCollection(metaclass=MetaLazyCollection):
             pipe.to(device)
         return self
 
+    def train(self, mode=True):
+        """
+        Enables training mode on pytorch modules
+
+        Parameters
+        ----------
+        mode: bool
+            Whether to enable training or not
+        """
+
+        class context:
+            def __enter__(self):
+                pass
+
+            def __exit__(ctx_self, type, value, traceback):
+                for name, proc in self.torch_components():
+                    proc.train(was_training[name])
+
+        was_training = {name: proc.training for name, proc in self.torch_components()}
+        for name, proc in self.torch_components():
+            proc.train(mode)
+
+        return context()
+
+    def eval(self):
+        """
+        Enables evaluation mode on pytorch modules
+        """
+        return self.train(False)
+
     def worker_copy(self):
         return LazyCollection(
             reader=self.reader.worker_copy(),

--- a/edsnlp/core/lazy_collection.py
+++ b/edsnlp/core/lazy_collection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import sys
+from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -26,6 +27,14 @@ if TYPE_CHECKING:
     from edsnlp.data.base import BaseReader, BaseWriter
 
 INFER = type("INFER", (), {"__repr__": lambda self: "INFER"})()
+
+
+def with_non_default_args(fn: Callable) -> Callable:
+    @wraps(fn)
+    def wrapper(self, **kwargs):
+        return fn(self, **kwargs, _non_default_args=kwargs.keys())
+
+    return wrapper
 
 
 class MetaLazyCollection(type):
@@ -58,6 +67,26 @@ class LazyCollection(metaclass=MetaLazyCollection):
         return self.config.get("batch_size", 1)
 
     @property
+    def batch_by(self):
+        return self.config.get("batch_by", "docs")
+
+    @property
+    def sort_chunks(self):
+        return self.config.get("sort_chunks", False)
+
+    @property
+    def split_into_batches_after(self):
+        return self.config.get("split_into_batches_after")
+
+    @property
+    def chunk_size(self):
+        return self.config.get("chunk_size", self.config.get("batch_size", 128))
+
+    @property
+    def disable_implicit_parallelism(self):
+        return self.config.get("disable_implicit_parallelism", True)
+
+    @property
     def num_cpu_workers(self):
         return self.config.get("num_cpu_workers")
 
@@ -83,30 +112,60 @@ class LazyCollection(metaclass=MetaLazyCollection):
 
     @property
     def show_progress(self):
-        return self.config.get("show_progress")
+        return self.config.get("show_progress", False)
 
     @property
     def process_start_method(self):
         return self.config.get("process_start_method")
 
+    @with_non_default_args
     def set_processing(
         self,
-        batch_size: int = INFER,
-        num_cpu_workers: int = INFER,
-        num_gpu_workers: int = INFER,
-        backend: Literal["simple", "multiprocessing", "spark"] = INFER,
-        gpu_pipe_names: List[str] = INFER,
-        show_progress: bool = INFER,
-        process_start_method: bool = INFER,
-        gpu_worker_devices: List[str] = INFER,
-        cpu_worker_devices: List[str] = INFER,
+        batch_size: int = 1,
+        batch_by: Literal["docs", "words", "padded_words"] = "docs",
+        chunk_size: int = INFER,
+        sort_chunks: bool = False,
+        split_into_batches_after: str = INFER,
+        num_cpu_workers: Optional[int] = INFER,
+        num_gpu_workers: Optional[int] = INFER,
+        disable_implicit_parallelism: bool = True,
+        backend: Optional[Literal["simple", "multiprocessing", "spark"]] = INFER,
+        gpu_pipe_names: Optional[List[str]] = INFER,
+        show_progress: bool = False,
+        process_start_method: Optional[Literal["fork", "spawn"]] = INFER,
+        gpu_worker_devices: Optional[List[str]] = INFER,
+        cpu_worker_devices: Optional[List[str]] = INFER,
+        _non_default_args: Iterable[str] = (),
     ) -> "LazyCollection":
         """
         Parameters
         ----------
         batch_size: int
-            Number of documents to process at a time in a CPU/GPU worker (or in the
+            Number of documents to process at a time in a GPU worker (or in the
             main process if no workers are used).
+        batch_by: Literal["docs", "words", "padded_words"]
+            How to compute the batch size. Can be "docs" or "words" :
+
+            - "docs" (default) is the number of documents.
+            - "words" is the total number of words in the documents.
+            - "padded_words" is the total number of words in the documents, including
+               padding, assuming the documents are padded to the same length.
+        chunk_size: int
+            Number of documents to build before splitting into batches. Only used
+            with "simple" and "multiprocessing" backends. This is also the number of
+            documents that will be passed through the first components of the pipeline
+            until a GPU worker is used (then the chunks will be split according to the
+            `batch_size` and `batch_by` arguments).
+
+            By default, the chunk size is equal to the batch size, or 128 if the batch
+            size is not set.
+        sort_chunks: bool
+            Whether to sort the documents by size before splitting into batches.
+        split_into_batches_after: str
+            The name of the component after which to split the documents into batches.
+            Only used with "simple" and "multiprocessing" backends.
+            By default, the documents are split into batches as soon as the input
+            are converted into Doc objects.
         num_cpu_workers: int
             Number of CPU workers. A CPU worker handles the non deep-learning components
             and the preprocessing, collating and postprocessing of deep-learning
@@ -115,9 +174,13 @@ class LazyCollection(metaclass=MetaLazyCollection):
         num_gpu_workers: Optional[int]
             Number of GPU workers. A GPU worker handles the forward call of the
             deep-learning components. Only used with "multiprocessing" backend.
+        disable_implicit_parallelism: bool
+            Whether to disable OpenMP and Huggingface tokenizers implicit parallelism in
+            multiprocessing mode. Defaults to True.
         gpu_pipe_names: Optional[List[str]]
             List of pipe names to accelerate on a GPUWorker, defaults to all pipes
             that inherit from TorchComponent. Only used with "multiprocessing" backend.
+            Inferred from the pipeline if not set.
         backend: Optional[Literal["simple", "multiprocessing", "spark"]]
             The backend to use for parallel processing. If not set, the backend is
             automatically selected based on the input data and the number of workers.
@@ -131,9 +194,9 @@ class LazyCollection(metaclass=MetaLazyCollection):
         show_progress: Optional[bool]
             Whether to show progress bars (only applicable with "simple" and
             "multiprocessing" backends).
-        process_start_method: Optional[bool]
+        process_start_method: Optional[Literal["fork", "spawn"]]
             Whether to use "fork" or "spawn" as the start method for the multiprocessing
-            backend.
+            backend. The default is "fork" on Unix systems and "spawn" on Windows.
 
             - "fork" is the default start method on Unix systems and is the fastest
                 start method, but it is not available on Windows, can cause issues
@@ -151,8 +214,7 @@ class LazyCollection(metaclass=MetaLazyCollection):
         -------
         LazyCollection
         """
-        kwargs = dict(locals())
-        kwargs.pop("self")
+        kwargs = {k: v for k, v in locals().items() if k in _non_default_args}
         return LazyCollection(
             reader=self.reader,
             writer=self.writer,

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -352,10 +352,10 @@ class Pipeline:
 
     def pipe(
         self,
-        inputs: Any,
+        inputs: Union[Iterable, LazyCollection],
         batch_size: Optional[int] = None,
         n_process: int = None,
-    ) -> Iterable[Doc]:
+    ) -> LazyCollection:
         """
         Process a stream of documents by applying each component successively on
         batches of documents.

--- a/edsnlp/core/torch_component.py
+++ b/edsnlp/core/torch_component.py
@@ -54,7 +54,11 @@ def cached_preprocess(fn):
     def wrapped(self: "TorchComponent", doc: Doc):
         if self._current_cache_id is None:
             return fn(self, doc)
-        cache_key = ("preprocess", f"{type(self)}<{id(self)}>: {id(doc)}")
+        cache_key = (
+            "preprocess",
+            f"{type(self).__name__}<{id(self)}>",
+            id(doc),
+        )
         cache = _caches[self._current_cache_id]
         if cache_key in cache:
             return cache[cache_key]
@@ -70,7 +74,11 @@ def cached_preprocess_supervised(fn):
     def wrapped(self: "TorchComponent", doc: Doc):
         if self._current_cache_id is None:
             return fn(self, doc)
-        cache_key = ("preprocess_supervised", f"{type(self)}<{id(self)}>: {id(doc)}")
+        cache_key = (
+            "preprocess_supervised",
+            f"{type(self).__name__}<{id(self)}>",
+            id(doc),
+        )
         cache = _caches[self._current_cache_id]
         if cache_key in cache:
             return cache[cache_key]
@@ -86,11 +94,17 @@ def cached_collate(fn):
     def wrapped(self: "TorchComponent", batch: Dict):
         if self._current_cache_id is None:
             return fn(self, batch)
-        cache_key = ("collate", f"{type(self)}<{id(self)}>: {hash_batch(batch)}")
+        batch_hash = hash_batch(batch)
+        cache_key = (
+            "collate",
+            f"{type(self).__name__}<{id(self)}>",
+            batch_hash,
+        )
         cache = _caches[self._current_cache_id]
         if cache_key in cache:
             return cache[cache_key]
         res = fn(self, batch)
+        res["__batch_hash__"] = batch_hash
         cache[cache_key] = res
         return res
 
@@ -103,7 +117,11 @@ def cached_forward(fn):
         # Convert args and kwargs to a dictionary matching fn signature
         if self._current_cache_id is None:
             return fn(self, batch)
-        cache_key = ("forward", f"{type(self)}<{id(self)}>: {hash_batch(batch)}")
+        cache_key = (
+            "forward",
+            f"{type(self).__name__}<{id(self)}>",
+            hash_batch(batch),
+        )
         cache = _caches[self._current_cache_id]
         if cache_key in cache:
             return cache[cache_key]
@@ -122,7 +140,8 @@ def cached_batch_to_device(fn):
             return fn(self, batch, device)
         cache_key = (
             "batch_to_device",
-            f"{type(self)}<{id(self)}>: {hash_batch(batch)}",
+            f"{type(self).__name__}<{id(self)}>",
+            hash_batch(batch),
         )
         cache = _caches[self._current_cache_id]
         if cache_key in cache:

--- a/edsnlp/data/parquet.py
+++ b/edsnlp/data/parquet.py
@@ -60,17 +60,15 @@ class ParquetReader(BaseReader):
             return (
                 (line, 1)
                 for f in fragments
-                for batch in f.to_table().to_batches(1024)
-                for line in dl_to_ld(batch.to_pydict())
+                # for line in make_longer(dl_to_ld(f.to_table().to_pydict()))
+                for line in dl_to_ld(f.to_table().to_pydict())
             )
 
     def read_worker(self, tasks):
         if self.read_in_worker:
             tasks = list(
                 chain.from_iterable(
-                    dl_to_ld(batch.to_pydict())
-                    for task in tasks
-                    for batch in task.to_table().to_batches(1024)
+                    dl_to_ld(task.to_table().to_pydict()) for task in tasks
                 )
             )
         return tasks
@@ -183,6 +181,53 @@ def read_parquet(
     filesystem: Optional[pyarrow.fs.FileSystem] = None,
     **kwargs,
 ) -> LazyCollection:
+    """
+    The ParquetReader (or `edsnlp.data.read_parquet`) reads a directory of parquet files
+    (or a single file) and yields documents.
+
+    Example
+    -------
+    ```{ .python .no-check }
+
+    import edsnlp
+
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(...)
+    doc_iterator = edsnlp.data.read_parquet("path/to/parquet", converter="omop")
+    annotated_docs = nlp.pipe(doc_iterator)
+    ```
+
+    !!! note "Generator vs list"
+
+        `edsnlp.data.read_parquet` returns a
+        [LazyCollection][edsnlp.core.lazy_collection.LazyCollection].
+        To iterate over the documents multiple times efficiently or to access them by
+        index, you must convert it to a list
+
+        ```{ .python .no-check }
+        docs = list(edsnlp.data.read_parquet("path/to/parquet", converter="omop"))
+        ```
+
+    Parameters
+    ----------
+    path: Union[str, Path]
+        Path to the directory containing the parquet files (will recursively look for
+        files in subdirectories). Supports any filesystem supported by pyarrow.
+    converter: Optional[Union[str, Callable]]
+        Converter to use to convert the parquet rows of the data source to Doc objects
+    read_in_worker: bool
+        Whether to read the files in the worker or in the main process.
+    filesystem: Optional[pyarrow.fs.FileSystem]
+        The filesystem to use to read the files. If None, the filesystem will be
+        inferred from the path (e.g. `s3://` will use S3).
+    kwargs:
+        Additional keyword arguments to pass to the converter. These are documented
+        on the [Data schemas](/data/schemas) page.
+
+    Returns
+    -------
+    LazyCollection
+    """
     data = LazyCollection(
         reader=ParquetReader(
             path,
@@ -209,6 +254,62 @@ def write_parquet(
     converter: Optional[Union[str, Callable]],
     **kwargs,
 ) -> None:
+    """
+    `edsnlp.data.write_parquet` writes a list of documents as a parquet dataset.
+
+    Example
+    -------
+    ```{ .python .no-check }
+
+    import edsnlp
+
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(...)
+
+    doc = nlp("My document with entities")
+
+    edsnlp.data.write_parquet([doc], "path/to/parquet")
+    ```
+
+    !!! warning "Overwriting files"
+
+        By default, `write_parquet` will raise an error if the directory already exists
+        and contains parquet files. This is to avoid overwriting existing annotations.
+        To allow overwriting existing files, use `overwrite=True`.
+
+    Parameters
+    ----------
+    data: Union[Any, LazyCollection],
+        The data to write (either a list of documents or a LazyCollection).
+    path: Union[str, Path]
+        Path to the directory containing the parquet files (will recursively look for
+        files in subdirectories). Supports any filesystem supported by pyarrow.
+    num_rows_per_file: int
+        The maximum number of documents to write in each parquet file.
+    overwrite: bool
+        Whether to overwrite existing directories.
+    write_in_worker: bool
+        Whether to write the files in the workers or in the main process.
+    accumulate: bool
+        Whether to accumulate the results sent to the writer by workers until the
+        batch is full or the writer is finalized. If False, each file will not be larger
+        than the size of the batches it receives. This option requires that the writer
+        is finalized before the end of the processing, which may not be compatible with
+        some backends, such as `spark`.
+
+        If `write_in_worker` is True, documents will be accumulated in each worker but
+        not across workers, therefore leading to a larger number of files.
+    converter: Optional[Union[str, Callable]]
+        Converter to use to convert the documents to dictionary objects before writing
+        them.
+    filesystem: Optional[pyarrow.fs.FileSystem]
+        The filesystem to use to write the files. If None, the filesystem will be
+        inferred from the path (e.g. `s3://` will use S3).
+    kwargs:
+        Additional keyword arguments to pass to the converter. These are documented
+        on the [Data schemas](/data/schemas) page.
+    """
+
     data = LazyCollection.ensure_lazy(data)
     if converter:
         converter, kwargs = get_doc2dict_converter(converter, kwargs)

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -399,6 +399,7 @@ class CPUWorker:
             lc: LazyCollection = load(
                 self.lazy_collection_path, map_location=self.device
             )
+            lc.eval()
             preprocess_pipes = []
             num_cpu = self.exchanger.num_cpu_workers
             split_into_batches_after = lc.split_into_batches_after
@@ -527,6 +528,7 @@ class GPUWorker:
         # mp._prctl_pr_set_pdeathsig(signal.SIGINT)
         try:
             lc = load(self.lazy_collection_path, map_location=self.device)
+            lc.eval()
             stage_components = [
                 pipe
                 # move_to_device(pipe, self.device)
@@ -842,7 +844,7 @@ def execute_multiprocessing_backend(
 
     def process():
         try:
-            with bar:
+            with bar, lc.eval():
                 for input_task_id, items in enumerate(
                     batchify(
                         iterable=inputs_iterator,

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -11,6 +11,17 @@ if TYPE_CHECKING:
     from edsnlp.core.lazy_collection import LazyCollection
 
 
+batch_size_fns = {
+    "words": lambda batch: sum(len(doc) for doc in batch),
+    "padded_words": lambda batch: max(len(doc) for doc in batch) * len(batch),
+    "docs": len,
+}
+
+doc_size_fns = {
+    "words": len,
+}
+
+
 def execute_simple_backend(
     lc: LazyCollection,
 ):
@@ -26,39 +37,68 @@ def execute_simple_backend(
     writer = lc.writer
     show_progress = lc.show_progress
 
+    split_into_batches_after = lc.split_into_batches_after
+    if split_into_batches_after is None or lc.batch_by != "docs" or lc.sort_chunks:
+        split_into_batches_after = next(
+            (p[0] for p in lc.pipeline if p[0] is not None), None
+        )
+    names = [step[0] for step in lc.pipeline] + [None]
+    chunk_components = lc.pipeline[: names.index(split_into_batches_after)]
+    batch_components = lc.pipeline[names.index(split_into_batches_after) :]
+
     def process():
         bar = nullcontext()
         if show_progress:
             from tqdm import tqdm
 
-            bar = tqdm()
+            bar = tqdm(smoothing=0.1, mininterval=5.0)
 
         with bar:
-            for batch in batchify(
+            for docs in batchify(
                 (
                     subtask
                     for task, count in reader.read_main()
                     for subtask in reader.read_worker([task])
                 ),
-                batch_size=lc.batch_size,
+                batch_size=lc.chunk_size,
             ):
-                with no_grad(), lc.cache():
-                    for name, pipe, kwargs, tokenizer in lc.pipeline:
-                        with set_current_tokenizer(tokenizer):
-                            if hasattr(pipe, "batch_process"):
-                                batch = pipe.batch_process(batch, **kwargs)
-                            else:
-                                batch = [pipe(doc, **kwargs) for doc in batch]  # type: ignore
+                for name, pipe, kwargs, tokenizer in chunk_components:
+                    with set_current_tokenizer(tokenizer):
+                        if hasattr(pipe, "batch_process"):
+                            docs = pipe.batch_process(docs, **kwargs)
+                        else:
+                            docs = [pipe(doc, **kwargs) for doc in docs]  #
 
-                if writer is not None:
-                    result, count = writer.write_worker(batch)
-                    if show_progress:
-                        bar.update(count)
-                    yield result
-                else:
-                    if show_progress:
-                        bar.update(len(batch))
-                    yield batch
+                if lc.sort_chunks:
+                    docs.sort(key=doc_size_fns.get(lc.sort_chunks, len))
+
+                batches = [
+                    batch
+                    for batch in batchify(
+                        docs,
+                        batch_size=lc.batch_size,
+                        formula=doc_size_fns.get(lc.batch_by, len),
+                    )
+                ]
+
+                for batch in batches:
+                    with no_grad(), lc.cache():
+                        for name, pipe, kwargs, tokenizer in batch_components:
+                            with set_current_tokenizer(tokenizer):
+                                if hasattr(pipe, "batch_process"):
+                                    batch = pipe.batch_process(batch, **kwargs)
+                                else:
+                                    batch = [pipe(doc, **kwargs) for doc in batch]  # type: ignore
+
+                    if writer is not None:
+                        result, count = writer.write_worker(batch)
+                        if show_progress:
+                            bar.update(count)
+                        yield result
+                    else:
+                        if show_progress:
+                            bar.update(len(batch))
+                        yield batch
             if writer is not None:
                 result, count = writer.finalize()
                 if show_progress:

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -63,7 +63,7 @@ def execute_simple_backend(
 
             bar = tqdm(smoothing=0.1, mininterval=5.0)
 
-        with bar:
+        with bar, lc.eval():
             for docs in batchify(
                 (
                     subtask

--- a/tests/pipelines/trainable/test_transformer.py
+++ b/tests/pipelines/trainable/test_transformer.py
@@ -65,7 +65,7 @@ def test_span_getter(gold):
     prep = qlf.make_batch([doc.copy() for doc in gold], supervision=True)
     batch = qlf.collate(prep)
     input_ids = batch["embedding"]["embedding"]["input_ids"]
-    mask = input_ids.mask
+    mask = batch["embedding"]["embedding"]["input_mask"]
     tok = trf.tokenizer
     assert len(input_ids) == 2
     assert tok.decode(input_ids[0][mask[0]]) == "[CLS] arret du ttt si folfox [SEP]"

--- a/tests/processing/test_backends.py
+++ b/tests/processing/test_backends.py
@@ -82,7 +82,14 @@ def test_end_to_end(
 
     data = data.map_pipeline(nlp)
 
-    data = data.set_processing(backend=backend, show_progress=True)
+    data = data.set_processing(
+        backend=backend,
+        show_progress=True,
+        chunk_size=2,
+        batch_by="words",
+        batch_size=2,
+        sort_chunks=True,
+    )
 
     if writer_format == "pandas":
         data.to_pandas(converter=writer_converter)
@@ -116,7 +123,14 @@ def test_multiprocessing_backend(frozen_ml_nlp):
         frozen_ml_nlp.pipe(
             texts * 20,
             batch_size=2,
-        ).set_processing(backend="multiprocessing", num_cpu_workers=-1)
+        ).set_processing(
+            backend="multiprocessing",
+            num_cpu_workers=-1,
+            sort_chunks=True,
+            chunk_size=2,
+            batch_by="words",
+            show_progress=True,
+        )
     )
     assert len(docs) == 40
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,7 +8,7 @@ from spacy.tokens import Doc
 
 import edsnlp
 from edsnlp import Pipeline, registry
-from edsnlp.pipelines.factories import normalizer, sentences
+from edsnlp.pipes.factories import normalizer, sentences
 
 
 class CustomClass:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -158,10 +158,10 @@ def test_torch_module(frozen_ml_nlp: Pipeline):
 
 
 def test_cache(frozen_ml_nlp: Pipeline):
+    from edsnlp.core.torch_component import _caches
+
     text = "Ceci est un exemple"
     frozen_ml_nlp(text)
-
-    trf = frozen_ml_nlp.get_pipe("transformer")
 
     doc = frozen_ml_nlp.make_doc(text)
     with frozen_ml_nlp.cache():
@@ -174,11 +174,13 @@ def test_cache(frozen_ml_nlp: Pipeline):
             else:
                 doc = pipe(doc)
         trf_forward_cache_entries = [
-            key for key in trf._cache if isinstance(key, tuple) and key[0] == "forward"
+            key
+            for key in _caches["default"]
+            if isinstance(key, tuple) and key[0] == "forward"
         ]
-        assert len(trf_forward_cache_entries) == 1
+        assert len(trf_forward_cache_entries) == 2
 
-    assert trf._cache is None
+    assert len(_caches) == 0
 
 
 def test_select_pipes(frozen_ml_nlp: Pipeline):

--- a/tests/utils/test_collections.py
+++ b/tests/utils/test_collections.py
@@ -1,7 +1,6 @@
 from edsnlp.utils.collections import (
     batch_compress_dict,
     batchify,
-    batchify_with_count,
     decompress_dict,
     dl_to_ld,
     flatten,
@@ -66,17 +65,10 @@ def test_dict_compression():
 
 def test_batchify():
     items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    batches = batchify(items, 3)
+    batches = list(batchify(items, 3))
     assert len(batches) == 4
     batches = list(batches)
     assert batches == [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9]]
-
-
-def test_batchify_with_count():
-    items = [(0, 50), (1, 10), (2, 10), (3, 10), (4, 5), (5, 5), (6, 1)]
-    batches = batchify_with_count(items, 20)
-    batches = list(batches)
-    assert batches == [([0], 50), ([1, 2], 20), ([3, 4, 5], 20), ([6], 1)]
 
 
 def test_deep_path():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- Added `batch_by`, `split_into_batches_after`, `sort_chunks`, `chunk_size`, `disable_implicit_parallelism` parameters to processing (`simple` and `multiprocessing`) backends to improve performance and memory usage. Sorting chunks can improve yield up to **twice the speed** in some cases.
- The deep learning cache mechanism now supports multitask models with weight sharing in multiprocessing mode.
- Added `max_tokens_per_device="auto"` parameter to `eds.transformer` to estimate memory usage and automatically split the input into chunks that fit into the GPU.

### Changed

- Improved speed and memory usage of the `eds.text_cnn` pipe by running the CNN on a non-padded version of its input: expect a speedup up to 1.3x in real-world use cases.

### Fixed

- Improved error handling in `multiprocessing` backend (e.g., no more deadlock)


## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
