### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,6 @@ jobs:
           # requites to grab the history of the PR
           fetch-depth: 0
       - uses: actions/setup-python@v4
-        with:
-          # cache: 'pip'
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --color=always --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.11.2
+pip install edsnlp==0.12.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.11.2"
+pip install "edsnlp[ml]==0.12.0"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## v0.12.0
+
+### Added
+
 - The `eds.transformer` component now accepts `prompts` (passed to its `preprocess` method, see breaking change below) to add before each window of text to embed.
 - `LazyCollection.map` / `map_batches` now support generator functions as arguments.
 - Window stride can now be disabled (i.e., stride = window) during training in the `eds.transformer` component by `training_stride = False`
@@ -55,7 +63,7 @@
     ```
 - Trainable embedding components now all use `foldedtensor` to return embeddings, instead of returning a tensor of floats and a mask tensor.
 - :boom: TorchComponent `__call__` no longer applies the end to end method, and instead calls the `forward` method directly, like all torch modules.
-- The trainable `eds.span_qualifier` component has been renamed to `eds.span_classifier` to reflect its general gpurpose (it doesn't only predict qualifiers, but any attribute of a span using its context or not).
+- The trainable `eds.span_qualifier` component has been renamed to `eds.span_classifier` to reflect its general purpose (it doesn't only predict qualifiers, but any attribute of a span using its context or not).
 - `omop` converter now takes the `note_datetime` field into account by default when building a document
 - `span._.date.to_datetime()` and `span._.date.to_duration()` now automatically take the `note_datetime` into account
 - `nlp.vocab` is no longer serialized when saving a model, as it may contain sensitive information and can be recomputed during inference anyway

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.11.2
+pip install edsnlp==0.12.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.11.2"
+pip install "edsnlp[ml]==0.12.0"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -15,7 +15,7 @@ import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 from . import reducers
 
-__version__ = "0.11.2"
+__version__ = "0.12.0"
 
 BASE_DIR = Path(__file__).parent
 

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -1213,7 +1213,7 @@ def load_from_huggingface(
     if should_install or not any(
         p.startswith(module_name) and p.endswith(".dist-info") for p in os.listdir(path)
     ):
-        pip = sys.executable.rsplit("/", 1)[0] + "/pip"
+        pip = os.path.join(*os.path.split(sys.executable)[:-1], "pip")
         subprocess.run(
             [pip, "install", path, "--target", path, "--no-deps", "--upgrade"]
         )

--- a/edsnlp/core/registries.py
+++ b/edsnlp/core/registries.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, Iterable, Optional, Sequence
 from weakref import WeakKeyDictionary
 
 import catalogue
-import importlib_metadata
 import spacy
 from confit import Config, Registry, RegistryCollection, set_default_registry
 from confit.errors import ConfitValidationError, patch_errors
@@ -16,6 +15,11 @@ from spacy.pipe_analysis import validate_attrs
 
 import edsnlp
 from edsnlp.utils.collections import FrozenDict, FrozenList
+
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 PIPE_META = WeakKeyDictionary()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,10 @@ import edsnlp
 os.environ["EDSNLP_MAX_CPU_WORKERS"] = "2"
 os.environ["TZ"] = "Europe/Paris"
 
-time.tzset()
+try:
+    time.tzset()
+except AttributeError:
+    pass
 logging.basicConfig(level=logging.INFO)
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

### Added

- The `eds.transformer` component now accepts `prompts` (passed to its `preprocess` method, see breaking change below) to add before each window of text to embed.
- `LazyCollection.map` / `map_batches` now support generator functions as arguments.
- Window stride can now be disabled (i.e., stride = window) during training in the `eds.transformer` component by `training_stride = False`
- Added a new `eds.ner_overlap_scorer` to evaluate matches between two lists of entities, counting true when the dice overlap is above a given threshold
- `edsnlp.load` now accepts EDS-NLP models from the huggingface hub 🤗 !

### Changed

- :boom: Major breaking change in trainable components, moving towards a more "task-centric" design:
  - the `eds.transformer` component is no longer responsible for deciding which spans of text ("contexts") should be embedded. These contexts are now passed via the `preprocess` method, which now accepts more arguments than just the docs to process.
  - similarly the `eds.span_pooler` is now longer responsible for deciding which spans to pool, and instead pools all spans passed to it in the `preprocess` method.

  Consequently, the `eds.transformer` and `eds.span_pooler` no longer accept their `span_getter` argument, and the `eds.ner_crf`, `eds.span_classifier`, `eds.span_linker` and `eds.span_qualifier` components now accept a `context_getter` argument instead, as well as a `span_getter` argument for the latter two. This refactoring can be summarized as follows:

    ```diff
    - eds.transformer.span_getter
    + eds.ner_crf.context_getter
    + eds.span_classifier.context_getter
    + eds.span_linker.context_getter

    - eds.span_pooler.span_getter
    + eds.span_qualifier.span_getter
    + eds.span_linker.span_getter
    ```

    and as an example for the `eds.span_linker` component:

    ```diff
    nlp.add_pipe(
        eds.span_linker(
            metric="cosine",
            probability_mode="sigmoid",
    +       span_getter="ents",
    +       # context_getter="ents",  -> by default, same as span_getter
            embedding=eds.span_pooler(
                hidden_size=128,
    -           span_getter="ents",
                embedding=eds.transformer(
    -               span_getter="ents",
                    model="prajjwal1/bert-tiny",
                    window=128,
                    stride=96,
                ),
            ),
        ),
        name="linker",
    )
    ```
- Trainable embedding components now all use `foldedtensor` to return embeddings, instead of returning a tensor of floats and a mask tensor.
- :boom: TorchComponent `__call__` no longer applies the end to end method, and instead calls the `forward` method directly, like all torch modules.
- The trainable `eds.span_qualifier` component has been renamed to `eds.span_classifier` to reflect its general purpose (it doesn't only predict qualifiers, but any attribute of a span using its context or not).
- `omop` converter now takes the `note_datetime` field into account by default when building a document
- `span._.date.to_datetime()` and `span._.date.to_duration()` now automatically take the `note_datetime` into account
- `nlp.vocab` is no longer serialized when saving a model, as it may contain sensitive information and can be recomputed during inference anyway

### Fixed

- `edsnlp.data.read_json` now correctly read the files from the directory passed as an argument, and not from the parent directory.
- Overwrite spacy's Doc, Span and Token pickling utils to allow recursively storing Doc, Span and Token objects in the extension values (in particular, span._.date.doc)
- Removed pendulum dependency, solving various pickling, multiprocessing and missing attributes errors

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
