### PR TITLE
Data fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,17 @@
 ### Added
 
 - Support for a `filesystem` parameter in every `edsnlp.data.read_*` and `edsnlp.data.write_*` functions
+- Support builtin Span attributes in converters `span_attributes` parameter, e.g.
+    ```python
+    import edsnlp
+
+    nlp = ...
+    nlp.add_pipe("eds.sentences")
+
+    data = edsnlp.data.from_xxx(...)
+    data = data.map_pipeline(nlp)
+    data.to_pandas(converters={"ents": {"span_attributes": ["sent.text", "start", "end"]}})
+    ```
 
 ## v0.10.7
 

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,10 @@
     data.to_pandas()
     ```
 
+### Fixed
+
+- Flatten list outputs (such as "ents" converter) when iterating: `nlp.map(data).to_iterable("ents")` is now a list of entities, and not a list of lists of entities
+
 ## v0.10.7
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
     data = data.map_pipeline(nlp)
     data.to_pandas(converters={"ents": {"span_attributes": ["sent.text", "start", "end"]}})
     ```
+- Support assigning Brat AnnotatorNotes as span attributes: `edsnlp.data.read_standoff(...,  notes_as_span_attribute="cui")`
 
 ## v0.10.7
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support for a `filesystem` parameter in every `edsnlp.data.read_*` and `edsnlp.data.write_*` functions
+- Pipes of a pipeline are now easily accessible with `nlp.pipes.xxx` instead of `nlp.get_pipe("xxx")`
 - Support builtin Span attributes in converters `span_attributes` parameter, e.g.
     ```python
     import edsnlp
@@ -25,6 +26,10 @@
     data = data.map_batches(lambda batch: do_something(batch))
     data.to_pandas()
     ```
+
+### Changed
+
+- `nlp.preprocess_many` now uses lazy collections to enable parallel processing
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,14 @@
     data.to_pandas(converters={"ents": {"span_attributes": ["sent.text", "start", "end"]}})
     ```
 - Support assigning Brat AnnotatorNotes as span attributes: `edsnlp.data.read_standoff(...,  notes_as_span_attribute="cui")`
+- Support for mapping full batches in `edsnlp.processing` pipelines with `map_batches` lazy collection method:
+    ```python
+    import edsnlp
+
+    data = edsnlp.data.from_xxx(...)
+    data = data.map_batches(lambda batch: do_something(batch))
+    data.to_pandas()
+    ```
 
 ## v0.10.7
 

--- a/docs/concepts/inference.md
+++ b/docs/concepts/inference.md
@@ -47,7 +47,7 @@ A lazy collection contains :
 - an optional `writer`: the destination of the data (e.g., a file, a database, a list of strings, etc.)
 - the execution `config`, containing the backend to use and its configuration such as the number of workers, the batch size, etc.
 
-All methods (`.map`, `.map_pipeline`, `.set_processing`) of the lazy collection are chainable, meaning that they return a new object (no in-place modification).
+All methods (`.map`, `.map_batches`, `.map_pipeline`, `.set_processing`) of the lazy collection are chainable, meaning that they return a new object (no in-place modification).
 
 For instance, the following code will load a model, read a folder of JSON files, apply the model to each document and write the result in a Parquet folder, using 4 CPUs and 2 GPUs.
 
@@ -89,6 +89,8 @@ data.write_parquet("path/to/output_folder", converter="...", write_in_worker=Tru
 ### Applying operations to a lazy collection
 
 To apply an operation to a lazy collection, you can use the `.map` method. It takes a callable as input and an optional dictionary of keyword arguments. The function will be applied to each element of the collection.
+
+To apply an operation to a lazy collection in batches, you can use the `.map_batches` method. It takes a callable as input and an optional dictionary of keyword arguments. The function will be applied to each batch of the collection (as a list of elements), and should return a list of results, that will be concatenated at the end.
 
 To apply a model, you can use the `.map_pipeline` method. It takes a model as input and will add every pipe of the model to the scheduled operations.
 

--- a/docs/tutorials/make-a-training-script.md
+++ b/docs/tutorials/make-a-training-script.md
@@ -186,7 +186,7 @@ Finally, the model is evaluated on the validation dataset and saved at regular i
 from edsnlp.scorers.ner import create_ner_exact_scorer
 from copy import deepcopy
 
-scorer = create_ner_exact_scorer(nlp.get_pipe('ner').target_span_getter)
+scorer = create_ner_exact_scorer(nlp.pipes.ner.target_span_getter)
 
     ...
 
@@ -281,7 +281,7 @@ Let's wrap the training code in a function, and make it callable from the comman
             shuffle=True,
         )
 
-        scorer = create_ner_exact_scorer(nlp.get_pipe("ner").target_span_getter)
+        scorer = create_ner_exact_scorer(nlp.pipes.ner.target_span_getter)
 
         optimizer = torch.optim.AdamW(
             params=nlp.parameters(),

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -35,6 +35,7 @@ from edsnlp.utils.span_getters import (
 )
 
 FILENAME = "__FILENAME__"
+SPAN_BUILTIN_ATTRS = ("sent", "label_", "kb_id_", "text")
 
 SCHEMA = {}
 
@@ -505,6 +506,14 @@ class OmopDoc2DictConverter:
 
     def __call__(self, doc):
         spans = get_spans(doc, self.span_getter)
+        span_binding_getters = {
+            obj_name: BINDING_GETTERS[
+                ("_." + ext_name)
+                if ext_name.split(".")[0] not in SPAN_BUILTIN_ATTRS
+                else ext_name
+            ]
+            for ext_name, obj_name in self.span_attributes.items()
+        }
         obj = {
             FILENAME: doc._.note_id,
             "note_id": doc._.note_id,
@@ -522,9 +531,8 @@ class OmopDoc2DictConverter:
                     "lexical_variant": ent.text,
                     "note_nlp_source_value": ent.label_,
                     **{
-                        obj_name: getattr(ent._, ext_name)
-                        for ext_name, obj_name in self.span_attributes.items()
-                        if ent._.has(ext_name)
+                        obj_name: getter(ent)
+                        for obj_name, getter in span_binding_getters.items()
                     },
                 }
                 for i, ent in enumerate(sorted(dict.fromkeys(spans)))
@@ -562,7 +570,11 @@ class EntsDoc2DictConverter:
 
     def __call__(self, doc):
         span_binding_getters = {
-            obj_name: BINDING_GETTERS["_." + ext_name]
+            obj_name: BINDING_GETTERS[
+                ("_." + ext_name)
+                if ext_name.split(".")[0] not in SPAN_BUILTIN_ATTRS
+                else ext_name
+            ]
             for ext_name, obj_name in self.span_attributes.items()
         }
         doc_attributes_values = {

--- a/edsnlp/data/standoff.py
+++ b/edsnlp/data/standoff.py
@@ -112,7 +112,7 @@ def parse_standoff_file(
                             "entity_id": ann_id,
                             "fragments": [],
                             "attributes": {},
-                            "comments": [],
+                            "notes": [],
                             "label": entity,
                         }
                         last_end = None
@@ -198,11 +198,11 @@ def parse_standoff_file(
                             raise BratParsingError(ann_file, line)
                         ann_id = match.group(1)
                         entity_id = match.group(2)
-                        comment = match.group(3)
-                        entities[entity_id]["comments"].append(
+                        note = match.group(3)
+                        entities[entity_id]["notes"].append(
                             {
-                                "comment_id": ann_id,
-                                "comment": comment,
+                                "note_id": ann_id,
+                                "value": note,
                             }
                         )
                 except Exception:
@@ -470,8 +470,17 @@ def read_standoff(
     keep_raw_attribute_values : bool
         Whether to keep the raw attribute values (as strings) or to convert them to
         Python objects (e.g. booleans).
-    bool_attributes : SequenceStr
-        List of attributes for which missing values should be set to False.
+    default_attributes : AttributesMappingArg
+        How to set attributes on spans for which no attribute value was found in the
+        input format. This is especially useful for negation, or frequent attributes
+        values (e.g. "negated" is often False, "temporal" is often "present"), that
+        annotators may not want to annotate every time.
+    notes_as_span_attribute : Optional[str]
+        If set, the AnnotatorNote annotations will be concatenated and stored in a span
+        attribute with this name.
+    split_fragments : bool
+        Whether to split the fragments into separate spans or not. If set to False, the
+        fragments will be concatenated into a single span.
     keep_ipynb_checkpoints : bool
         Whether to keep the files that are in the `.ipynb_checkpoints` directory.
     keep_txt_only_docs : bool

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -29,7 +29,7 @@ from typing_extensions import TypedDict
 
 from edsnlp.core.lazy_collection import LazyCollection
 from edsnlp.data.converters import set_current_tokenizer
-from edsnlp.utils.collections import batchify, flatten_once
+from edsnlp.utils.collections import batchify, flatten
 
 batch_size_fns = {
     "words": lambda batch: sum(len(doc) for doc in batch),
@@ -973,4 +973,4 @@ def execute_multiprocessing_backend(
                         queue.cancel_join_thread()
 
     gen = process()
-    return lc.writer.write_main(gen) if lc.writer is not None else flatten_once(gen)
+    return flatten(gen) if lc.writer is None else lc.writer.write_main(gen)

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -5,7 +5,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 from edsnlp.data.converters import set_current_tokenizer
-from edsnlp.utils.collections import batchify, flatten_once
+from edsnlp.utils.collections import batchify, flatten
 
 if TYPE_CHECKING:
     from edsnlp.core.lazy_collection import LazyCollection
@@ -107,4 +107,4 @@ def execute_simple_backend(
                     yield result
 
     gen = process()
-    return flatten_once(gen) if writer is None else writer.write_main(gen)
+    return flatten(gen) if writer is None else writer.write_main(gen)

--- a/edsnlp/processing/spark.py
+++ b/edsnlp/processing/spark.py
@@ -10,7 +10,7 @@ from edsnlp.core.lazy_collection import LazyCollection
 from edsnlp.data.base import BaseWriter
 from edsnlp.data.converters import set_current_tokenizer
 from edsnlp.data.spark import SparkReader, SparkWriter
-from edsnlp.utils.collections import batchify, flatten_once
+from edsnlp.utils.collections import batchify, flatten
 
 try:
     from koalas.dataframe import DataFrame as KoalasDataFrame
@@ -151,6 +151,4 @@ def execute_spark_backend(
             pickle.loads(item["content"])
             for item in df.rdd.mapPartitions(process_partition).toLocalIterator()
         )
-        return (
-            writer.write_main(results) if writer is not None else flatten_once(results)
-        )
+        return flatten(results) if writer is None else writer.write_main(results)

--- a/tests/data/test_converters.py
+++ b/tests/data/test_converters.py
@@ -110,6 +110,7 @@ def test_write_omop_dict(blank_nlp):
                 "end_char": 4,
                 "lexical_variant": "This",
                 "note_nlp_source_value": "test",
+                "sent.text": "This is a test.",
                 "negation": True,
             },
             {
@@ -118,6 +119,7 @@ def test_write_omop_dict(blank_nlp):
                 "end_char": 7,
                 "lexical_variant": "is",
                 "note_nlp_source_value": "test",
+                "sent.text": "This is a test.",
                 "negation": False,
             },
         ],
@@ -127,7 +129,7 @@ def test_write_omop_dict(blank_nlp):
             "omop",
             dict(
                 span_getter={"ents": True},
-                span_attributes=["negation"],
+                span_attributes=["negation", "sent.text"],
             ),
         )[0](doc)
         == json

--- a/tests/data/test_lazy_collection.py
+++ b/tests/data/test_lazy_collection.py
@@ -1,0 +1,15 @@
+import edsnlp
+
+
+def test_map_batches():
+    items = [1, 2, 3, 4, 5]
+    lazy = edsnlp.data.from_iterable(items)
+    lazy = lazy.map(lambda x: x + 1)
+    lazy = lazy.map_batches(lambda x: [sum(x)])
+    lazy = lazy.set_processing(
+        num_cpu_workers=2,
+        sort_chunks=False,
+        batch_size=2,
+    )
+    res = list(lazy)
+    assert set(res) == {5, 9, 6}

--- a/tests/data/test_lazy_collection.py
+++ b/tests/data/test_lazy_collection.py
@@ -1,3 +1,5 @@
+import pytest
+
 import edsnlp
 
 
@@ -13,3 +15,13 @@ def test_map_batches():
     )
     res = list(lazy)
     assert set(res) == {5, 9, 6}
+
+
+@pytest.mark.parametrize("num_cpu_workers", [1, 2])
+def test_flat_iterable(num_cpu_workers):
+    items = [1, 2, 3, 4]
+    lazy = edsnlp.data.from_iterable(items)
+    lazy = lazy.set_processing(num_cpu_workers=num_cpu_workers)
+    lazy = lazy.map(lambda x: [x] * x)
+    res = list(lazy)
+    assert sorted(res) == [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]

--- a/tests/data/test_parquet.py
+++ b/tests/data/test_parquet.py
@@ -5,6 +5,7 @@ import pyarrow.fs
 import pytest
 
 import edsnlp
+from edsnlp.data.converters import get_dict2doc_converter, get_doc2dict_converter
 from edsnlp.utils.collections import dl_to_ld
 
 
@@ -65,125 +66,149 @@ def assert_doc_read(doc):
     }
 
 
-def assert_doc_write(exported_obj):
-    assert exported_obj == {
-        "entities": [
-            {
-                "assertion": None,
-                "end_char": 38,
-                "etat": "test",
-                "lexical_variant": "douleurs",
-                "note_nlp_id": 0,
-                "note_nlp_source_value": "sosy",
-                "start_char": 30,
-            },
-            {
-                "assertion": None,
-                "end_char": 57,
-                "etat": None,
-                "lexical_variant": "dans le bras droit",
-                "note_nlp_id": 1,
-                "note_nlp_source_value": "localisation",
-                "start_char": 39,
-            },
-            {
-                "assertion": None,
-                "end_char": 57,
-                "etat": None,
-                "lexical_variant": "bras droit",
-                "note_nlp_id": 2,
-                "note_nlp_source_value": "anatomie",
-                "start_char": 47,
-            },
-            {
-                "assertion": "absent",
-                "end_char": 98,
-                "etat": None,
-                "lexical_variant": "problème \nde locomotion",
-                "note_nlp_id": 3,
-                "note_nlp_source_value": "pathologie",
-                "start_char": 75,
-            },
-            {
-                "assertion": "non-associé",
-                "end_char": 117,
-                "etat": "passé",
-                "lexical_variant": "AVC",
-                "note_nlp_id": 4,
-                "note_nlp_source_value": "pathologie",
-                "start_char": 114,
-            },
-            {
-                "assertion": "hypothétique",
-                "end_char": 164,
-                "etat": "présent",
-                "lexical_variant": "rhume",
-                "note_nlp_id": 5,
-                "note_nlp_source_value": "pathologie",
-                "start_char": 159,
-            },
-            {
-                "assertion": "hypothétique",
-                "end_char": 296,
-                "etat": "présent",
-                "lexical_variant": "rhume",
-                "note_nlp_id": 6,
-                "note_nlp_source_value": "pathologie",
-                "start_char": 291,
-            },
-            {
-                "assertion": None,
-                "end_char": 314,
-                "etat": None,
-                "lexical_variant": "Douleurs",
-                "note_nlp_id": 7,
-                "note_nlp_source_value": "sosy",
-                "start_char": 306,
-            },
-            {
-                "assertion": None,
-                "end_char": 333,
-                "etat": None,
-                "lexical_variant": "dans le bras droit",
-                "note_nlp_id": 8,
-                "note_nlp_source_value": "localisation",
-                "start_char": 315,
-            },
-            {
-                "assertion": None,
-                "end_char": 333,
-                "etat": None,
-                "lexical_variant": "bras droit",
-                "note_nlp_id": 9,
-                "note_nlp_source_value": "anatomie",
-                "start_char": 323,
-            },
-            {
-                "assertion": "absent",
-                "end_char": 386,
-                "etat": None,
-                "lexical_variant": "anomalie",
-                "note_nlp_id": 10,
-                "note_nlp_source_value": "sosy",
-                "start_char": 378,
-            },
-        ],
-        "note_id": "subfolder/doc-1",
-        "context_var": "test",
-        "note_text": "Le patient est admis pour des douleurs dans le bras droit, mais "
-        "n'a pas de problème \n"
-        "de locomotion. \n"
-        "Historique d'AVC dans la famille. pourrait être un cas de "
-        "rhume.\n"
-        "NBNbWbWbNbWbNBNbNbWbWbNBNbWbNbNbWbNBNbWbNbNBWbWbNbNbNBWbNbWbNbWBNbNbWbNbNBNbWb"
-        "WbNbWBNbNbWbNBNbWbWbNb\n"
-        "Pourrait être un cas de rhume.\n"
-        "Motif :\n"
-        "Douleurs dans le bras droit.\n"
-        "ANTÉCÉDENTS\n"
-        "Le patient est déjà venu\n"
-        "Pas d'anomalie détectée.\n",
-    }
+GOLD_OMOP = {
+    "entities": [
+        {
+            "assertion": None,
+            "end_char": 38,
+            "etat": "test",
+            "lexical_variant": "douleurs",
+            "note_nlp_id": 0,
+            "note_nlp_source_value": "sosy",
+            "start_char": 30,
+        },
+        {
+            "assertion": None,
+            "end_char": 57,
+            "etat": None,
+            "lexical_variant": "dans le bras droit",
+            "note_nlp_id": 1,
+            "note_nlp_source_value": "localisation",
+            "start_char": 39,
+        },
+        {
+            "assertion": None,
+            "end_char": 57,
+            "etat": None,
+            "lexical_variant": "bras droit",
+            "note_nlp_id": 2,
+            "note_nlp_source_value": "anatomie",
+            "start_char": 47,
+        },
+        {
+            "assertion": "absent",
+            "end_char": 98,
+            "etat": None,
+            "lexical_variant": "problème \nde locomotion",
+            "note_nlp_id": 3,
+            "note_nlp_source_value": "pathologie",
+            "start_char": 75,
+        },
+        {
+            "assertion": "non-associé",
+            "end_char": 117,
+            "etat": "passé",
+            "lexical_variant": "AVC",
+            "note_nlp_id": 4,
+            "note_nlp_source_value": "pathologie",
+            "start_char": 114,
+        },
+        {
+            "assertion": "hypothétique",
+            "end_char": 164,
+            "etat": "présent",
+            "lexical_variant": "rhume",
+            "note_nlp_id": 5,
+            "note_nlp_source_value": "pathologie",
+            "start_char": 159,
+        },
+        {
+            "assertion": "hypothétique",
+            "end_char": 296,
+            "etat": "présent",
+            "lexical_variant": "rhume",
+            "note_nlp_id": 6,
+            "note_nlp_source_value": "pathologie",
+            "start_char": 291,
+        },
+        {
+            "assertion": None,
+            "end_char": 314,
+            "etat": None,
+            "lexical_variant": "Douleurs",
+            "note_nlp_id": 7,
+            "note_nlp_source_value": "sosy",
+            "start_char": 306,
+        },
+        {
+            "assertion": None,
+            "end_char": 333,
+            "etat": None,
+            "lexical_variant": "dans le bras droit",
+            "note_nlp_id": 8,
+            "note_nlp_source_value": "localisation",
+            "start_char": 315,
+        },
+        {
+            "assertion": None,
+            "end_char": 333,
+            "etat": None,
+            "lexical_variant": "bras droit",
+            "note_nlp_id": 9,
+            "note_nlp_source_value": "anatomie",
+            "start_char": 323,
+        },
+        {
+            "assertion": "absent",
+            "end_char": 386,
+            "etat": None,
+            "lexical_variant": "anomalie",
+            "note_nlp_id": 10,
+            "note_nlp_source_value": "sosy",
+            "start_char": 378,
+        },
+    ],
+    "note_id": "subfolder/doc-1",
+    "context_var": "test",
+    "note_text": "Le patient est admis pour des douleurs dans le bras droit, mais "
+    "n'a pas de problème \n"
+    "de locomotion. \n"
+    "Historique d'AVC dans la famille. pourrait être un cas de "
+    "rhume.\n"
+    "NBNbWbWbNbWbNBNbNbWbWbNBNbWbNbNbWbNBNbWbNbNBWbWbNbNbNBWbNbWbNbWBNbNbWbNbNBNbWb"
+    "WbNbWBNbNbWbNBNbWbWbNb\n"
+    "Pourrait être un cas de rhume.\n"
+    "Motif :\n"
+    "Douleurs dans le bras droit.\n"
+    "ANTÉCÉDENTS\n"
+    "Le patient est déjà venu\n"
+    "Pas d'anomalie détectée.\n",
+}
+
+
+def assert_doc_write_omop(exported_obj):
+    assert exported_obj == GOLD_OMOP
+
+
+def assert_doc_write_ents(exported_objs):
+    in_converter, kwargs = get_dict2doc_converter(
+        "omop",
+        dict(
+            span_attributes=["etat", "assertion"],
+            doc_attributes=["context_var"],
+        ),
+    )
+    doc = in_converter(GOLD_OMOP, **kwargs)
+    out_converter, kwargs = get_doc2dict_converter(
+        "ents",
+        dict(
+            span_attributes=["etat", "assertion"],
+            doc_attributes=["context_var"],
+            span_getter=["ents", "sosy", "localisation", "anatomie", "pathologie"],
+        ),
+    )
+    GOLD_ENTS = out_converter(doc, **kwargs)
+    assert exported_objs == GOLD_ENTS
 
 
 def test_read_write_in_worker(blank_nlp, tmpdir):
@@ -236,7 +261,7 @@ def test_read_to_parquet(blank_nlp, tmpdir):
         span_getter=["ents", "sosy", "localisation", "anatomie", "pathologie"],
     )
 
-    assert_doc_write(
+    assert_doc_write_omop(
         next(dl_to_ld(pyarrow.dataset.dataset(output_dir).to_table().to_pydict()))
     )
 
@@ -259,3 +284,43 @@ def test_read_to_parquet(blank_nlp, tmpdir):
         span_getter=["ents", "sosy", "localisation", "anatomie", "pathologie"],
         overwrite=True,
     )
+
+
+def test_read_to_parquet_ents(blank_nlp, tmpdir):
+    input_dir = Path(__file__).parent.parent.resolve() / "resources" / "docs.pq"
+    output_dir = Path(tmpdir)
+    fs = pyarrow.fs.LocalFileSystem()
+    doc = list(
+        edsnlp.data.read_parquet(
+            input_dir,
+            converter="omop",
+            span_attributes=["etat", "assertion"],
+            doc_attributes=["context_var"],
+            filesystem=fs,
+        )
+    )[0]
+    assert_doc_read(doc)
+    doc.ents[0]._.etat = "test"
+
+    edsnlp.data.write_parquet(
+        [doc],
+        output_dir,
+        converter="ents",
+        doc_attributes=["context_var"],
+        span_attributes=["etat", "assertion"],
+        span_getter=["ents", "sosy", "localisation", "anatomie", "pathologie"],
+    )
+
+    assert_doc_write_ents(
+        list(dl_to_ld(pyarrow.dataset.dataset(output_dir).to_table().to_pydict()))
+    )
+
+    with pytest.raises(FileExistsError):
+        edsnlp.data.write_parquet(
+            [doc],
+            output_dir,
+            converter="ents",
+            doc_attributes=["context_var"],
+            span_attributes=["etat", "assertion"],
+            span_getter=["ents", "sosy", "localisation", "anatomie", "pathologie"],
+        )

--- a/tests/data/test_standoff.py
+++ b/tests/data/test_standoff.py
@@ -232,9 +232,16 @@ def test_brat(
 def test_read_to_standoff(blank_nlp, tmpdir):
     input_dir = Path(__file__).parent.parent.resolve() / "resources" / "brat_data"
     output_dir = Path(tmpdir)
-    doc = list(edsnlp.data.read_standoff(input_dir, bool_attributes=["bool flag 0"]))[0]
+    doc = list(
+        edsnlp.data.read_standoff(
+            input_dir,
+            bool_attributes=["bool flag 0"],
+            notes_as_span_attribute="cui",
+        )
+    )[0]
     assert_doc_read(doc)
     doc.ents[0]._.etat = "test"
+    doc.ents[0]._.cui = "C0030193"
 
     edsnlp.data.write_standoff(
         [doc],

--- a/tests/extract_docs_code.py
+++ b/tests/extract_docs_code.py
@@ -48,13 +48,9 @@ class PyCodePreprocessor(FencedBlockPreprocessor):
 
     def run(self, lines):
         text = "\n".join(lines)
-        if 'nlp.add_pipe(f"eds.aids")' in text:
-            print("TEXT", text)
         while True:
             # ----  https://github.com/Python-Markdown/markdown/blob/5a2fee/markdown/extensions/fenced_code.py#L84C9-L98  # noqa: E501
             m = self.FENCED_BLOCK_RE.search(text)
-            if 'nlp.add_pipe(f"eds.aids")' in text:
-                print("CODE ==>", m.group("code") if m else None)
             if m:
                 lang, id, classes, config = None, "", [], {}
                 if m.group("attrs"):
@@ -155,4 +151,7 @@ def extract_docs_code():
 
     docs_code_blocks = plugin.docs_code_blocks
     # Deduplicate both keys and values
-    return {k: v for v, k in {v: k for k, v in docs_code_blocks}.items()}
+    return {
+        k: v
+        for v, k in {v: k for k, v in docs_code_blocks if "changelog" not in k}.items()
+    }

--- a/tests/resources/brat_data/subfolder/doc-1.ann
+++ b/tests/resources/brat_data/subfolder/doc-1.ann
@@ -24,3 +24,4 @@ A8	assertion T11 absent
 E1	MyArg1:T3 MyArg2:T1
 E2	MyArg1:T1 MyArg2:E1
 T12	test label 0 378 386	anomalie
+#1	AnnotatorNotes T1	C0030193

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -37,10 +37,12 @@ def test_add_pipe_component():
     model.add_pipe(normalizer(nlp=model), name="normalizer")
     assert "normalizer" in model.pipe_names
     assert model.has_pipe("normalizer")
+    assert model.pipes.normalizer is model.get_pipe("normalizer")
 
     model.add_pipe(sentences(nlp=model), name="sentences")
     assert "sentences" in model.pipe_names
     assert model.has_pipe("sentences")
+    assert model.pipes.sentences is model.get_pipe("sentences")
 
     with pytest.raises(ValueError):
         model.add_pipe(


### PR DESCRIPTION
## Description

### Added

- Support for a `filesystem` parameter in every `edsnlp.data.read_*` and `edsnlp.data.write_*` functions
- Pipes of a pipeline are now easily accessible with `nlp.pipes.xxx` instead of `nlp.get_pipe("xxx")`
- Support builtin Span attributes in converters `span_attributes` parameter, e.g.
    ```python
    import edsnlp

    nlp = ...
    nlp.add_pipe("eds.sentences")

    data = edsnlp.data.from_xxx(...)
    data = data.map_pipeline(nlp)
    data.to_pandas(converters={"ents": {"span_attributes": ["sent.text", "start", "end"]}})
    ```
- Support assigning Brat AnnotatorNotes as span attributes: `edsnlp.data.read_standoff(...,  notes_as_span_attribute="cui")`
- Support for mapping full batches in `edsnlp.processing` pipelines with `map_batches` lazy collection method:
    ```python
    import edsnlp

    data = edsnlp.data.from_xxx(...)
    data = data.map_batches(lambda batch: do_something(batch))
    data.to_pandas()
    ```

### Changed

- `nlp.preprocess_many` now uses lazy collections to enable parallel processing

### Fixed

- Flatten list outputs (such as "ents" converter) when iterating: `nlp.map(data).to_iterable("ents")` is now a list of entities, and not a list of lists of entities

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
