### PR TITLE
Better packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+Packages:
+
+- Pip-installable models are now built with `hatch` instead of poetry, which allows us to expose `artifacts` (weights)
+  at the root of the sdist package (uploadable to HF) and move them inside the package upon installation to avoid conflicts.
+- Dependencies are no longer inferred with dill-magic (this didn't work well before anyway)
+- Option to perform substitutions in the model's README.md file (e.g., for the model's name, metrics, ...)
+
 ## v0.12.1
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Packages:
   at the root of the sdist package (uploadable to HF) and move them inside the package upon installation to avoid conflicts.
 - Dependencies are no longer inferred with dill-magic (this didn't work well before anyway)
 - Option to perform substitutions in the model's README.md file (e.g., for the model's name, metrics, ...)
+- Huggingface models are now installed with pip *editable* installations, which is faster since it doesn't copy around the weights
 
 ## v0.12.1
 

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -27,6 +27,7 @@ from typing import (
     Union,
 )
 
+import huggingface_hub
 import pkg_resources
 import requests
 import spacy
@@ -932,7 +933,7 @@ class Pipeline:
         self,
         name: Optional[str] = None,
         root_dir: Union[str, Path] = ".",
-        build_dir: Union[str, Path] = "build",
+        build_dir: Optional[Union[str, Path]] = None,
         dist_dir: Union[str, Path] = "dist",
         artifacts_name: str = "artifacts",
         check_dependencies: bool = False,
@@ -943,6 +944,7 @@ class Pipeline:
         config_settings: Optional[Mapping[str, Union[str, Sequence[str]]]] = None,
         isolation: bool = True,
         skip_build_dependency_check: bool = False,
+        readme_replacements: Dict[str, str] = {},
     ):
         from edsnlp.package import package
 
@@ -961,6 +963,7 @@ class Pipeline:
             config_settings=config_settings,
             isolation=isolation,
             skip_build_dependency_check=skip_build_dependency_check,
+            readme_replacements=readme_replacements,
         )
 
     def __getstate__(self):
@@ -1124,6 +1127,7 @@ def load(
             and str(model).split("/")[0] not in FORBIDDEN_AUTO_HF_OWNERS
         ):
             try:
+                huggingface_hub.login()
                 return load_from_huggingface(
                     model,
                     overrides=overrides,

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import warnings
 from enum import Enum
 from pathlib import Path
@@ -27,7 +28,6 @@ from typing import (
     Union,
 )
 
-import huggingface_hub
 import pkg_resources
 import requests
 import spacy
@@ -1127,7 +1127,6 @@ def load(
             and str(model).split("/")[0] not in FORBIDDEN_AUTO_HF_OWNERS
         ):
             try:
-                huggingface_hub.login()
                 return load_from_huggingface(
                     model,
                     overrides=overrides,
@@ -1217,9 +1216,9 @@ def load_from_huggingface(
     if should_install or not any(
         p.startswith(module_name) and p.endswith(".dist-info") for p in os.listdir(path)
     ):
-        pip = os.path.join(*os.path.split(sys.executable)[:-1], "pip")
+        pip = os.path.join(sysconfig.get_path("scripts"), "pip")
         subprocess.run(
-            [pip, "install", path, "--target", path, "--no-deps", "--upgrade"]
+            [pip, "install", "-e", path, "--target", path, "--no-deps", "--upgrade"]
         )
 
     if path not in sys.path:

--- a/edsnlp/utils/examples.py
+++ b/edsnlp/utils/examples.py
@@ -1,8 +1,8 @@
-import json
 import re
 from typing import Any, Dict, List, Tuple, Union
 
 import regex
+from confit.utils.xjson import loads
 from pydantic import BaseModel, validator
 
 
@@ -19,14 +19,7 @@ class Modifier(BaseModel):
 
     @validator("value")
     def optional_dict_parsing(cls, v):
-        if v in ["True", "False"]:
-            return v == "True"
-        if isinstance(v, str):
-            try:
-                return json.loads(v.replace("'", '"'))
-            except json.JSONDecodeError:
-                return v
-        return v
+        return loads(v) if isinstance(v, str) else v
 
 
 class Entity(BaseModel):

--- a/tests/utils/test_package.py
+++ b/tests/utils/test_package.py
@@ -1,6 +1,8 @@
 import importlib
 import subprocess
 import sys
+import tarfile
+import zipfile
 
 import pytest
 
@@ -13,14 +15,13 @@ def test_blank_package(nlp, tmp_path):
     if not isinstance(nlp, edsnlp.Pipeline):
         pytest.skip("Only running for edsnlp.Pipeline")
 
-    with pytest.raises(Exception):
-        package(
-            pipeline=nlp,
-            root_dir=tmp_path,
-            name="test-model-fail",
-            metadata={},
-            project_type="poetry",
-        )
+    package(
+        pipeline=nlp,
+        root_dir=tmp_path,
+        name="test-model-fail",
+        metadata={},
+        project_type="poetry",
+    )
 
     nlp.package(
         root_dir=tmp_path,
@@ -33,10 +34,8 @@ def test_blank_package(nlp, tmp_path):
         distributions=["wheel"],
     )
     assert (tmp_path / "dist").is_dir()
-    assert (tmp_path / "build").is_dir()
     assert (tmp_path / "dist" / "test_model-0.1.0-py3-none-any.whl").is_file()
     assert not (tmp_path / "dist" / "test_model-0.1.0.tar.gz").is_file()
-    assert (tmp_path / "build" / "test-model").is_dir()
 
 
 @pytest.mark.parametrize("package_name", ["my-test-model", None])
@@ -50,6 +49,7 @@ def test_package_with_files(nlp, tmp_path, package_name):
     (tmp_path / "test_model" / "__init__.py").write_text('print("Hello World!")\n')
     (tmp_path / "README.md").write_text(
         """\
+<!-- INSERT -->
 # Test Model
 """
     )
@@ -67,21 +67,10 @@ authors = ["Test Author <test.author@mail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7"
+build = "*"  # sample light package to install
 """
     )
-
-    with pytest.raises(ValueError):
-        package(
-            pipeline=nlp,
-            root_dir=tmp_path,
-            version="0.1.0",
-            name=package_name,
-            metadata={
-                "description": "Wrong description",
-                "authors": "Test Author <test.author@mail.com>",
-            },
-        )
 
     package(
         name=package_name,
@@ -91,8 +80,11 @@ python = "^3.7"
         version="0.1.0",
         distributions=None,
         metadata={
-            "description": "A test model",
+            "description": "A new description",
             "authors": "Test Author <test.author@mail.com>",
+        },
+        readme_replacements={
+            "<!-- INSERT -->": "Replaced !",
         },
     )
 
@@ -103,6 +95,43 @@ python = "^3.7"
     assert (tmp_path / "dist" / f"{module_name}-0.1.0-py3-none-any.whl").is_file()
     assert (tmp_path / "pyproject.toml").is_file()
 
+    with zipfile.ZipFile(
+        tmp_path / "dist" / f"{module_name}-0.1.0-py3-none-any.whl"
+    ) as zf:
+        # check files
+        assert set(zf.namelist()) == {
+            f"{module_name}-0.1.0.dist-info/METADATA",
+            f"{module_name}-0.1.0.dist-info/RECORD",
+            f"{module_name}-0.1.0.dist-info/WHEEL",
+            f"{module_name}/__init__.py",
+            f"{module_name}/artifacts/config.cfg",
+            f"{module_name}/artifacts/meta.json",
+            f"{module_name}/artifacts/tokenizer",
+            "test_model/__init__.py",
+        }
+        # check description
+        with zf.open(f"{module_name}-0.1.0.dist-info/METADATA") as f:
+            assert b"A new description" in f.read()
+
+    with tarfile.open(tmp_path / "dist" / f"{module_name}-0.1.0.tar.gz") as tf:
+        # check files
+        assert set(tf.getnames()) == {
+            f"{module_name}-0.1.0/PKG-INFO",
+            f"{module_name}-0.1.0/README.md",
+            f"{module_name}-0.1.0/artifacts/config.cfg",
+            f"{module_name}-0.1.0/artifacts/meta.json",
+            f"{module_name}-0.1.0/artifacts/tokenizer",
+            f"{module_name}-0.1.0/{module_name}/__init__.py",
+            f"{module_name}-0.1.0/pyproject.toml",
+            f"{module_name}-0.1.0/test_model/__init__.py",
+        }
+        # check description
+        with tf.extractfile(f"{module_name}-0.1.0/PKG-INFO") as f:
+            assert b"A new description" in f.read()
+
+        with tf.extractfile(f"{module_name}-0.1.0/README.md") as f:
+            assert b"Replaced !" in f.read()
+
     # pip install the whl file
     (tmp_path / "site-packages").mkdir(exist_ok=True)
     print(
@@ -112,6 +141,7 @@ python = "^3.7"
                 "-m",
                 "pip",
                 "install",
+                "-vvv",
                 "--target",
                 str(tmp_path / "site-packages"),
                 str(tmp_path / "dist" / f"{module_name}-0.1.0-py3-none-any.whl"),
@@ -120,7 +150,17 @@ python = "^3.7"
         )
     )
 
-    sys.path.insert(0, str(tmp_path / "site-packages"))
+    site_packages = tmp_path / "site-packages"
+    sys.path.insert(0, str(site_packages))
+    # check site-package files
+    files = {str(f.relative_to(site_packages)) for f in set(site_packages.rglob("*"))}
+    assert files >= {
+        f"{module_name}/artifacts",
+        f"{module_name}/artifacts/config.cfg",
+        f"{module_name}/artifacts/meta.json",
+        f"{module_name}/artifacts/tokenizer",
+    }
+
     module = importlib.import_module(module_name)
 
     assert module.__version__ == "0.1.0"
@@ -142,8 +182,10 @@ __version__ = '{module.__version__}'
 def load(
     overrides: Optional[Dict[str, Any]] = None,
 ) -> edsnlp.Pipeline:
-    artifacts_path = Path(__file__).parent / "artifacts"
-    model = edsnlp.load(artifacts_path, overrides=overrides)
+    path_outside = Path(__file__).parent / "../artifacts"
+    path_inside = Path(__file__).parent / "artifacts"
+    path = path_inside if path_inside.exists() else path_outside
+    model = edsnlp.load(path, overrides=overrides)
     return model
 """
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Changed

Packages:

- Pip-installable models are now built with `hatch` instead of poetry, which allows us to expose `artifacts` (weights)
  at the root of the sdist package (uploadable to HF) and move them inside the package upon installation to avoid conflicts.
- Dependencies are no longer inferred with dill-magic (this didn't work well before anyway)
- Option to perform substitutions in the model's README.md file (e.g., for the model's name, metrics, ...)
- Huggingface models are now installed with pip *editable* installations, which is faster since it doesn't copy around the weights

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
