### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.10.7
+pip install edsnlp==0.11.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.10.7"
+pip install "edsnlp[ml]==0.11.0"
 ```
 
 ### A first pipeline
@@ -48,7 +48,7 @@ pip install "edsnlp[ml]==0.10.7"
 Once you've installed the library, let's begin with a very simple example that extracts mentions of COVID19 in a text, and detects whether they are negated.
 
 ```python
-import edsnlp
+import edsnlp, edsnlp.pipes as eds
 
 nlp = edsnlp.blank("eds")
 
@@ -57,10 +57,10 @@ terms = dict(
 )
 
 # Split the documents into sentences, this isneeded for negation detection
-nlp.add_pipe("eds.sentences")
+nlp.add_pipe(eds.sentences())
 # Matcher component
-nlp.add_pipe("eds.matcher", config=dict(terms=terms))
-# Negation detection
+nlp.add_pipe(eds.matcher(terms=terms))
+# Negation detection (we also support spacy-like API !)
 nlp.add_pipe("eds.negation")
 
 # Process your text in one call !

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.11.0 (2024-03-29)
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.10.7
+pip install edsnlp==0.11.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.10.7"
+pip install "edsnlp[ml]==0.11.0"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -14,7 +14,7 @@ from .core.registries import registry
 import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 
-__version__ = "0.10.7"
+__version__ = "0.11.0"
 
 BASE_DIR = Path(__file__).parent
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

### Added

- Support for a `filesystem` parameter in every `edsnlp.data.read_*` and `edsnlp.data.write_*` functions
- Pipes of a pipeline are now easily accessible with `nlp.pipes.xxx` instead of `nlp.get_pipe("xxx")`
- Support builtin Span attributes in converters `span_attributes` parameter, e.g.
  ```python
  import edsnlp

  nlp = ...
  nlp.add_pipe("eds.sentences")

  data = edsnlp.data.from_xxx(...)
  data = data.map_pipeline(nlp)
  data.to_pandas(converters={"ents": {"span_attributes": ["sent.text", "start", "end"]}})
  ```
- Support assigning Brat AnnotatorNotes as span attributes: `edsnlp.data.read_standoff(...,  notes_as_span_attribute="cui")`
- Support for mapping full batches in `edsnlp.processing` pipelines with `map_batches` lazy collection method:
  ```python
  import edsnlp

  data = edsnlp.data.from_xxx(...)
  data = data.map_batches(lambda batch: do_something(batch))
  data.to_pandas()
  ```
- New `data.map_gpu` method to map a deep learning operation on some data and take advantage of edsnlp multi-gpu inference capabilities
- Added average precision computation in edsnlp span_classification scorer
- You can now add pipes to your pipeline by instantiating them directly, which comes with many advantages, such as auto-completion, introspection and type checking !

  ```python
  import edsnlp, edsnlp.pipes as eds

  nlp = edsnlp.blank("eds")
  nlp.add_pipe(eds.sentences())
  # instead of nlp.add_pipe("eds.sentences")
  ```

  *The previous way of adding pipes is still supported.*
- New `eds.span_linker` deep-learning component to match entities with their concepts in a knowledge base, in synonym-similarity or concept-similarity mode.

### Changed

- `nlp.preprocess_many` now uses lazy collections to enable parallel processing
- :warning: Breaking change. Improved and simplified `eds.span_qualifier`: we didn't support combination groups before, so this feature was scrapped for now. We now also support splitting values of a single qualifier between different span labels.
- Optimized edsnlp.data batching, especially for large batch sizes (removed a quadratic loop)
- :warning: Breaking change. By default, the name of components added to a pipeline is now the default name defined in their class `__init__` signature. For most components of EDS-NLP, this will change the name from "eds.xxx" to "xxx".

### Fixed

- Flatten list outputs (such as "ents" converter) when iterating: `nlp.map(data).to_iterable("ents")` is now a list of entities, and not a list of lists of entities
- Allow span pooler to choose between multiple base embedding spans (as likely produced by `eds.transformer`) by sorting them by Dice overlap score.
- EDS-NLP does not raise an error anymore when saving a model to an already existing, but empty directory
