### PR TITLE
Adding minimum_table_size argument to eds.tables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
           name: coverage-data-${{ matrix.python-version }}
           path: .coverage.*
           if-no-files-found: ignore
+          include-hidden-files: true
 
   coverage:
     name: Coverage

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `eds.tables` accepts a minimum_table_size (default 2) argument to reduce pollution
+
 ### Fixed
 
 - Numbers are now only detected without trying to remove the pollution in between digits, ie `55 @ 77777` could be detected as a full number before, but not anymore.

--- a/edsnlp/pipes/misc/tables/patterns.py
+++ b/edsnlp/pipes/misc/tables/patterns.py
@@ -1,2 +1,2 @@
 sep = ["¦", "|"]
-regex_template = [r"(?:{sep}?(?:[^{sep}\n]*{sep})+[^{sep}\n]*{sep}?\n)+"]
+regex_template = [r"(?:{sep}?(?:[^{sep}\n]*{sep})+[^{sep}\n]*{sep}?\n){{{n},}}"]

--- a/edsnlp/pipes/misc/tables/tables.py
+++ b/edsnlp/pipes/misc/tables/tables.py
@@ -111,6 +111,8 @@ class TablesMatcher(BaseComponent):
     sep_pattern : Optional[str]
         The regex pattern to identify the separator pattern.
         Used when calling `to_pd_table`.
+    min_rows : Optional[int]
+        Only tables with more then `min_rows` lines will be detected.
     attr : str
         spaCy's attribute to use:
         a string with the value "TEXT" or "NORM", or a dict with
@@ -130,6 +132,7 @@ class TablesMatcher(BaseComponent):
         *,
         tables_pattern: Optional[AsList[str]] = None,
         sep_pattern: Optional[AsList[str]] = None,
+        min_rows: int = 2,
         attr: Union[Dict[str, str], str] = "TEXT",
         ignore_excluded: bool = True,
     ):
@@ -145,7 +148,7 @@ class TablesMatcher(BaseComponent):
             "table",
             list(
                 dict.fromkeys(
-                    template.format(sep=re.escape(sep))
+                    template.format(sep=re.escape(sep), n=re.escape(str(min_rows)))
                     for sep in sep_pattern
                     for template in tables_pattern
                 )

--- a/tests/pipelines/misc/test_tables.py
+++ b/tests/pipelines/misc/test_tables.py
@@ -17,6 +17,13 @@ qdfsdf
 
 2/2Pat : <NOM> <Prenom> |<date> | <ipp> |Intitulé RCP
 
+Table de taille <= 3 :
+
+ |Libellé | Unité | Valeur | Intervalle |
+ |Leucocytes |x10*9/L |4.97 | 4.09-11 |
+
+qdfsdf
+
  |Libellé | Unité | Valeur | Intervalle |
  |Leucocytes |x10*9/L |4.97 | 4.09-11 |
  |Hématies |x10*12/L|4.68 | 4.53-5.79 |
@@ -35,7 +42,7 @@ def test_tables(blank_nlp):
     if blank_nlp.lang != "eds":
         pytest.skip("Test only for eds language")
     blank_nlp.add_pipe("eds.normalizer")
-    blank_nlp.add_pipe("eds.tables")
+    blank_nlp.add_pipe("eds.tables", config=dict(min_rows=3))
 
     doc = blank_nlp(TEXT)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Adding a `minimum_table_size` argument (default 2) to `eds.tables` to reduce pollution and withdraw table detections such as : 

_Pierre | Dupont | M | 29/07/1981_

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
