### PR TITLE
Disable NER CRF BOS/EOS transitions when CRF windows are enabled

### DIFF
--- a/tests/pipelines/trainable/test_ner.py
+++ b/tests/pipelines/trainable/test_ner.py
@@ -5,8 +5,16 @@ from spacy.tokens import Span
 import edsnlp
 
 
-@mark.parametrize("ner_mode", ["independent", "joint", "marginal"])
-def test_ner(ner_mode):
+@mark.parametrize(
+    "ner_mode,window",
+    [
+        ("independent", 1),
+        ("joint", 0),
+        ("joint", 5),
+        ("marginal", 0),
+    ],
+)
+def test_ner(ner_mode, window):
     nlp = edsnlp.blank("eds")
     nlp.add_pipe(
         "eds.transformer",
@@ -24,7 +32,7 @@ def test_ner(ner_mode):
             embedding=nlp.get_pipe("transformer"),
             mode=ner_mode,
             target_span_getter=["ents", "ner-preds"],
-            window=1 if ner_mode == "independent" else 5,
+            window=window,
         ),
     )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -127,8 +127,8 @@ mode = "independent"
 target_span_getter = ["ents", "ner-preds"]
 labels = ["PERSON", "GIFT"]
 infer_span_setter = false
-window = 20
-stride = 18
+window = 40
+stride = 20
 
 [components.ner.span_setter]
 ents = true


### PR DESCRIPTION
## Description

### Fixed
- Begin of sentence / end of sentence transitions of the `eds.ner_crf` component are now
  disabled when windows are used (e.g., neither `window=1` equivalent to softmax and
  `window=0`equivalent to default full sequence Viterbi decoding)

### Changed
- Default `eds.ner_crf` window is now set to 40 and stride set to 20, as it doesn't
  affect throughput (compared to before, window set to 20) and improves accuracy.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
