### PR TITLE
Remove pollution exclusion during numbers matching

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Numbers are now only detected without trying to remove the pollution in between digits, ie `55 @ 77777` could be detected as a full number before, but not anymore.
+
 ## v0.13.0
 
 ### Added

--- a/edsnlp/pipes/misc/measurements/measurements.py
+++ b/edsnlp/pipes/misc/measurements/measurements.py
@@ -714,7 +714,12 @@ class MeasurementsMatcher(BaseNERComponent):
                     self.unitless_patterns[pattern_name] = {"name": name, **pattern}
 
         # NUMBER PATTERNS
-        self.regex_matcher.add("number", [number_regex])
+        self.regex_matcher.add(
+            "number",
+            [number_regex],
+            ignore_excluded=False,
+            ignore_space_tokens=False,
+        )
         self.number_label_hashes = {nlp.vocab.strings["number"]}
         for number, terms in number_terms.items():
             self.term_matcher.build_patterns(nlp, {number: terms})

--- a/tests/pipelines/misc/test_measurements.py
+++ b/tests/pipelines/misc/test_measurements.py
@@ -226,6 +226,7 @@ def test_numbers(blank_nlp: PipelineProtocol, matcher: MeasurementsMatcher):
         ("2 m", "2 m"),
         ("⅛ m", "0.125 m"),
         ("0 m", "0 m"),
+        ("55 @ 77777 cm", "77777 cm"),
     ]:
         doc = blank_nlp(text)
         doc = matcher(doc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Fixes #315 
Error was caused by a pollution spans being between two numbers. We obviously don't want to match numbers that are not contiguous spans of text, even under the assumption that the text extraction was faulty so I disabled the ignore_pollution of the number regex matcher.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
