### PR TITLE
chore: bump version to 0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.13.0
+pip install edsnlp==0.13.1
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.13.0"
+pip install "edsnlp[ml]==0.13.1"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,19 +1,19 @@
 # Changelog
 
-## Unreleased
+## v0.13.1
 
 ### Added
 
 - `eds.tables` accepts a minimum_table_size (default 2) argument to reduce pollution
-- `RuleBasedQualifier` now expose a `process` method that only returns qualified entities and token without actually tagging them, defering this task to the `__call__` method.
+- `RuleBasedQualifier` now expose a `process` method that only returns qualified entities and token without actually tagging them, deferring this task to the `__call__` method.
 - Added new patterns for metastasis detection. Developed on CT-Scan reports.
 - Added citation of articles
 
 ### Fixed
 
-- Disorder and Behavor pipes don't use a "PRESENT" or "ABSENT" `status` anymore. Instead, `status=None` by default,
+- Disorder and Behavior pipes don't use a "PRESENT" or "ABSENT" `status` anymore. Instead, `status=None` by default,
   and `ent._.negation` is set to True instead of setting `status` to "ABSENT". To this end, the *tobacco* and *alcohol*
-  now use the `NegationQualifier` internaly.
+  now use the `NegationQualifier` internally.
 - Numbers are now only detected without trying to remove the pollution in between digits, ie `55 @ 77777` could be detected as a full number before, but not anymore.
 - Fix fsspec open file encoding to "utf-8".
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.13.0
+pip install edsnlp==0.13.1
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.13.0"
+pip install "edsnlp[ml]==0.13.1"
 ```
 
 ### A first pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pytz",
     "pysimstring>=1.2.1",
     "regex",
-    "spacy>=3.1,<3.8",
+    "spacy>=3.2,<3.8",
     "confit>=0.5.5",
     "tqdm",
     "umls-downloader>=0.1.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- `eds.tables` accepts a minimum_table_size (default 2) argument to reduce pollution
- `RuleBasedQualifier` now expose a `process` method that only returns qualified entities and token without actually tagging them, defering this task to the `__call__` method.

### Fixed

- Disorder and Behavor pipes don't use a "PRESENT" or "ABSENT" `status` anymore. Instead, `status=None` by default,
  and `ent._.negation` is set to True instead of setting `status` to "ABSENT". To this end, the *tobacco* and *alcohol*
  now use the `NegationQualifier` internaly.
- Numbers are now only detected without trying to remove the pollution in between digits, ie `55 @ 77777` could be detected as a full number before, but not anymore.
- Fix fsspec open file encoding to "utf-8".

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
