### PR TITLE
Fix dates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,11 +54,14 @@
 - Trainable embedding components now all use `foldedtensor` to return embeddings, instead of returning a tensor of floats and a mask tensor.
 - :boom: TorchComponent `__call__` no longer applies the end to end method, and instead calls the `forward` method directly, like all torch modules.
 - The trainable `eds.span_qualifier` component has been renamed to `eds.span_classifier` to reflect its general gpurpose (it doesn't only predict qualifiers, but any attribute of a span using its context or not).
+- `omop` converter now takes the `note_datetime` field into account by default when building a document
+- `span._.date.to_datetime()` and `span._.date.to_duration()` now automatically take the `note_datetime` into account
 
 ### Fixed
 
 - `edsnlp.data.read_json` now correctly read the files from the directory passed as an argument, and not from the parent directory.
 - Overwrite spacy's Doc, Span and Token pickling utils to allow recursively storing Doc, Span and Token objects in the extension values (in particular, span._.date.doc)
+- Removed pendulum dependency, solving various pickling, multiprocessing and missing attributes errors
 
 ## v0.11.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,7 @@
 ### Fixed
 
 - `edsnlp.data.read_json` now correctly read the files from the directory passed as an argument, and not from the parent directory.
+- Overwrite spacy's Doc, Span and Token pickling utils to allow recursively storing Doc, Span and Token objects in the extension values (in particular, span._.date.doc)
 
 ## v0.11.2
 

--- a/docs/tutorials/multiple-texts.md
+++ b/docs/tutorials/multiple-texts.md
@@ -83,6 +83,7 @@ for doc in docs:
             end=date.end_char,
             label="date",
             entity_text=date.text,
+            datetime=date._.date.datetime,
         )
         rows.append(d)
 df = pd.DataFrame(rows)
@@ -160,7 +161,8 @@ def convert_doc_to_rows(doc):
             begin=date.start_char,
             end=date.end_char,
             label="date",
-            entity_text=date.text,
+            lexical_variant=date.text,
+            datetime=date._.date.datetime,
         )
         entities.append(d)
 
@@ -172,7 +174,13 @@ df = docs.to_pandas(converter=convert_doc_to_rows)
 df = docs.to_pandas(
     converter="ents",
     span_getter=["ents", "dates"],
-    span_attributes=["negation", "hypothesis", "family"],
+    span_attributes={
+        # span._.*** name: column name
+        "negation": "negation",
+        "hypothesis": "hypothesis",
+        "family": "family",
+        "date.datetime": "datetime",
+    },
 )
 ```
 
@@ -263,10 +271,14 @@ note_nlp = docs.to_pandas(
     # Below are the arguments to the converter
     span_getter=["ents", "dates"],
     span_attributes={  # (1)
+        # span._.*** name: column name
         "negation": "negation",
         "hypothesis": "hypothesis",
         "family": "family",
-        "date.day": "date_day",  # slugified name
+        "date.datetime": "datetime",
+        # having individual columns for each date part
+        # can be useful for incomplete dates (eg, "in May")
+        "date.day": "date_day",
         "date.month": "date_month",
         "date.year": "date_year",
     },
@@ -308,9 +320,13 @@ note_nlp = docs.to_pandas(
         "negation": "negation",
         "hypothesis": "hypothesis",
         "family": "family",
-        "date.day": "date_day",  # slugify the extension name
+        "date.datetime": "datetime",
+
+        # having individual columns for each date part
+        # can be useful for incomplete dates (eg, "in May")
+        "date.day": "date_day",
         "date.month": "date_month",
-        "date.year": "date_year"
+        "date.year": "date_year",
     },
 )
 ```
@@ -336,9 +352,13 @@ note_nlp = docs.to_spark(
         "negation": "negation",
         "hypothesis": "hypothesis",
         "family": "family",
-        "date.day": "date_day",  # slugify the extension name
+        "date.datetime": "datetime",
+
+        # having individual columns for each date part
+        # can be useful for incomplete dates (eg, "in May")
+        "date.day": "date_day",
         "date.month": "date_month",
-        "date.year": "date_year"
+        "date.year": "date_year",
     },
     dtypes=None,  # (1)
 )

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -13,6 +13,7 @@ from .core.pipeline import Pipeline, blank, load
 from .core.registries import registry
 import edsnlp.data  # noqa: F401
 import edsnlp.pipes
+from . import reducers
 
 __version__ = "0.11.2"
 

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -432,7 +432,7 @@ class OmopDict2DocConverter:
         *,
         tokenizer: Optional[PipelineProtocol] = None,
         span_setter: SpanSetterArg = {"ents": True, "*": True},
-        doc_attributes: AttributesMappingArg = {},
+        doc_attributes: AttributesMappingArg = {"note_datetime": "note_datetime"},
         span_attributes: Optional[AttributesMappingArg] = None,
         default_attributes: AttributesMappingArg = {},
         bool_attributes: SequenceStr = [],

--- a/edsnlp/pipes/misc/consultation_dates/consultation_dates.py
+++ b/edsnlp/pipes/misc/consultation_dates/consultation_dates.py
@@ -52,7 +52,7 @@ class ConsultationDatesMatcher(GenericMatcher):
     # Out: [Consultation du 03/10/2018]
 
     doc.spans["consultation_dates"][0]._.consultation_date.to_datetime()
-    # Out: DateTime(2018, 10, 3, 0, 0, 0, tzinfo=Timezone('Europe/Paris'))
+    # Out: DateTime(2018, 10, 3, 0, 0, 0)
     ```
 
     Extensions

--- a/edsnlp/pipes/qualifiers/history/history.py
+++ b/edsnlp/pipes/qualifiers/history/history.py
@@ -1,7 +1,7 @@
-from datetime import timedelta
+from datetime import timedelta, tzinfo
 from typing import List, Optional, Set, Union
 
-import pendulum
+import pytz
 from loguru import logger
 from spacy.tokens import Doc, Span, Token
 
@@ -162,6 +162,8 @@ class HistoryQualifier(RuleBasedQualifier):
         for each key in the iterable
     explain : bool
         Whether to keep track of cues for each entity.
+    tz : Optional[Union[str, tzinfo]]
+        The timezone to use. Defaults to "Europe/Paris".
 
     Authors and citation
     --------------------
@@ -186,6 +188,7 @@ class HistoryQualifier(RuleBasedQualifier):
         span_getter: Optional[SpanGetterArg] = None,
         on_ents_only: Optional[Union[bool, str, List[str], Set[str]]] = None,
         explain: bool = False,
+        tz: Optional[Union[str, tzinfo]] = None,
     ):
         terms = dict(
             history=patterns.history if history is None else history,
@@ -206,6 +209,7 @@ class HistoryQualifier(RuleBasedQualifier):
         self.history_limit = timedelta(history_limit)
         self.exclude_birthdate = exclude_birthdate
         self.closest_dates_only = closest_dates_only
+        self.tz = pytz.timezone(tz) if tz is not None else None
 
         self.sections = use_sections and (
             "eds.sections" in nlp.pipe_names or "sections" in nlp.pipe_names
@@ -299,8 +303,11 @@ class HistoryQualifier(RuleBasedQualifier):
         note_datetime = None
         if doc._.note_datetime is not None:
             try:
-                note_datetime = pendulum.instance(doc._.note_datetime)
-                note_datetime = note_datetime.set(tz="Europe/Paris")
+                note_datetime = (
+                    self.tz.localize(doc._.note_datetime, is_dst=None)
+                    if doc._.note_datetime.tzinfo is None and self.tz is not None
+                    else doc._.note_datetime
+                )
             except ValueError:
                 logger.debug(
                     "note_datetime must be a datetime objects. "
@@ -311,8 +318,11 @@ class HistoryQualifier(RuleBasedQualifier):
         birth_datetime = None
         if doc._.birth_datetime is not None:
             try:
-                birth_datetime = pendulum.instance(doc._.birth_datetime)
-                birth_datetime = birth_datetime.set(tz="Europe/Paris")
+                birth_datetime = (
+                    self.tz.localize(doc._.birth_datetime, is_dst=None)
+                    if doc._.birth_datetime.tzinfo is None and self.tz is not None
+                    else doc._.birth_datetime
+                )
             except ValueError:
                 logger.debug(
                     "birth_datetime must be a datetime objects. "
@@ -365,7 +375,7 @@ class HistoryQualifier(RuleBasedQualifier):
                             -value.to_duration(
                                 note_datetime=doc._.note_datetime,
                                 infer_from_context=True,
-                                tz="Europe/Paris",
+                                tz=self.tz,
                                 default_day=15,
                             )
                             >= self.history_limit
@@ -382,7 +392,7 @@ class HistoryQualifier(RuleBasedQualifier):
                         absolute_date = value.to_datetime(
                             note_datetime=note_datetime,
                             infer_from_context=True,
-                            tz="Europe/Paris",
+                            tz=self.tz,
                             default_day=15,
                         )
                     except ValueError as e:
@@ -395,7 +405,7 @@ class HistoryQualifier(RuleBasedQualifier):
                             e,
                         )
                     if absolute_date:
-                        if note_datetime.diff(absolute_date) < self.history_limit:
+                        if note_datetime - absolute_date < self.history_limit:
                             recent_dates.append(
                                 Span(doc, date.start, date.end, label="absolute_date")
                             )

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -796,7 +796,7 @@ def execute_multiprocessing_backend(
         and num_gpu_workers > 0
     )
 
-    num_cpus = cpu_count()
+    num_cpus = int(os.environ["EDSNLP_MAX_CPU_WORKERS"] or cpu_count())
     num_devices = 0
     if requires_gpu:
         import torch

--- a/edsnlp/reducers.py
+++ b/edsnlp/reducers.py
@@ -1,0 +1,114 @@
+import copyreg
+from weakref import WeakSet
+
+from spacy.tokens import Doc, Span, Token
+from spacy.vocab import Vocab
+
+_pickle_memo = WeakSet()
+
+
+def _reduce_doc(doc):
+    seen = doc in _pickle_memo
+
+    if not seen:
+        # uid = uuid.uuid4()
+        _pickle_memo.add(doc)
+        # -> [uid, need to encode body]
+        return (_add_back_user_data_and_hooks, (doc, doc.user_data, doc.user_hooks))
+
+    # uid, need_to_encode_body = _pickle_memo[doc]
+    # if not need_to_encode_body:
+    #     return (_rebuild_doc, (uid,))
+
+    array_head = Doc._get_array_attrs()
+    strings = set()
+    for token in doc:
+        strings.add(token.tag_)
+        strings.add(token.lemma_)
+        strings.add(str(token.morph))
+        strings.add(token.dep_)
+        strings.add(token.ent_type_)
+        strings.add(token.ent_kb_id_)
+        strings.add(token.ent_id_)
+        strings.add(token.norm_)
+    for group in doc.spans.values():
+        for span in group:
+            strings.add(span.label_)
+            if span.kb_id in span.doc.vocab.strings:
+                strings.add(span.kb_id_)
+            if span.id in span.doc.vocab.strings:
+                strings.add(span.id_)
+    data = {
+        "vocab": doc.vocab,
+        "text": doc.text,
+        "array_head": array_head,
+        "array_body": doc.to_array(array_head),
+        "sentiment": doc.sentiment,
+        "tensor": doc.tensor,
+        "cats": doc.cats,
+        "spans": doc.spans.to_bytes(),
+        "strings": list(strings),
+        "has_unknown_spaces": doc.has_unknown_spaces,
+    }
+    _pickle_memo.remove(doc)
+    return (_rebuild_doc, (data,))
+
+
+def _rebuild_doc(data):
+    doc = Doc(Vocab())
+    doc.from_dict(data)
+    return doc
+
+
+def _add_back_user_data_and_hooks(doc, user_data, user_hooks):
+    doc.user_data = user_data
+    doc.user_hooks = user_hooks
+    return doc
+
+
+def _reduce_span(span):
+    data = {
+        "start": span.start,
+        "end": span.end,
+        "label": span.label_,
+        "kb_id": span.kb_id_,
+        "id": span.id_,
+        "doc": span.doc,
+    }
+    return (_rebuild_span, (data,))
+
+
+def _rebuild_span(data):
+    return Span(
+        doc=data["doc"],
+        start=data["start"],
+        end=data["end"],
+        label=data["label"],
+        kb_id=data["kb_id"],
+        span_id=data["id"],
+    )
+
+
+def _reduce_token(token):
+    return (
+        _rebuild_token,
+        (
+            token.doc,
+            token.i,
+        ),
+    )
+
+
+def _rebuild_token(doc, i):
+    """Import the token contents from a dictionary.
+
+    doc (Doc): The parent document.
+    i (int): The index of the token in the document.
+    RETURNS (Token): The deserialized `Token`.
+    """
+    return doc[i]
+
+
+copyreg.pickle(Doc, _reduce_doc)
+copyreg.pickle(Span, _reduce_span)
+copyreg.pickle(Token, _reduce_token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dynamic = ['version']
 dependencies = [
     "decorator",
     "loguru",
-    "pendulum>=2.1.2",
+    "pytz",
+    "python-dateutil",
     "pydantic>=1.10.2",
     "pysimstring>=1.2.1",
     "regex",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import time
 from datetime import datetime
 
 import pandas as pd
@@ -9,6 +11,10 @@ from pytest import fixture
 
 import edsnlp
 
+os.environ["EDSNLP_MAX_CPU_WORKERS"] = "2"
+os.environ["TZ"] = "Europe/Paris"
+
+time.tzset()
 logging.basicConfig(level=logging.INFO)
 
 

--- a/tests/processing/test_backends.py
+++ b/tests/processing/test_backends.py
@@ -51,6 +51,7 @@ docs = [
         ("parquet", "omop", "spark", "parquet", "omop", False),
         ("parquet", "omop", "multiprocessing", "parquet", "omop", True),
         ("parquet", "omop", "spark", "parquet", "omop", True),
+        ("parquet", "omop", "multiprocessing", "iterable", None, False),
     ],
 )
 def test_end_to_end(
@@ -113,6 +114,8 @@ def test_end_to_end(
                 converter=writer_converter,
                 write_in_worker=worker_io,
             )
+    elif writer_format == "iterable":
+        list(data)
     else:
         raise ValueError(writer_format)
 

--- a/tests/test_reducers.py
+++ b/tests/test_reducers.py
@@ -1,0 +1,64 @@
+import copy
+import pickle
+
+import dill
+import pytest
+from spacy.tokens import Doc
+
+import edsnlp
+
+if not hasattr(Doc, "custom_test_reducers"):
+    Doc.set_extension("custom_test_reducers", default=None)
+
+
+@pytest.mark.parametrize("pickler_module", ["pickle", "dill"])
+def test_reducers(pickler_module):
+    pickler = pickle if pickler_module == "pickle" else dill
+    doc = edsnlp.blank("eds")("This is a test.")
+    doc.spans["test"] = [doc[0:1]]
+    span = doc.spans["test"][0]
+    token = doc[0]
+    data = [
+        doc,  # data[0]
+        token,  # data[1]
+        token,  # data[2]
+        span,  # data[3]
+        span,  # data[4]
+    ]
+    doc._.custom_test_reducers = data
+    doc_bytes = pickler.dumps(doc)
+
+    doc_bis = pickler.loads(doc_bytes)
+    data_bis = doc_bis._.custom_test_reducers
+    assert data_bis[0] is doc_bis
+    assert data_bis[1] == doc_bis[0]
+    assert data_bis[1] is data_bis[2]
+    assert data_bis[3] is data_bis[4]
+
+    doc_ter = pickler.loads(doc_bytes)
+    data_ter = doc_ter._.custom_test_reducers
+    assert data_ter[0] is not data_bis[0]
+
+
+def test_deep_copy():
+    doc = edsnlp.blank("eds")("This is a test.")
+    doc.spans["test"] = [doc[0:1]]
+    span = doc.spans["test"][0]
+    token = doc[0]
+    data = [
+        doc,  # data[0]
+        token,  # data[1]
+        token,  # data[2]
+        span,  # data[3]
+        span,  # data[4]
+    ]
+
+    bis = copy.deepcopy(data)
+    ter = copy.deepcopy(data)
+    assert bis[1].doc is bis[0]
+    assert bis[3].doc is bis[0]
+    assert bis[1] is bis[2]
+    assert bis[3] is bis[4]
+
+    assert bis[0] is not doc
+    assert bis[0] is not ter[0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

Various date related fixes. May also fix issues like serializing date cues (see https://github.com/aphp/edsnlp/issues/116) and multiprocessing issues like #290.

## Description

### Added

- Added `span._.date.datetime` and `span._.date.duration` properties, to easily add them as exported span attributes in converters (e.g., `to_pandas(converter="ents", span_attributes=["date.datetime"])`)

### Changed

- `omop` converter now takes the `note_datetime` field into account by default when building a document
- `span._.date.to_datetime()` and `span._.date.to_duration()` now automatically take the `note_datetime` into account

### Fixed

- Overwrite spacy's Doc, Span and Token pickling utils to allow recursively storing Doc, Span and Token objects in the extension values (in particular, span._.date.doc)
- Removed pendulum dependency, solving various pickling, multiprocessing and missing attributes errors

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
