### PR TITLE
fix: only match 'ne' negation pattern when not part of another word

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
   disabled when windows are used (e.g., neither `window=1` equivalent to softmax and
   `window=0`equivalent to default full sequence Viterbi decoding)
 - `eds` tokenizer nows inherits from `spacy.Tokenizer` to avoid typing errors
+- Only match 'ne' negation pattern when not part of another word to avoid false positives cases like `u[ne] cure de 10 jours`
 
 ## v0.10.5
 

--- a/edsnlp/pipes/qualifiers/negation/patterns.py
+++ b/edsnlp/pipes/qualifiers/negation/patterns.py
@@ -103,7 +103,7 @@ preceding: List[str] = [
 
 preceding_regex = [
     # ne (up to 3 words separated by spaces or newlines) pas/point/...
-    r"ne(?=[ \n]*(?:\w*[ \n]*){3}(?:pas|point|ni|aucun|jamais|rien))"
+    r"\bne\b(?=[ \n]*(?:\w*[ \n]*){3}(?:pas|point|ni|aucun|jamais|rien))"
 ]
 
 following: List[str] = [

--- a/tests/pipelines/qualifiers/test_negation.py
+++ b/tests/pipelines/qualifiers/test_negation.py
@@ -29,6 +29,8 @@ negation_examples: List[str] = [
     "Le patient ne <ent negated=false>fume</ent> que des cigares.",
     "Le résultat exclut un <ent negated=true>SMD</ent>",
     "Le résultat ne permet pas d'exclure un <ent negated=false>SMD</ent>",
+    "Situation aggravée par une <ent negated=false>neutropénie fébrile</ent>."
+    "Patient est traité d'une cure d'<ent negated=false>ALECTINIB</ent> depuis le ...",
 ]
 
 


### PR DESCRIPTION
## Description

Fixes #256.

### Fixed

- Only match 'ne' negation pattern when not part of another word to avoid false positives cases like `u[ne] cure de 10 jours`

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
