### PR TITLE
Add overlap_policy='merge' option to make_sentence_span_getter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@
   annotate every time.
 - Default `eds.ner_crf` window is now set to 40 and stride set to 20, as it doesn't
   affect throughput (compared to before, window set to 20) and improves accuracy.
+- New default `overlap_policy='merge'` option and parameter renaming in
+  `eds.span_context_getter` (which replaces `eds.span_sentence_getter`)
 
 ### Fixed
 

--- a/tests/training/qlf_config.cfg
+++ b/tests/training/qlf_config.cfg
@@ -29,7 +29,7 @@ kernel_sizes = [3]
 model = "hf-internal-testing/tiny-bert"
 window = 128
 stride = 96
-span_getter = { "@misc": "eds.span_sentence_getter", "span_getter": ${["ents", *vars.ml_span_groups]} }
+span_getter = { "@misc": "eds.span_context_getter", "span_getter": ${["ents", *vars.ml_span_groups]} }
 
 [components.qualifier]
 @factory = "eds.span_qualifier"

--- a/tests/utils/test_span_getters.py
+++ b/tests/utils/test_span_getters.py
@@ -1,0 +1,64 @@
+import edsnlp
+from edsnlp.utils.span_getters import make_span_context_getter
+
+
+def test_span_sentence_getter(lang):
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe("eds.normalizer")
+    nlp.add_pipe("eds.sentences")
+    nlp.add_pipe("eds.matcher", config={"terms": {"sentence": "sentence"}})
+    doc = nlp(
+        "This is a sentence. "
+        "This is another sentence. "
+        "This is a third one. "
+        "Last sentence."
+    )
+
+    span_getter = make_span_context_getter(
+        span_getter=["ents"],
+        context_words=2,
+        overlap_policy="merge",
+    )
+    spans = span_getter(doc)
+    assert [s.text for s in spans] == [
+        "This is a sentence. This is another sentence. This",
+        ". Last sentence.",
+    ]
+
+    span_getter = make_span_context_getter(
+        span_getter=["ents"],
+        context_words=2,
+        overlap_policy="filter",
+    )
+    spans = span_getter(doc)
+    assert [s.text for s in spans] == [
+        "This is a sentence. This",
+        ". Last sentence.",
+    ]
+
+    span_getter = make_span_context_getter(
+        span_getter=["ents"],
+        context_words=0,
+        context_sents=1,
+        overlap_policy="filter",
+    )
+    spans = span_getter(doc)
+    assert [s.text for s in spans] == [
+        "This is a sentence.",
+        "This is another sentence.",
+        "Last sentence.",
+    ]
+
+    span_getter = make_span_context_getter(
+        span_getter=["ents"],
+        context_words=0,
+        context_sents=2,
+        overlap_policy="merge",
+    )
+    spans = span_getter(doc)
+    assert [s.text for s in spans] == [
+        (
+            "This is a sentence. This is another sentence. "
+            "This is a third one. Last sentence."
+        )
+    ]


### PR DESCRIPTION
## Description

@aricohen93 

Training config example:

```ini
[components.qualifier.embedding.embedding.embedding]
@factory = "eds.transformer"
model = "camembert-base"
window = 255
stride = 128
span_getter = {
    "@misc": "eds.span_context_getter",
    "span_getter": ${components.qualifier.embedding.span_getter},
    "context_words": 30,  # add 30 words on each side
    "context_sents": 2, #  ent sent + 1 on each side
    "overlap_policy": "merge"
    }
```

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
