### PR TITLE
chore: bump version to 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.12.3
+pip install edsnlp==0.13.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.12.3"
+pip install "edsnlp[ml]==0.13.0"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.13.0
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.12.3
+pip install edsnlp==0.13.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.12.3"
+pip install "edsnlp[ml]==0.13.0"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -15,7 +15,7 @@ import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 from . import reducers
 
-__version__ = "0.12.3"
+__version__ = "0.13.0"
 
 BASE_DIR = Path(__file__).parent
 

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -3,6 +3,7 @@ import functools
 import importlib
 import inspect
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1229,8 +1230,9 @@ def load_from_huggingface(
     missing_deps = []
     # Check if the dependencies are installed, with the correct version
     for req in reqs:
+        req_without_extra = re.sub(r"\[.*\]", "", req)
         try:
-            pkg_resources.require(req)
+            pkg_resources.require(req_without_extra)
         except (pkg_resources.VersionConflict, pkg_resources.DistributionNotFound):
             missing_deps.append(req)
 

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -662,7 +662,7 @@ class GPUWorker:
                     device_type=autocast_device_type,
                     dtype=autocast_dtype,
                 )
-                if lc.autocast is not None
+                if lc.autocast
                 else nullcontext()
             )
 

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -28,7 +28,11 @@ def execute_simple_backend(
         torch = sys.modules["torch"]
         no_grad_ctx = torch.no_grad()
         autocast_device_type = next(
-            (p.device for _ in lc.torch_components() for p in lc.parameters()),
+            (
+                p.device
+                for name, pipe in lc.torch_components()
+                for p in pipe.parameters()
+            ),
             torch.device("cpu"),
         ).type.split(":")[0]
         autocast_dtype = lc.autocast if lc.autocast is not True else None
@@ -37,7 +41,7 @@ def execute_simple_backend(
                 device_type=autocast_device_type,
                 dtype=autocast_dtype,
             )
-            if lc.autocast is not None
+            if lc.autocast
             else nullcontext()
         )
         inference_mode_ctx = (


### PR DESCRIPTION
## Changelog

### Added

- `data.set_processing(...)` now expose an `autocast` parameter to disable or tweak the automatic casting of the tensor
  during the processing. Autocasting should result in a slight speedup, but may lead to numerical instability.
- Use `torch.inference_mode` to disable view tracking and version counter bumps during inference.
- Added a new NER pipeline for suicide attempt detection
- Added date cues (regular expression matches that contributed to a date being detected) under the extension `ent._.date_cues`
- Added tables processing in eds.measurement
- Added 'all' as possible input in eds.measurement measurements config
- Added new units in eds.measurement

### Changed

- Default to mixed precision inference

### Fixed

- `edsnlp.load("your/huggingface-model", install_dependencies=True)` now correctly resolves the python pip
  (especially on Colab) to auto-install the model dependencies
- We now better handle empty documents in the `eds.transformer`, `eds.text_cnn` and `eds.ner_crf` components
- Support mixed precision in `eds.text_cnn` and `eds.ner_crf` components
- Support pre-quantization (<4.30) transformers versions
- Verify that all batches are non empty
- Fix `span_context_getter` for `context_words` = 0, `context_sents` > 2 and support assymetric contexts
- Don't split sentences on rare unicode symbols
- Better detect abbreviations, like `E.coli`, now split as [`E.`, `coli`] and not [`E`, `.`, `coli`]


## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
