### PR TITLE
chore: bump version to 0.10.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build wheels
         # 2.4 is too low (can't build for macos, 2.16 is too high (OpenSSL issues)
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.10.5
+pip install edsnlp==0.10.6
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.10.5"
+pip install "edsnlp[ml]==0.10.6"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.10.6
 
 ### Added
 
@@ -33,6 +33,7 @@
 - `eds` tokenizer nows inherits from `spacy.Tokenizer` to avoid typing errors
 - Only match 'ne' negation pattern when not part of another word to avoid false positives cases like `u[ne] cure de 10 jours`
 - Disabled pipes are now correctly ignored in the `Pipeline.preprocess` method
+- Add "eventuel*" patterns to `eds.hyphothesis`
 
 ## v0.10.5
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.10.5
+pip install edsnlp==0.10.6
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.10.5"
+pip install "edsnlp[ml]==0.10.6"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -14,7 +14,7 @@ from .core.registries import registry
 import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 
-__version__ = "0.10.5"
+__version__ = "0.10.6"
 
 BASE_DIR = Path(__file__).parent
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ where = ["."]
 [build-system]
 requires = [
     "setuptools",
-    "cython>=0.25,<3.0",
+    "cython>=0.25",
     "spacy>=3.2,<4.0",
     # to update from https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # while setting numpy >= 1.15.0 due to spacy reqs
@@ -381,6 +381,6 @@ skip = [
     "*-manylinux_s390x", # Skip slow Linux
 ]
 
-before-test = "pip install pytest"
+before-test = 'pip install pytest "urllib3<2"'
 test-extras = "ml"
 test-command = "pytest {project}/tests/pipelines/test_pipelines.py"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

## v0.10.6

### Added

- Added `batch_by`, `split_into_batches_after`, `sort_chunks`, `chunk_size`, `disable_implicit_parallelism` parameters to processing (`simple` and `multiprocessing`) backends to improve performance
  and memory usage. Sorting chunks can improve yield up to **twice the speed** in some cases.
- The deep learning cache mechanism now supports multitask models with weight sharing in multiprocessing mode.
- Added `max_tokens_per_device="auto"` parameter to `eds.transformer` to estimate memory usage and automatically split the input into chunks that fit into the GPU.

### Changed

- Improved speed and memory usage of the `eds.text_cnn` pipe by running the CNN on a non-padded version of its input: expect a speedup up to 1.3x in real-world use cases.
- Deprecate the converters' (especially for BRAT/Standoff data) `bool_attributes`
  parameter in favor of general `default_attributes`. This new mapping describes how to
  set attributes on spans for which no attribute value was found in the input format.
  This is especially useful for negation, or frequent attributes values (e.g. "negated"
  is often False, "temporal" is often "present"), that annotators may not want to
  annotate every time.
- Default `eds.ner_crf` window is now set to 40 and stride set to 20, as it doesn't
  affect throughput (compared to before, window set to 20) and improves accuracy.
- New default `overlap_policy='merge'` option and parameter renaming in
  `eds.span_context_getter` (which replaces `eds.span_sentence_getter`)

### Fixed

- Improved error handling in `multiprocessing` backend (e.g., no more deadlock)
- Various improvements to the data processing related documentation pages
- Begin of sentence / end of sentence transitions of the `eds.ner_crf` component are now
  disabled when windows are used (e.g., neither `window=1` equivalent to softmax and
  `window=0`equivalent to default full sequence Viterbi decoding)
- `eds` tokenizer nows inherits from `spacy.Tokenizer` to avoid typing errors
- Only match 'ne' negation pattern when not part of another word to avoid false positives cases like `u[ne] cure de 10 jours`
- Disabled pipes are now correctly ignored in the `Pipeline.preprocess` method
- Add "eventuel*" patterns to `eds.hyphothesis`

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
