### PR TITLE
Refacto span classification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,7 @@
 
 - Flatten list outputs (such as "ents" converter) when iterating: `nlp.map(data).to_iterable("ents")` is now a list of entities, and not a list of lists of entities
 - Allow span pooler to choose between multiple base embedding spans (as likely produced by `eds.transformer`) by sorting them by Dice overlap score.
+- EDS-NLP does not raise an error anymore when saving a model to an already existing, but empty directory
 
 ## v0.10.7
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 ### Changed
 
 - `nlp.preprocess_many` now uses lazy collections to enable parallel processing
+- :warning: Breaking change. Improved and simplified `eds.span_qualifier`: we didn't support combination groups before, so this feature was scrapped for now. We now also support splitting values of a single qualifier between different span labels.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,7 @@
 ### Fixed
 
 - Flatten list outputs (such as "ents" converter) when iterating: `nlp.map(data).to_iterable("ents")` is now a list of entities, and not a list of lists of entities
+- Allow span pooler to choose between multiple base embedding spans (as likely produced by `eds.transformer`) by sorting them by Dice overlap score.
 
 ## v0.10.7
 

--- a/docs/tutorials/multiple-texts.md
+++ b/docs/tutorials/multiple-texts.md
@@ -279,6 +279,10 @@ The result on the first note:
 
 ### Locally, using multiple parallel workers
 
+!!! warning "Caveat"
+
+    Since workers can produce their results in any order, the order of the rows in the resulting DataFrame may not be the same as the order of the input data.
+
 ```{ .python hl_lines="8" }
 # Read from a dataframe & use the omop converter
 docs = edsnlp.data.from_pandas(data, converter="omop")

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -729,11 +729,15 @@ class Pipeline:
 
         path = Path(path) if isinstance(path, str) else path
 
-        if os.path.exists(path) and not os.path.exists(path / "config.cfg"):
+        if (
+            os.path.exists(path)
+            and os.listdir(path)
+            and not os.path.exists(path / "config.cfg")
+        ):
             raise Exception(
                 "The directory already exists and doesn't appear to be a"
-                "saved pipeline. Please erase it manually or choose a "
-                "different directory."
+                "saved pipeline (missing config.cfg). Please erase it manually or "
+                "choose a different directory."
             )
         shutil.rmtree(path, ignore_errors=True)
         os.makedirs(path, exist_ok=True)

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -46,6 +46,7 @@ from ..utils.collections import (
     decompress_dict,
     multi_tee,
 )
+from ..utils.typing import AsList
 from .lazy_collection import LazyCollection
 
 if TYPE_CHECKING:
@@ -912,7 +913,7 @@ class Pipeline:
         project_type: Optional[Literal["poetry", "setuptools"]] = None,
         version: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = {},
-        distributions: Optional[Sequence[Literal["wheel", "sdist"]]] = ["wheel"],
+        distributions: Optional[AsList[Literal["wheel", "sdist"]]] = ["wheel"],
         config_settings: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
         isolation: bool = True,
         skip_build_dependency_check: bool = False,

--- a/edsnlp/pipes/trainable/embeddings/text_cnn/text_cnn.py
+++ b/edsnlp/pipes/trainable/embeddings/text_cnn/text_cnn.py
@@ -1,14 +1,14 @@
 from typing import Optional, Sequence
 
 import torch
-from typing_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
 from edsnlp.core.torch_component import BatchInput
 from edsnlp.pipes.trainable.embeddings.typing import (
     WordEmbeddingBatchOutput,
     WordEmbeddingComponent,
 )
-from edsnlp.pipes.trainable.layers.text_cnn import NormalizationPlacement, TextCnn
+from edsnlp.pipes.trainable.layers.text_cnn import TextCnn
 from edsnlp.utils.torch import ActivationFunction
 
 TextCnnBatchInput = TypedDict(
@@ -44,7 +44,7 @@ class TextCnnEncoder(WordEmbeddingComponent):
         Activation function to use
     residual : bool
         Whether to use residual connections
-    normalize : NormalizationPlacement
+    normalize : Literal["pre", "post", "none"]
         Whether to normalize before or after the residual connection
     """
 
@@ -58,7 +58,7 @@ class TextCnnEncoder(WordEmbeddingComponent):
         kernel_sizes: Sequence[int] = (3, 4, 5),
         activation: ActivationFunction = "relu",
         residual: bool = True,
-        normalize: NormalizationPlacement = "pre",
+        normalize: Literal["pre", "post", "none"] = "pre",
     ):
         super().__init__(nlp, name)
         self.embedding = embedding

--- a/edsnlp/pipes/trainable/embeddings/transformer/transformer.py
+++ b/edsnlp/pipes/trainable/embeddings/transformer/transformer.py
@@ -134,7 +134,6 @@ class Transformer(WordEmbeddingComponent[TransformerBatchInput]):
         super().__init__(nlp, name)
         self.transformer = AutoModel.from_pretrained(
             model,
-            add_pooling_layer=False,
             quantization_config=quantization,
             **kwargs,
         )

--- a/edsnlp/pipes/trainable/layers/text_cnn.py
+++ b/edsnlp/pipes/trainable/layers/text_cnn.py
@@ -1,20 +1,14 @@
-from enum import Enum
 from typing import Optional, Sequence
 
 import torch
 import torch.nn.functional as F
+from typing_extensions import Literal
 
 from edsnlp.utils.torch import ActivationFunction, get_activation_function
 
 
-class NormalizationPlacement(str, Enum):
-    pre = "pre"
-    post = "post"
-    none = "none"
-
-
 class Residual(torch.nn.Module):
-    def __init__(self, normalize: NormalizationPlacement = "pre"):
+    def __init__(self, normalize: Literal["pre", "post", "none"] = "pre"):
         super().__init__()
         self.normalize = normalize
 
@@ -37,7 +31,7 @@ class TextCnn(torch.nn.Module):
         kernel_sizes: Sequence[int] = (3, 4, 5),
         activation: ActivationFunction = "relu",
         residual: bool = True,
-        normalize: NormalizationPlacement = "pre",
+        normalize: Literal["pre", "post", "none"] = "pre",
     ):
         """
         Parameters
@@ -55,7 +49,7 @@ class TextCnn(torch.nn.Module):
             Activation function to use
         residual: bool
             Whether to use residual connections
-        normalize: NormalizationPlacement
+        normalize: Literal["pre", "post", "none"]
             Whether to normalize before or after the residual connection
         """
         super().__init__()

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -363,8 +363,8 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
         for embedded_span, target_ents in zip(
             embedded_spans,
             align_spans(
-                source=list(self.get_target_spans(doc)),
-                target=embedded_spans,
+                list(self.get_target_spans(doc)),
+                embedded_spans,
             ),
         ):
             span_tags = [[0] * len(self.labels) for _ in range(len(embedded_span))]

--- a/edsnlp/pipes/trainable/span_qualifier/span_qualifier.py
+++ b/edsnlp/pipes/trainable/span_qualifier/span_qualifier.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import logging
 import os
 import pickle
 import warnings
-from collections import defaultdict
 from typing import (
     Any,
     Dict,
@@ -12,6 +12,8 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
+    Union,
 )
 
 import foldedtensor as ft
@@ -29,18 +31,18 @@ from edsnlp.pipes.trainable.embeddings.typing import (
 from edsnlp.utils.bindings import (
     BINDING_GETTERS,
     BINDING_SETTERS,
-    Binding,
     Qualifiers,
     QualifiersArg,
 )
-from edsnlp.utils.span_getters import get_spans
+from edsnlp.utils.span_getters import SpanFilter, get_spans
+
+logger = logging.getLogger(__name__)
 
 SpanQualifierBatchInput = TypedDict(
     "SpanQualifierBatchInput",
     {
         "embedding": BatchInput,
-        "bindings_group_mask": torch.Tensor,
-        "bindings": NotRequired[torch.Tensor],
+        "targets": NotRequired[torch.Tensor],
     },
 )
 """
@@ -59,115 +61,107 @@ class TrainableSpanQualifier(
     TorchComponent[BatchOutput, SpanQualifierBatchInput], BaseComponent
 ):
     """
-    The `eds.span_qualifier` component is a trainable qualifier, predictor of span
-    attributes. In this context, the span qualification task consists in assigning
-    values (boolean, strings or any complex object) to attributes/extensions of spans
-    such as:
+    The `eds.span_qualifier` component is a trainable qualifier predictor. In EDS-NLP,
+    we call span attributes "qualifiers". In this context, the span qualification task
+    consists in assigning values (boolean, strings or any complex object) to
+    attributes/extensions of spans such as:
 
-    - `span.label_`,
     - `span._.negation`,
     - `span._.date.mode`
-    - etc.
+    - `span._.cui`
+
+    In the rest of this page, we will refer to a pair of (qualifier, value) as a
+    "binding". For instance, the binding `("_.negation", True)` means that the
+    qualifier `negation` of the span is (or should be, when predicted) set to `True`.
 
     Architecture
     ------------
-    The underlying `eds.span_multilabel_classifier.v1` model performs span
-    classification by:
+    The model performs span classification by:
 
-    1. Pooling the words embedding (`mean`, `max` or `sum`) into a single embedding per
-    span
-    2. Computing logits for each possible binding (i.e. qualifier-value assignment)
-    3. Splitting these bindings into independent groups such as
+    1. Calling a word pooling embedding such as `eds.span_pooler` to compute a single
+    embedding for each span
+    2. Computing logits for each possible binding using a linear layer
+    3. Splitting these bindings into groups of exclusive values such as
 
         - `event=start` and `event=stop`
         - `negated=False` and `negated=True`
 
-    4. Learning or predicting a combination amongst legal combination of these bindings.
-    For instance in the second group, we can't have both `negated=True` and
-    `negated=False` so the combinations are `[(1, 0), (0, 1)]`
-    5. Assigning bindings on spans depending on the predicted results
+        Note that the above groups are not exclusive, but the values within each group
+        are.
 
-    Step by step
-    ------------
-    ## Initialization
-    During the initialization of the pipeline, the `span_qualifier` component will
-    gather all spans that match `on_ents` and `on_span_groups` patterns (or
-    `candidate_getter` function). It will then list all possible values for each
-    `qualifier` of the `qualifiers` list and store every possible (qualifier, value)
-    pair (i.e. binding).
-
-    For instance, a custom qualifier `negation` with possible values `True` and `False`
-    will result in the following bindings
-    `[("_.negation", True), ("_.negation", False)]`, while a custom qualifier
-    `event` with possible values `start`, `stop`, and `start-stop` will result in
-    the following bindings
-    `[("_.event", "start"), ("_.event", "stop"), ("_.event", "start-stop")]`.
-
-    ## Training
-    During training, the `span_qualifier` component will gather spans on the documents
-    in a mini-batch and evaluate each binding on each span to build a supervision
-    matrix. This matrix will be feed it to the underlying model (most likely a
-    `eds.span_multilabel_classifier.v1`). The model will compute logits for each entry
-    of the matrix and compute a cross-entropy loss for each group of bindings sharing
-    the same qualifier.
-
-    ## Prediction
-    During prediction, the `span_qualifier` component will gather spans on a given
-    document and evaluate each binding on each span using the underlying model. Using
-    the same binding exclusion and label constraint mechanisms as during training,
-    scores will be computed for each binding and the best legal combination of bindings
-    will be selected. Finally, the selected bindings will be assigned to the spans.
+    4. Applying the best scoring binding in each group to each span
 
     Examples
     --------
-    Let us define the pipeline and train it. We provide utils to train the model using
-    an API, but you can use a spaCy's config file as well.
+    To create a span qualifier component, you can use the following code:
 
     ```python
     import edsnlp
 
     nlp = edsnlp.blank("eds")
     nlp.add_pipe(
-        "eds.transformer",
-        name="transformer",
-        config=dict(
-            model="prajjwal1/bert-tiny",
-            window=128,
-            stride=96,
-        ),
-    )
-    nlp.add_pipe(
         "eds.span_qualifier",
         name="qualifier",
         config={
             "embedding": {
+                # To embed the spans, we will use a span pooler
                 "@factory": "eds.span_pooler",
-                "embedding": nlp.get_pipe("transformer"),
+                "pooling_mode": "mean",  # mean pooling
                 "span_getter": ["ents", "sc"],
+                "embedding": {
+                    # that will use a transformer to embed the doc words
+                    "@factory": "eds.transformer",
+                    "model": "prajjwal1/bert-tiny",
+                    "window": 128,
+                    "stride": 96,
+                },
             },
+            # For every span embedded by the span pooler
+            # (doc.ents and doc.spans["sc"]), we will predict both
+            # span._.negation and span._.event_type
             "qualifiers": ["_.negation", "_.event_type"],
         },
     )
     ```
 
+    To infer the values of the qualifiers, you can use the pipeline `post_init` method:
+
+    ```{ .python .no-check }
+    nlp.post_init(gold_data)
+    ```
+
+    To train the model, refer to the [Training](/tutorials/training.md) tutorial.
+
+    You can inspect the bindings that will be used for training and prediction
+    ```{ .python .no-check }
+    print(nlp.pipes.qualifier.bindings)
+    # list of (qualifier name, span labels or True if all, values)
+    # Out: [
+    #   ('_.negation', True, [True, False]),
+    #   ('_.event_type', True, ['start', 'stop'])
+    # ]
+    ```
+
+    You can also change these values and update the bindings by calling the
+    `update_bindings` method. Don't forget to retrain the model if new values are
+    added !
+
     Parameters
     ----------
-    nlp: PipelineProtocol
-        Spacy vocabulary
-    name: str
+    nlp : PipelineProtocol
+        The pipeline object
+    name : str
         Name of the component
     embedding : SpanEmbeddingComponent
         The word embedding component
-    qualifiers: QualifiersArg
+    qualifiers : QualifiersArg
         The qualifiers to predict or train on. If a dict is given, keys are the
         qualifiers and values are the labels for which the qualifier is allowed, or True
         if the qualifier is allowed for all labels.
-    keep_none: bool
+    keep_none : bool
         If False, skip spans for which a qualifier returns None. If True (default), the
         None values will be learned and predicted, just as any other value.
     """
-
-    qualifiers: Qualifiers
 
     def __init__(
         self,
@@ -176,25 +170,41 @@ class TrainableSpanQualifier(
         *,
         embedding: SpanEmbeddingComponent,
         qualifiers: QualifiersArg,
+        values: Optional[Dict[str, List[Any]]] = None,
         keep_none: bool = False,
     ):
-        self.qualifiers = {
-            (k if k.startswith("_.") else f"_.{k}"): v for k, v in qualifiers.items()
-        }
+        qualifiers: Qualifiers
+        self.values = values
+        self.keep_none = keep_none
+        self.bindings: List[Tuple[str, List[str], List[Any]]] = [
+            (k if k.startswith("_.") else f"_.{k}", v, [])
+            for k, v in qualifiers.items()
+        ]
 
         super().__init__(nlp, name)
-
         self.embedding = embedding
-
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             self.classifier = torch.nn.Linear(embedding.output_size, 0)
 
-        self.bindings_indexer_per_group: List[slice] = []
-        self.bindings_group_mask = None
-        self.bindings: List[Binding] = []
-        self.group_qualifiers: List[set] = []
-        self.keep_none = keep_none
+    @property
+    def qualifiers(self) -> Qualifiers:
+        return {qlf: labels for qlf, labels, _ in self.bindings}
+
+    @qualifiers.setter
+    def qualifiers(self, value: Qualifiers):
+        bindings = []
+        for qlf, labels in value.items():
+            groups = [group for group in self.bindings if group[0] == qlf]
+            if len(groups) > 1:
+                raise ValueError(
+                    f"Qualifier {qlf} has different label filters: "
+                    f"{[g[0] for g in groups]}. Please use the `update_bindings` "
+                    f"method to update the labels."
+                )
+            if groups:
+                bindings.append((qlf, labels, groups[0][2]))
+        self.update_bindings(bindings)
 
     @property
     def span_getter(self):
@@ -212,10 +222,6 @@ class TrainableSpanQualifier(
             pickle.dump(
                 {
                     "bindings": self.bindings,
-                    "bindings_indexer_per_group": self.bindings_indexer_per_group,
-                    "combinations": [
-                        comb.tolist() for comb in self.combinations_per_group
-                    ],
                 },
                 f,
             )
@@ -229,27 +235,28 @@ class TrainableSpanQualifier(
         data_path = path / "bindings.pkl"
         with open(data_path, "rb") as f:
             data = pickle.load(f)
-        self.bindings = data["bindings"]
-        self.bindings_indexer_per_group = data["bindings_indexer_per_group"]
-        self.group_qualifiers = [
-            list(dict.fromkeys(key for key, _ in self.bindings[group_indexer]))
-            for group_indexer in self.bindings_indexer_per_group
-        ]
-        self.classifier = torch.nn.Linear(
-            self.embedding.output_size,
-            len(self.bindings),
-        )
-        for grp_idx, combinations in enumerate(data["combinations"]):
-            self.register_buffer(
-                f"combinations_{grp_idx}",
-                torch.tensor(combinations, dtype=torch.float),
-            )
+        self.update_bindings(data["bindings"])
         self.set_extensions()
         super().from_disk(path, exclude=exclude)
 
+    @property
+    def bindings_to_idx(self) -> List[Tuple[str, List[str], Dict[Any, int]]]:
+        if getattr(self, "_bindings_to_idx", None) is not None:
+            return self._bindings_to_idx
+        self._bindings_to_idx = [  # noqa
+            (qualifier, labels, {value: idx for idx, value in enumerate(values)})
+            for qualifier, labels, values in self.bindings
+        ]
+        return self._bindings_to_idx
+
+    @property
+    def bindings_indexers(self) -> List[Union[Sequence[int], slice]]:
+        return self._bindings_indexers
+
     def set_extensions(self):
         super().set_extensions()
-        for qlf in self.qualifiers or ():
+        for group in self.bindings:
+            qlf = group[0]
             if qlf.startswith("_."):
                 qlf = qlf[2:]
             if not Span.has_extension(qlf):
@@ -258,113 +265,92 @@ class TrainableSpanQualifier(
     def post_init(self, gold_data: Iterable[Doc], exclude: Set[str]):
         super().post_init(gold_data, exclude=exclude)
 
-        qualifier_values = defaultdict(set)
+        bindings = [
+            (qlf, labels, dict.fromkeys(vals)) for qlf, labels, vals in self.bindings
+        ]
         for doc in gold_data:
             spans = list(get_spans(doc, self.embedding.span_getter))
             for span in spans:
-                for qualifier, labels in self.qualifiers.items():
+                for qualifier, labels, values in bindings:
                     if labels is True or span.label_ in labels:
                         value = BINDING_GETTERS[qualifier](span)
                         if value is not None or self.keep_none:
-                            qualifier_values[qualifier].add(value)
+                            values[value] = None
 
-        qualifier_values = {
-            key: sorted(values, key=str) for key, values in qualifier_values.items()
-        }
+        bindings = [
+            (qualifier, labels, sorted(values, key=str))
+            for qualifier, labels, values in bindings
+        ]
 
-        for qualifier, values in qualifier_values.items():
+        for qualifier, labels, values in bindings:
             if len(values) < 2:
                 warnings.warn(
-                    f"Qualifier {qualifier} should have at least 2 values, found "
-                    f"{len(values)}: {values}"
+                    f"Qualifier {qualifier} for labels {labels} should have at "
+                    f"least 2 values but found {len(values)}: {values}."
                 )
 
-        # if self.qualifiers is not None and set(self.qualifiers) != set(
-        #     qualifier_values.keys()
-        # ):
-        #     warnings.warn(
-        #         f"Qualifiers {sorted(self.qualifiers)} do not match qualifiers found
-        #         f"in gold data {sorted(qualifier_values.keys())}"
-        #     )
-        self.bindings = []
-        self.bindings_indexer_per_group = []
+        self.update_bindings(bindings)
 
-        # `groups_combinations`:
-        # - for each group (i.e. qualifier here)
-        # - for each legal combination of bindings in this group
-        # - bindings in this combination
-        # ATM, create one group per qualifier (e.g. one group for _.event,
-        # one for _.negation, ...), and so one binding per combination
-        combinations_per_group = [
-            [((key, value),) for value in sorted(values, key=str)]
-            for key, values in qualifier_values.items()
+    def update_bindings(self, bindings: List[Tuple[str, SpanFilter, List[Any]]]):
+        keep_bindings = [
+            (labels is True or len(labels) > 0) and len(values) > 0
+            for k, labels, values in bindings
         ]
-        bindings_per_group = [
-            list(dict.fromkeys(binding for comb in group for binding in comb))
-            for group in combinations_per_group
-        ]
-        self.group_qualifiers = [
-            list(dict.fromkeys(key for key, _ in group)) for group in bindings_per_group
-        ]
-
-        for grp_idx, (group_combinations, group_bindings) in enumerate(
-            zip(combinations_per_group, bindings_per_group)
-        ):
-            self.bindings_indexer_per_group.append(
-                slice(len(self.bindings), len(self.bindings) + len(group_bindings))
+        if not all(keep_bindings):
+            logger.warning(
+                "Some qualifiers have no labels or values and have been removed:"
+                + "".join(
+                    "\n- " + str(b[0]) + " for labels " + str(b[1])
+                    for b, keep in zip(bindings, keep_bindings)
+                    if not keep
+                )
             )
-            self.bindings.extend(group_bindings)
-            # combinations buffer: bool tensor of shape
-            #   num legal combinations
-            # * num bindings in this group
-            # TODO: use sparse tensor or None to mark identity combinations
-            self.register_buffer(
-                f"combinations_{grp_idx}",
-                ft.as_folded_tensor(
-                    [
-                        [binding in combination_bindings for binding in group_bindings]
-                        for combination_bindings in group_combinations
-                    ],
-                    dtype=torch.float,
-                    full_names=("combination", "binding"),
-                ).as_tensor(),
-            )
-        if len(self.bindings) == 0:
-            raise ValueError(
-                f"No bindings found for qualifiers {sorted(self.qualifiers)} on the "
-                f"spans provided by the span embedding ({self.embedding.span_getter})."
-            )
-        self.classifier = torch.nn.Linear(
-            in_features=self.classifier.in_features,
-            out_features=len(self.bindings),
+        bindings = [b for b, keep in zip(bindings, keep_bindings) if keep]
+        new_bindings = list(
+            dict.fromkeys((k, v) for k, _, group in bindings for v in group)
+        )
+        old_bindings = list(
+            dict.fromkeys((k, v) for k, _, group in self.bindings for v in group)
         )
 
-    @property
-    def combinations_per_group(self):
-        return (
-            getattr(self, f"combinations_{i}")
-            for i in range(len(self.bindings_indexer_per_group))
-        )
+        new_bindings_to_idx = {binding: idx for idx, binding in enumerate(new_bindings)}
+        old_bindings_to_idx = {binding: idx for idx, binding in enumerate(old_bindings)}
+
+        common = [b for b in new_bindings if b in old_bindings]
+        old_index = [old_bindings_to_idx[label] for label in common]
+        new_index = [new_bindings_to_idx[label] for label in common]
+        new_linear = torch.nn.Linear(self.classifier.in_features, len(new_bindings))
+        new_linear.weight.data[new_index] = self.classifier.weight.data[old_index]
+        self.classifier.weight = new_linear.weight
+        self.classifier.out_features = new_bindings
+        missing_bindings = set(new_bindings) - set(old_bindings)
+        if missing_bindings and len(old_bindings) > 0:
+            warnings.warn(
+                f"Added {len(missing_bindings)} new bindings. Consider retraining "
+                f"the model to learn these new bindings."
+            )
+
+        if hasattr(self.classifier, "bias"):
+            new_linear.bias.data[new_index] = self.classifier.bias.data[old_index]
+            self.classifier.bias = new_linear.bias
+
+        def simplify_indexer(indexer):
+            return (
+                slice(indexer[0], indexer[-1] + 1)
+                if len(indexer) and list(range(indexer[0], indexer[-1] + 1)) == indexer
+                else indexer
+            )
+
+        self.bindings = bindings
+        self._bindings_indexers = [
+            simplify_indexer([new_bindings_to_idx[(qlf, value)] for value in values])
+            for qlf, labels, values in bindings
+        ]
+        self._bindings_to_idx = None
 
     def preprocess(self, doc: Doc) -> Dict[str, Any]:
-        embedding = self.embedding.preprocess(doc)
-        # "$" prefix means this field won't be accessible from the outside.
-        spans = embedding["$spans"]
         return {
-            "embedding": embedding,
-            "bindings_group_mask": [
-                [
-                    not set(group_qualifiers).isdisjoint(
-                        set(
-                            qlf
-                            for qlf, span_filter in self.qualifiers.items()
-                            if span_filter is True or span.label_ in span_filter
-                        )
-                    )
-                    for group_qualifiers in self.group_qualifiers
-                ]
-                for span in spans
-            ],
+            "embedding": self.embedding.preprocess(doc),
         }
 
     def preprocess_supervised(self, doc: Doc) -> Dict[str, Any]:
@@ -372,44 +358,29 @@ class TrainableSpanQualifier(
         spans = preps["embedding"]["$spans"]
         return {
             **preps,
-            "bindings": [
+            "targets": [
                 [
-                    (
-                        self.qualifiers[binding[0]] is True
-                        or span.label_ in self.qualifiers[binding[0]]
-                    )
-                    and BINDING_GETTERS[binding](span)
-                    for binding in self.bindings
+                    values_to_idx.get(BINDING_GETTERS[qlf](span), -100)
+                    if labels is True or span.label_ in labels
+                    else -100
+                    for qlf, labels, values_to_idx in self.bindings_to_idx
                 ]
                 for span in spans
             ],
         }
 
     def collate(self, batch: Dict[str, Sequence[Any]]) -> SpanQualifierBatchInput:
-        bindings_group_mask = ft.as_folded_tensor(
-            batch["bindings_group_mask"],
-            dtype=torch.bool,
-            full_names=("sample", "span", "binding"),
-            data_dims=("span", "binding"),
-        ).as_tensor()
-        bindings_group_mask = bindings_group_mask.view(
-            len(bindings_group_mask), len(self.group_qualifiers)
-        )
         collated: SpanQualifierBatchInput = {
             "embedding": self.embedding.collate(batch["embedding"]),
-            "bindings_group_mask": bindings_group_mask,
         }
-        if "bindings" in batch:
-            bindings = ft.as_folded_tensor(
-                [
-                    span_bindings
-                    for sample in batch["bindings"]
-                    for span_bindings in sample
-                ],
-                dtype=torch.float,
-                full_names=("span", "binding"),
+        if "targets" in batch:
+            targets = ft.as_folded_tensor(
+                batch["targets"],
+                dtype=torch.long,
+                full_names=("sample", "span", "group"),
+                data_dims=("span", "group"),
             ).as_tensor()
-            collated["bindings"] = bindings.view(len(bindings), len(self.bindings))
+            collated["targets"] = targets.view(len(targets), len(self.bindings))
         return collated
 
     # noinspection SpellCheckingInspection
@@ -418,8 +389,6 @@ class TrainableSpanQualifier(
         Apply the span classifier module to the document embeddings and given spans to:
         - compute the loss
         - and/or predict the labels of spans
-        If labels are predicted, they are assigned to the `additional_outputs`
-        dictionary.
 
         Parameters
         ----------
@@ -433,55 +402,30 @@ class TrainableSpanQualifier(
         embedding = self.embedding.module_forward(batch["embedding"])
         span_embeds = embedding["embeddings"]
 
-        n_spans, dim = span_embeds.shape
-        n_bindings = len(self.bindings)
-        device = span_embeds.device
-
         binding_scores = self.classifier(span_embeds)
 
-        if "bindings" not in batch:
-            pred = torch.zeros(n_spans, n_bindings, device=device)
-            losses = None
-        else:
-            losses = [torch.zeros((), dtype=torch.float, device=device)]
+        if "targets" in batch:
+            losses = []
             pred = None
+        else:
+            pred = []
+            losses = None
 
-        for group_idx, (bindings_indexer, combinations) in enumerate(
-            zip(
-                self.bindings_indexer_per_group,
-                self.combinations_per_group,
-            )
-        ):
-            group_samples_mask = batch["bindings_group_mask"][:, group_idx]
-            combinations_scores = torch.einsum(
-                "eb,cb->ec",
-                binding_scores[group_samples_mask][:, bindings_indexer],
-                combinations.float(),
-            )
-
-            if "bindings" in batch:
-                group_samples_mask = batch["bindings_group_mask"][:, group_idx]
-                # ([e]ntities * [b]indings) * ([c]ombinations * [b]indings)
-                targets = torch.einsum(
-                    "eb,cb->ec",
-                    batch["bindings"][group_samples_mask][:, bindings_indexer],
-                    combinations,
-                )
-                # [e]ntities * [c]comb --(argmax)--> [e]entities
-                # Choose the combination of bindings in this group that fits the
-                # most the gold bindings
-                targets = targets.argmax(-1)
+        # For each group, for instance:
+        # - `event=start` and `event=stop`
+        # - `negated=False` and `negated=True`
+        for group_idx, bindings_indexer in enumerate(self.bindings_indexers):
+            if "targets" in batch:
                 losses.append(
-                    F.cross_entropy(combinations_scores, targets, reduction="sum")
+                    F.cross_entropy(
+                        binding_scores[:, bindings_indexer],
+                        batch["targets"][:, group_idx],
+                        reduction="sum",
+                    )
                 )
-                assert not torch.isnan(losses[-1]).any(), combinations_scores
-            elif "bindings" not in batch:
-                pred[:, bindings_indexer][group_samples_mask] = combinations[
-                    combinations_scores.argmax(-1)
-                ]
-
-        if "bindings" in batch:
-            assert len(losses) > 0, "No group found"
+                assert not torch.isnan(losses[-1]).any(), "NaN loss"
+            else:
+                pred.append(binding_scores[:, bindings_indexer].argmax(dim=1))
 
         return {
             "loss": sum(losses) if losses is not None else None,
@@ -489,10 +433,14 @@ class TrainableSpanQualifier(
         }
 
     def postprocess(self, docs: Sequence[Doc], batch: BatchOutput) -> Sequence[Doc]:
-        spans = [
-            span for doc in docs for span in get_spans(doc, self.embedding.span_getter)
-        ]
-        for span_idx, binding_idx in batch["labels"].nonzero(as_tuple=False):
-            span = spans[span_idx]
-            BINDING_SETTERS[self.bindings[binding_idx]](span)
+        # Preprocessed docs should still be in the cache
+        spans = [s for doc in docs for s in self.preprocess(doc)["embedding"]["$spans"]]
+        # For each prediction group (exclusive bindings)...
+        for val_indices, (qlf, labels, values) in zip(batch["labels"], self.bindings):
+            # For each span...
+            for span, idx in zip(spans, val_indices.tolist()):
+                # If the span is not filtered out...
+                if labels is True or span.label_ in labels:
+                    # ...assign the predicted value to the span
+                    BINDING_SETTERS[qlf](span, values[idx])
         return docs

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -680,6 +680,11 @@ def execute_multiprocessing_backend(
         <img src="/assets/images/model-parallelism.png" />
     </div>
 
+    !!! warning "Caveat"
+
+        Since workers can produce their results in any order, the order of the results
+        may not be the same as the order of the input tasks.
+
     """
     try:
         TorchComponent = sys.modules["edsnlp.core.torch_component"].TorchComponent

--- a/edsnlp/utils/filter.py
+++ b/edsnlp/utils/filter.py
@@ -232,8 +232,8 @@ def span_f1(a: Span, b: Span) -> float:
 
 
 def align_spans(
-    source: Sequence[Span],
-    target: Sequence[Span],
+    source_spans: Sequence[Span],
+    target_spans: Sequence[Span],
     sort_by_overlap: bool = False,
 ) -> List[List[Span]]:
     """
@@ -242,9 +242,9 @@ def align_spans(
 
     Parameters
     ----------
-    source : List[Span]
+    source_spans : List[Span]
         List of spans to align.
-    target : List[Span]
+    target_spans : List[Span]
         List of spans to align.
     sort_by_overlap : bool
         Whether to sort the aligned spans by maximum dice/f1 overlap
@@ -255,17 +255,22 @@ def align_spans(
     List[List[Span]]
         Subset of `source` spans for each target span
     """
-    source = sorted(source, key=lambda x: (x.start, x.end))
-    targets_with_idx = sorted(enumerate(target), key=lambda x: (x[1].start, x[1].end))
+    source_spans = sorted(source_spans, key=lambda x: (x.start, x.end))
+    targets_with_idx = sorted(
+        enumerate(target_spans), key=lambda x: (x[1].start, x[1].end)
+    )
 
-    aligned = [set() for _ in target]
+    aligned = [set() for _ in target_spans]
     source_idx = 0
     for target_idx, target in targets_with_idx:
-        while source_idx < len(source) and source[source_idx].end <= target.start:
+        while (
+            source_idx < len(source_spans)
+            and source_spans[source_idx].end <= target.start
+        ):
             source_idx += 1
         i = source_idx
-        while i < len(source) and source[i].start < target.end:
-            aligned[target_idx].add(source[i])
+        while i < len(source_spans) and source_spans[i].start < target.end:
+            aligned[target_idx].add(source_spans[i])
             i += 1
 
     aligned = [list(span_set) for span_set in aligned]
@@ -273,8 +278,10 @@ def align_spans(
     # Sort the aligned spans by maximum dice/f1 overlap with the target span
     if sort_by_overlap:
         aligned = [
-            sorted(span_set, key=lambda x: span_f1(x, y), reverse=True)
-            for span_set, (_, y) in zip(aligned, targets_with_idx)
+            sorted(
+                aligned_span_set, key=lambda x: span_f1(x, target_span), reverse=True
+            )
+            for aligned_span_set, target_span in zip(aligned, target_spans)
         ]
 
     return aligned

--- a/edsnlp/utils/span_getters.py
+++ b/edsnlp/utils/span_getters.py
@@ -17,8 +17,9 @@ from typing_extensions import Literal
 
 from edsnlp import registry
 from edsnlp.utils.filter import filter_spans
+from edsnlp.utils.typing import AsList
 
-SeqStr = Union[str, Sequence[str]]
+SeqStr = AsList[str]
 SpanFilter = Union[bool, SeqStr]
 
 SpanSetterMapping = Dict[str, SpanFilter]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 import pandas as pd
@@ -7,6 +8,8 @@ from helpers import make_nlp
 from pytest import fixture
 
 import edsnlp
+
+logging.basicConfig(level=logging.INFO)
 
 
 @fixture(scope="session", params=["eds", "fr"])

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -305,7 +305,7 @@ def test_torch_save(ml_nlp):
 
 
 def test_parameters(frozen_ml_nlp):
-    assert len(list(frozen_ml_nlp.parameters())) == 40
+    assert len(list(frozen_ml_nlp.parameters())) == 42
 
 
 def test_missing_factory(nlp):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,4 @@
+import os
 from io import BytesIO
 
 import pytest
@@ -73,6 +74,8 @@ def test_disk_serialization(tmp_path, ml_nlp):
     assert nlp.get_pipe("transformer").stride == 96
     ner = nlp.get_pipe("ner")
     ner.update_labels(["PERSON", "GIFT"])
+
+    os.makedirs(tmp_path / "model", exist_ok=True)
     nlp.to_disk(tmp_path / "model")
 
     print("tmp_path", tmp_path, list((tmp_path / "model/transformer").iterdir()))

--- a/tests/training/ner_qlf_config.cfg
+++ b/tests/training/ner_qlf_config.cfg
@@ -74,14 +74,16 @@ randomize = true
 max_length = 10
 multi_sentence = false
 [train.train_data.reader]
-@readers: "standoff"
-path: ${vars.train}
-span_setter: ${vars.gold_span_group}
-span_attributes: "negation"
+@readers = "standoff"
+path = ${vars.train}
+span_setter = ${vars.gold_span_group}
+span_attributes = "negation"
+bool_attributes = ["negation"]
 
 [train.val_data]
 [train.val_data.reader]
-@readers: "standoff"
-path: ${vars.dev}
-span_setter: ${vars.gold_span_group}
-span_attributes: "negation"
+@readers = "standoff"
+path = ${vars.dev}
+span_setter = ${vars.gold_span_group}
+span_attributes = "negation"
+bool_attributes = ["negation"]

--- a/tests/training/qlf_config.cfg
+++ b/tests/training/qlf_config.cfg
@@ -70,6 +70,7 @@ path: ${vars.train}
 converter: "custom"
 span_setter: ${vars.ml_span_groups}
 span_attributes: "negation"
+bool_attributes: ["negation"]
 
 [train.val_data]
 [train.val_data.reader]
@@ -78,3 +79,4 @@ path: ${vars.dev}
 converter: "custom"
 span_setter: ${vars.ml_span_groups}
 span_attributes: "negation"
+bool_attributes: ["negation"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Changed

- :warning: Breaking change. Improved and simplified `eds.span_qualifier`: we didn't support combination groups before, so this feature was scrapped for now. We now also support splitting values of a single qualifier between different span labels.

### Fixed

- Allow span pooler to choose between multiple base embedding spans (as likely produced by `eds.transformer`) by sorting them by Dice overlap score.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
