### PR TITLE
Fix span context getter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,7 @@
 - Support mixed precision in `eds.text_cnn` and `eds.ner_crf` components
 - Support pre-quantization (<4.30) transformers versions
 - Verify that all batches are non empty
-- Fix `span_context_getter` for `context_sents` > 2 and support assymetric contexts
+- Fix `span_context_getter` for `context_words` = 0, `context_sents` > 2 and support assymetric contexts
 
 ## v0.12.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@
 - Support mixed precision in `eds.text_cnn` and `eds.ner_crf` components
 - Support pre-quantization (<4.30) transformers versions
 - Verify that all batches are non empty
+- Fix `span_context_getter` for `context_sents` > 2 and support assymetric contexts
 
 ## v0.12.3
 

--- a/edsnlp/utils/span_getters.py
+++ b/edsnlp/utils/span_getters.py
@@ -307,11 +307,13 @@ class make_span_context_getter:
         n_words_left = self.n_words_left
         n_words_right = self.n_words_right
 
-        start = span.start - n_words_left
-        end = span.end + n_words_right
+        start = max(0, span.start - n_words_left)
+        end = min(len(span.doc), span.end + n_words_right)
 
         n_sents_max = max(n_sents_left, n_sents_right)
         if n_sents_max > 0:
+            min_start_sent = start
+            max_end_sent = end
             if n_sents_left == 1:
                 sent = span.sent
                 min_start_sent = sent.start
@@ -325,10 +327,7 @@ class make_span_context_getter:
                 max_end_sent = sents[
                     min(len(sents) - 1, sent_i + n_sents_right - 1)
                 ].end
-            start = max(0, min(start, min_start_sent))
-            end = min(len(span.doc), max(end, max_end_sent))
-        else:
-            start = max(0, start)
-            end = min(len(span.doc), end)
+            start = min(start, min_start_sent)
+            end = max(end, max_end_sent)
 
         return span.doc[start:end]

--- a/tests/utils/test_span_getters.py
+++ b/tests/utils/test_span_getters.py
@@ -2,8 +2,8 @@ import edsnlp
 from edsnlp.utils.span_getters import make_span_context_getter
 
 
-def test_span_sentence_getter(lang):
-    nlp = edsnlp.blank("eds")
+def test_span_context_getter_symmetric(lang):
+    nlp = edsnlp.blank(lang)
     nlp.add_pipe("eds.normalizer")
     nlp.add_pipe("eds.sentences")
     nlp.add_pipe("eds.matcher", config={"terms": {"sentence": "sentence"}})
@@ -13,15 +13,6 @@ def test_span_sentence_getter(lang):
         "This is a third one. "
         "Last sentence."
     )
-
-    span_getter = make_span_context_getter(
-        context_words=2,
-    )
-    assert [span_getter(s).text for s in doc.ents] == [
-        "This is a sentence. This",
-        "This is another sentence. This",
-        ". Last sentence.",
-    ]
 
     span_getter = make_span_context_getter(
         context_words=2,
@@ -47,8 +38,62 @@ def test_span_sentence_getter(lang):
         context_sents=2,
     )
     assert [span_getter(s).text for s in doc.ents] == [
+        "This is a sentence. This is another sentence.",
         "This is a sentence. This is another sentence. This is a third one.",
-        "This is a sentence. This is another sentence. This is a third one. Last "
-        "sentence.",
-        "This is another sentence. This is a third one. Last sentence.",
+        "This is a third one. Last sentence.",
+    ]
+
+
+def test_span_context_getter_asymmetric(lang):
+    nlp = edsnlp.blank(lang)
+    nlp.add_pipe("eds.normalizer")
+    nlp.add_pipe("eds.sentences")
+    nlp.add_pipe("eds.matcher", config={"terms": {"animal": "kangaroo"}})
+    doc = nlp(
+        "This is a sentence. "
+        "This is another sentence with a kangaroo. "
+        "This is a third one. "
+        "Last sentence."
+    )
+
+    span_getter = make_span_context_getter(context_words=2, context_sents=0)
+    assert [span_getter(s).text for s in doc.ents] == [
+        "with a kangaroo. This",
+    ]
+
+    span_getter = make_span_context_getter(context_words=(2, 1), context_sents=0)
+    assert [span_getter(s).text for s in doc.ents] == [
+        "with a kangaroo.",
+    ]
+
+    span_getter = make_span_context_getter(context_words=(1, 2), context_sents=0)
+    assert [span_getter(s).text for s in doc.ents] == [
+        "a kangaroo. This",
+    ]
+
+    span_getter = make_span_context_getter(context_words=0, context_sents=(1, 2))
+    assert [span_getter(s).text for s in doc.ents] == [
+        "This is another sentence with a kangaroo. This is a third one.",
+    ]
+
+    span_getter = make_span_context_getter(context_words=0, context_sents=(2, 2))
+    assert [span_getter(s).text for s in doc.ents] == [
+        "This is a sentence. This is another sentence with a kangaroo. This is a third one."  # noqa: E501
+    ]
+
+    span_getter = make_span_context_getter(context_words=0, context_sents=(1, 1))
+    assert [span_getter(s).text for s in doc.ents] == [
+        "This is another sentence with a kangaroo."
+    ]
+
+    span_getter = make_span_context_getter(context_words=(1000, 0), context_sents=0)
+    assert [span_getter(s).text for s in doc.ents] == [
+        "This is a sentence. This is another sentence with a kangaroo"
+    ]
+
+    span_getter = make_span_context_getter(
+        context_words=(1000, 0), context_sents=(1, 2)
+    )
+    assert [span_getter(s).text for s in doc.ents] == [
+        "This is a sentence. This is another sentence with a kangaroo. This is a third one."  # noqa: E501
     ]


### PR DESCRIPTION
## Description
- Add the possibility to get asymmetric contexts
- Fix when context_sents=2. Before it was taking the phrase +-2. This behaviour didn't allow to get only the phrase of the span and the 
juxtaposed phrases

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
