### PR TITLE
Fs encoding fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Numbers are now only detected without trying to remove the pollution in between digits, ie `55 @ 77777` could be detected as a full number before, but not anymore.
+- Fix fsspec open file encoding to "utf-8".
 
 ## v0.13.0
 

--- a/edsnlp/data/standoff.py
+++ b/edsnlp/data/standoff.py
@@ -77,7 +77,7 @@ def parse_standoff_file(
     relations = []
     events = {}
 
-    with fs.open(txt_path, "r") as f:
+    with fs.open(txt_path, "r", encoding='utf-8') as f:
         text = f.read()
 
     if not len(ann_paths):
@@ -86,7 +86,7 @@ def parse_standoff_file(
         }
 
     for ann_file in ann_paths:
-        with fs.open(ann_file, "r") as f:
+        with fs.open(ann_file, "r", encoding='utf-8') as f:
             for line_idx, line in enumerate(f):
                 try:
                     if line.startswith("T"):

--- a/edsnlp/data/standoff.py
+++ b/edsnlp/data/standoff.py
@@ -77,7 +77,7 @@ def parse_standoff_file(
     relations = []
     events = {}
 
-    with fs.open(txt_path, "r", encoding='utf-8') as f:
+    with fs.open(txt_path, "r", encoding="utf-8") as f:
         text = f.read()
 
     if not len(ann_paths):
@@ -86,7 +86,7 @@ def parse_standoff_file(
         }
 
     for ann_file in ann_paths:
-        with fs.open(ann_file, "r", encoding='utf-8') as f:
+        with fs.open(ann_file, "r", encoding="utf-8") as f:
             for line_idx, line in enumerate(f):
                 try:
                     if line.startswith("T"):


### PR DESCRIPTION
Fix FS encoding

## Description

Force the fsspec open method to use "UTF-8" encoding.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] Changes were documented in the changelog (pending section).
