### PR TITLE
chore: bump version to 0.10.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.10.6
+pip install edsnlp==0.10.7
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.10.6"
+pip install "edsnlp[ml]==0.10.7"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.10.7
 
 ### Added
 
@@ -17,6 +17,7 @@
 - Allow missing `meta.json`, `tokenizer` and `vocab` paths when loading saved models
 - Save torch buffers when dumping machine learning models to disk (previous versions only saved the model parameters)
 - Fix automatic `batch_size` estimation in `eds.transformer` when `max_tokens_per_device` is set to `auto` and multiple GPUs are used
+- Fix JSONL file parsing
 
 ## v0.10.6
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 - Add support for polars data import / export
 - Allow kwargs in `eds.transformer` to pass to the transformer model
 
+### Changed
+
+- Saving pipelines now longer saves the `disabled` status of the pipes (i.e., all pipes are considered "enabled" when saved). This feature was not used and causing issues when saving a model wrapped in a `nlp.select_pipes` context.
+
 ### Fixed
 
 - Allow missing `meta.json`, `tokenizer` and `vocab` paths when loading saved models

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.10.6
+pip install edsnlp==0.10.7
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.10.6"
+pip install "edsnlp[ml]==0.10.7"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -14,7 +14,7 @@ from .core.registries import registry
 import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 
-__version__ = "0.10.6"
+__version__ = "0.10.7"
 
 BASE_DIR = Path(__file__).parent
 

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -821,7 +821,6 @@ class Pipeline:
                 "lang": self.lang,
                 "pipeline": list(self.pipe_names),
                 "components": {key: component for key, component in self._components},
-                "disabled": list(self.disabled),
                 "tokenizer": self._tokenizer_config,
             }
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -104,7 +104,6 @@ config_str = """\
 lang = "eds"
 pipeline = ["sentences", "transformer", "ner"]
 components = ${components}
-disabled = []
 
 [nlp.tokenizer]
 @tokenizers = "eds.tokenizer"
@@ -221,7 +220,6 @@ fail_config = """
 [nlp]
 lang = "eds"
 pipeline = ["transformer", "ner"]
-disabled = []
 
 [nlp.tokenizer]
 @tokenizers = "eds.tokenizer"


### PR DESCRIPTION
## Changelog

### Added

- Support empty writer converter by default in `edsnlp.data` readers / writers (do not convert by default)
- Add support for polars data import / export
- Allow kwargs in `eds.transformer` to pass to the transformer model

### Fixed

- Allow missing `meta.json`, `tokenizer` and `vocab` paths when loading saved models
- Save torch buffers when dumping machine learning models to disk (previous versions only saved the model parameters)
- Fix automatic `batch_size` estimation in `eds.transformer` when `max_tokens_per_device` is set to `auto` and multiple GPUs are used
- Fix JSONL file parsing

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
