### PR TITLE
DOC replace from_* into read_* in case of reading files

### DIFF
--- a/docs/data/json.md
+++ b/docs/data/json.md
@@ -5,7 +5,7 @@
     ```{ .python .no-check }
     import edsnlp
 
-    docs = edsnlp.data.from_json(df, converter="omop")
+    docs = edsnlp.data.read_json(df, converter="omop")
     docs = docs.map_pipeline(nlp)
     res = edsnlp.data.to_json(docs, converter="omop")
     ```

--- a/docs/data/parquet.md
+++ b/docs/data/parquet.md
@@ -5,7 +5,7 @@
     ```{ .python .no-check }
     import edsnlp
 
-    docs = edsnlp.data.from_parquet(df, converter="omop")
+    docs = edsnlp.data.read_parquet(df, converter="omop")
     docs = docs.map_pipeline(nlp)
     res = edsnlp.data.to_parquet(docs, converter="omop")
     ```

--- a/docs/data/standoff.md
+++ b/docs/data/standoff.md
@@ -5,7 +5,7 @@
     ```{ .python .no-check }
     import edsnlp
 
-    doc_iterator = edsnlp.data.from_standoff(path)
+    doc_iterator = edsnlp.data.read_standoff(path)
     res = edsnlp.data.write_standoff(docs, path)
     ```
 


### PR DESCRIPTION
Doc pages for standoff, json & parquet were mentioning `from_*` instead of `read_*`

