### PR TITLE
Various fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Support for setuptools based projects in `edsnlp.package` command
-- Pipelines can now be instantiated directly from a config file (instead of having to cast a dict containing their arguments) by putting the @pipelines = "base" or "load" field in the pipeline section)
+- Pipelines can now be instantiated directly from a config file (instead of having to cast a dict containing their arguments) by putting the @core = "pipeline" or "load" field in the pipeline section)
 - `edsnlp.load` now correctly takes disable, enable and exclude parameters into account
 - Pipeline now has a basic repr showing is base langage (mostly useful to know its tokenizer) and its pipes
 - New `python -m edsnlp.evaluate` script to evaluate a model on a dataset

--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,12 @@
 
 - We now provide a training script `python -m edsnlp.train --config config.cfg` that should fit many use cases. Check out the docs !
 - In particular, we do not require pytorch's Dataloader for training and can rely solely on EDS-NLP stream/data API, which is better suited for large streamable datasets and dynamic preprocessing (ie different result each time we apply a noised preprocessing op on a sample).
+- Each trainable component can now provide a `stats` field in its `preprocess` output to log info about the sample (number of words, tokens, spans, ...):
+
+    - these stats are both used for batching (e.g., make batches of no more than "25000 tokens")
+    - for logging
+    - for computing correct loss means when accumulating gradients over multiple mini-mini-batches
+    - for computing correct loss means in multi-GPU setups, since these stats are synchronized and accumulated across GPUs
 
 ## v0.13.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,25 @@
 - New revamped and documented `edsnlp.train` script and API
 - Support YAML config files (supported only CFG/INI files before)
 - Most of EDS-NLP functions are now clickable in the documentation
+- ScheduledOptimizer now accepts schedules directly in place of parameters, and easy parameter selection:
+
+    ```
+    ScheduledOptimizer(
+        optim="adamw",
+        module=nlp,
+        total_steps=2000,
+        groups={
+            "^transformer": {
+                # lr will go from 0 to 5e-5 then to 0 for params matching "transformer"
+                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0 "max_value": 5e-5,},
+            },
+            "": {
+                # lr will go from 3e-4 during 200 steps then to 0 for other params
+                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4 "max_value": 3e-4,},
+            },
+        },
+    )
+    ```
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 ### Changed
 
 - `eds.span_context_getter`'s parameter `context_sents` is no longer optional and must be explicitly set to 0 to disable sentence context
+- In multi-GPU setups, streams that contain torch components are now stripped of their parameter tensors when sent to CPU Workers since these workers only perform preprocessing and postprocessing and should therefore not need the model parameters.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -80,6 +80,8 @@
     - for computing correct loss means when accumulating gradients over multiple mini-mini-batches
     - for computing correct loss means in multi-GPU setups, since these stats are synchronized and accumulated across GPUs
 
+- Support multi GPU training via hugginface `accelerate` and EDS-NLP `Stream` API consideration of env['WOLRD_SIZE'] and env['LOCAL_RANK'] environment variables
+
 ## v0.13.1
 
 ### Added

--- a/docs/concepts/inference.md
+++ b/docs/concepts/inference.md
@@ -153,7 +153,7 @@ To apply an operation to a stream in batches, you can use the `map_batches()` me
 
 ### Configure the execution with `set_processing()` {: #edsnlp.core.stream.Stream.set_processing }
 
-You can configure how the operations performed in the stream is executed by calling its `set_processing(...)` method. The following options are available :
+You can configure how the operations performed in the stream are executed by calling its `set_processing(...)` method. The following options are available :
 
 ::: edsnlp.core.stream.Stream.set_processing
     options:

--- a/docs/data/converters.md
+++ b/docs/data/converters.md
@@ -8,6 +8,24 @@ Converters can be configured in the `from_*` (or `read_*` in the case of files) 
 - a function, in which case it will be interpreted as a custom converter
 - a string, in which case it will be interpreted as the name of a pre-defined converter
 
+## No converter (`converter=None`) {: #none }
+
+Except in `read_standoff` and `write_standoff`, the default converter is `None`. When `converter=None`, readers output the raw content of the input data (most often dictionaries) and writers expect dictionaries. This can actually be useful is you plan to use Streams without converting to Doc objects, for instance to parallelizing the execution of a function on raw Json, Parquet files or simple lists.
+
+```python
+import edsnlp.data
+
+
+def complex_func(n):
+    return n * n
+
+
+stream = edsnlp.data.from_iterable(range(20))
+stream = stream.map(complex_func)
+stream = stream.set_processing(num_cpu_workers=2)
+res = list(stream)
+```
+
 ## Custom converter {: #custom }
 
 You can always define your own converter functions to convert between your data and Doc objects.

--- a/docs/data/json.md
+++ b/docs/data/json.md
@@ -5,9 +5,11 @@
     ```{ .python .no-check }
     import edsnlp
 
-    docs = edsnlp.data.read_json(df, converter="omop")
-    docs = docs.map_pipeline(nlp)
-    res = edsnlp.data.to_json(docs, converter="omop")
+    stream = edsnlp.data.read_json(path, converter="omop")
+    stream = stream.map_pipeline(nlp)
+    res = stream.to_json(path, converter="omop")
+    # or equivalently
+    edsnlp.data.to_json(stream, path, converter="omop")
     ```
 
 We provide methods to read and write documents (raw or annotated) from and to json files.

--- a/docs/data/pandas.md
+++ b/docs/data/pandas.md
@@ -5,9 +5,11 @@
     ```{ .python .no-check }
     import edsnlp
 
-    docs = edsnlp.data.from_pandas(df, converter="omop")
-    docs = docs.map_pipeline(nlp)
-    res = edsnlp.data.to_pandas(docs, converter="omop")
+    stream = edsnlp.data.from_pandas(df, converter="omop")
+    stream = stream.map_pipeline(nlp)
+    res = stream.to_pandas(converter="omop")
+    # or equivalently
+    edsnlp.data.to_pandas(stream, converter="omop")
     ```
 
 We provide methods to read and write documents (raw or annotated) from and to Pandas DataFrames.

--- a/docs/data/parquet.md
+++ b/docs/data/parquet.md
@@ -5,9 +5,11 @@
     ```{ .python .no-check }
     import edsnlp
 
-    docs = edsnlp.data.read_parquet(df, converter="omop")
-    docs = docs.map_pipeline(nlp)
-    res = edsnlp.data.to_parquet(docs, converter="omop")
+    stream = edsnlp.data.read_parquet(path, converter="omop")
+    stream = stream.map_pipeline(nlp)
+    res = stream.to_parquet(path, converter="omop")
+    # or equivalently
+    edsnlp.data.to_parquet(stream, path, converter="omop")
     ```
 
 We provide methods to read and write documents (raw or annotated) from and to parquet files.

--- a/docs/data/polars.md
+++ b/docs/data/polars.md
@@ -5,9 +5,11 @@
     ```{ .python .no-check }
     import edsnlp
 
-    docs = edsnlp.data.from_polars(df, converter="omop")
-    docs = docs.map_pipeline(nlp)
-    res = edsnlp.data.to_polars(docs, converter="omop")
+    stream = edsnlp.data.from_polars(df, converter="omop")
+    stream = stream.map_pipeline(nlp)
+    res = stream.to_polars(converter="omop")
+    # or equivalently
+    edsnlp.data.to_polars(stream, converter="omop")
     ```
 
 We provide methods to read and write documents (raw or annotated) from and to Polars DataFrames.

--- a/docs/data/spark.md
+++ b/docs/data/spark.md
@@ -5,10 +5,11 @@
     ```{ .python .no-check }
     import edsnlp
 
-
-    docs = edsnlp.data.from_spark(df, converter="omop")
-    docs = docs.map_pipeline(nlp)
-    res = edsnlp.data.to_spark(docs, converter="omop")
+    stream = edsnlp.data.from_spark(df, converter="omop")
+    stream = stream.map_pipeline(nlp)
+    res = stream.to_spark(converter="omop")
+    # or equivalently
+    edsnlp.data.to_spark(stream, converter="omop")
     ```
 
 We provide methods to read and write documents (raw or annotated) from and to Spark DataFrames.

--- a/docs/data/standoff.md
+++ b/docs/data/standoff.md
@@ -5,8 +5,11 @@
     ```{ .python .no-check }
     import edsnlp
 
-    doc_iterator = edsnlp.data.read_standoff(path)
-    res = edsnlp.data.write_standoff(docs, path)
+    stream = edsnlp.data.read_standoff(path)
+    stream = stream.map_pipeline(nlp)
+    res = stream.write_standoff(path)
+    # or equivalently
+    edsnlp.data.write_standoff(stream, path)
     ```
 
 You can easily integrate [BRAT](https://brat.nlplab.org/) into your project by using EDS-NLP's BRAT reader and writer.

--- a/docs/scripts/plugin.py
+++ b/docs/scripts/plugin.py
@@ -145,11 +145,13 @@ def on_post_page(
         if ref.startswith("edsnlp.") and "--" not in ref:
             code = "import edsnlp; " + ref
             interpreter = jedi.Interpreter(code, namespaces=[{}])
-            goto = interpreter.goto(1, len(code), follow_imports=True)
+            goto = interpreter.infer(1, len(code))
+            try:
+                file = goto[0].module_path.relative_to(Path.cwd())
+            except Exception:
+                goto = []
             if not goto:
-                print("Could not get source for", ref)
                 continue
-            file = goto[0].module_path.relative_to(Path.cwd())
             line = goto[0].line
             # Add a "[source]" span with a link to the source code in a new tab
             url = f"https://github.com/aphp/edsnlp/blob/{GIT_COMMIT}/{file}#L{line}"

--- a/docs/tutorials/training.md
+++ b/docs/tutorials/training.md
@@ -125,18 +125,18 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         # Assign parameters starting with transformer (ie the parameters of the transformer component)
         # to a first group
         "^transformer":
-          lr: 5e-5
-          schedules:
+          lr:
             '@schedules': linear
             "warmup_rate": 0.1
             "start_value": 0
+            "max_value": 5e-5
         # And every other parameters to the second group
         "":
-          lr: 3e-4
-          schedules:
+          lr:
             '@schedules': linear
             "warmup_rate": 0.1
             "start_value": 3e-4
+            "max_value": 3e-4
       module: ${ nlp }
       total_steps: ${ train.max_steps }
 
@@ -256,12 +256,10 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         total_steps=max_steps,
         groups={
             "^transformer": {
-                "lr": 5e-5,
-                "schedules": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0},
+                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0 "max_value": 5e-5,},
             },
             "": {
-                "lr": 3e-4,
-                "schedules": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4},
+                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4 "max_value": 3e-4,},
             },
         },
     )

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -1034,6 +1034,9 @@ class Pipeline(Validated):
             readme_replacements=readme_replacements,
         )
 
+    if TYPE_CHECKING:
+        from edsnlp.package import package as package
+
     def __getstate__(self):
         state = self.__dict__.copy()
         state["_pipe_meta"] = [PIPE_META.get(pipe, {}) for _, pipe in self.pipeline]

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -104,7 +104,7 @@ class Pipeline(Validated):
         batch_size: Optional[int] = 128,
         vocab_config: Type[BaseDefaults] = None,
         meta: Dict[str, Any] = None,
-        pipeline: Sequence[str] = (),
+        pipeline: Optional[Sequence[str]] = None,
         components: Dict[str, CurriedFactory] = {},
         disable: AsList[str] = EMPTY_LIST,
         enable: AsList[str] = EMPTY_LIST,
@@ -155,6 +155,7 @@ class Pipeline(Validated):
         self.lang: str = lang
         self._cache: Optional[Dict] = None
 
+        pipeline = list(components) if pipeline is None else pipeline
         self._add_pipes(pipeline, components, exclude, enable, disable)
 
     @property

--- a/edsnlp/core/registries.py
+++ b/edsnlp/core/registries.py
@@ -421,7 +421,7 @@ class registry(RegistryCollection):
     adapters = Registry(("edsnlp", "adapters"), entry_points=True)
     readers = Registry(("edsnlp", "readers"), entry_points=True)
     writers = Registry(("edsnlp", "writers"), entry_points=True)
-    pipelines = Registry(("edsnlp", "pipelines"), entry_points=True)
+    core = Registry(("edsnlp", "core"), entry_points=True)
     optimizers = Registry(("edsnlp", "optimizers"), entry_points=True)
     schedules = Registry(("edsnlp", "schedules"), entry_points=True)
 

--- a/edsnlp/core/stream.py
+++ b/edsnlp/core/stream.py
@@ -362,7 +362,6 @@ class Stream(metaclass=MetaStream):
         gpu_worker_devices: Optional[List[str]] = None,
         cpu_worker_devices: Optional[List[str]] = None,
         deterministic: bool = True,
-        work_unit: Literal["record", "fragment"] = "record",
         chunk_size: int = None,
         sort_chunks: bool = False,
         _non_default_args: Iterable[str] = (),

--- a/edsnlp/core/stream.py
+++ b/edsnlp/core/stream.py
@@ -1051,14 +1051,14 @@ class Stream(metaclass=MetaStream):
         )
 
     if TYPE_CHECKING:
-        to_spark = edsnlp.data.to_spark  # noqa: F811
-        to_pandas = edsnlp.data.to_pandas  # noqa: F811
-        to_polars = edsnlp.data.to_polars  # noqa: F811
-        to_iterable = edsnlp.data.to_iterable  # noqa: F811
-        write_parquet = edsnlp.data.write_parquet  # noqa: F811
-        write_standoff = edsnlp.data.write_standoff  # noqa: F811
-        write_brat = edsnlp.data.write_brat  # noqa: F811
-        write_json = edsnlp.data.write_json  # noqa: F811
+        from edsnlp.data import to_iterable as to_iterable  # noqa: F401
+        from edsnlp.data import to_pandas as to_pandas  # noqa: F401
+        from edsnlp.data import to_polars as to_polars  # noqa: F401
+        from edsnlp.data import to_spark as to_spark  # noqa: F401
+        from edsnlp.data import write_brat as write_brat  # noqa: F401
+        from edsnlp.data import write_json as write_json  # noqa: F401
+        from edsnlp.data import write_parquet as write_parquet  # noqa: F401
+        from edsnlp.data import write_standoff as write_standoff  # noqa: F401
 
 
 # For backwards compatibility

--- a/edsnlp/data/base.py
+++ b/edsnlp/data/base.py
@@ -216,7 +216,7 @@ def to_iterable(
     **kwargs,
 ):
     """
-    `edsnlp.data.to_items` returns an iterator of documents, as converted by the
+    `edsnlp.data.to_iterable` returns an iterator of documents, as converted by the
     `converter`. In comparison to just iterating over a Stream, this will
     also apply the `converter` to the documents, which can lower the data transfer
     overhead when using multiprocessing.
@@ -232,7 +232,7 @@ def to_iterable(
 
     doc = nlp("My document with entities")
 
-    edsnlp.data.to_items([doc], converter="omop")
+    edsnlp.data.to_iterable([doc], converter="omop")
     ```
 
     Parameters

--- a/edsnlp/data/json.py
+++ b/edsnlp/data/json.py
@@ -58,12 +58,6 @@ class JsonReader(FileBasedReader):
         self.shuffle = shuffle
         self.loop = loop
         self.rng = random.Random(seed)
-        if self.read_in_worker is not None:
-            warnings.warn(
-                "The `read_in_worker` parameter of EDS-NLP readers is "
-                "deprecated, please use `data.set_processing(work_unit='fragment').`",
-                FutureWarning,
-            )
         for file in self.files:
             if not self.fs.exists(file):
                 raise FileNotFoundError(f"File {file} does not exist")

--- a/edsnlp/data/polars.py
+++ b/edsnlp/data/polars.py
@@ -37,7 +37,7 @@ class PolarsReader(MemoryBasedReader):
         assert isinstance(data, pl.DataFrame)
         self.data = data
 
-    def read_records(self, work_unit: str = "record") -> Iterable[Any]:
+    def read_records(self) -> Iterable[Any]:
         data: polars.DataFrame = self.data
         while True:
             if self.shuffle:

--- a/edsnlp/package.py
+++ b/edsnlp/package.py
@@ -559,8 +559,8 @@ class SetuptoolsPackager(Packager):
 
 @app.command(name="package")
 def package(
-    *,
     pipeline: Union[Path, "edsnlp.Pipeline"],
+    *,
     name: Optional[ModuleName] = None,
     root_dir: Path = Path("."),
     build_dir: Optional[Path] = None,

--- a/edsnlp/pipes/ner/adicap/adicap.py
+++ b/edsnlp/pipes/ner/adicap/adicap.py
@@ -98,7 +98,7 @@ Name=cgts_sem_adicap_fiche-detaillee.pdf).
     ent.label_
     # Out: adicap
 
-    ent._.adicap.model_dump()
+    ent._.adicap.dict()
     # Out: {'code': 'BHGS0040',
     # 'sampling_mode': 'BIOPSIE CHIRURGICALE',
     # 'technic': 'HISTOLOGIE ET CYTOLOGIE PAR INCLUSION',

--- a/edsnlp/pipes/ner/tnm/model.py
+++ b/edsnlp/pipes/ner/tnm/model.py
@@ -197,3 +197,6 @@ class TNM(pydantic.BaseModel):
                 d[k] = v.value
 
         return d
+
+    if pydantic.VERSION < "2":
+        model_dump = pydantic.BaseModel.dict

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -484,9 +484,9 @@ def train(
                     )
                 )
             )
-            if hasattr(optim, "initialize"):
-                optim.initialize()
             (accel_optim, *trained_pipes) = accelerator.prepare(optim, *trained_pipes)
+            if hasattr(accel_optim.optimizer, "initialize"):
+                accel_optim.optimizer.initialize()
 
             cumulated_data = defaultdict(lambda: 0.0, count=0)
             all_metrics = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,10 @@ version = { attr = "edsnlp.__version__" }
 [tool.setuptools.packages.find]
 where = ["."]
 
-[project.entry-points."edsnlp_pipelines"]
-"base" = "edsnlp.core.pipeline:Pipeline"
-"load" = "edsnlp.core.pipeline:load"
+[project.entry-points."edsnlp_core"]
+"pipeline"  = "edsnlp.core.pipeline:Pipeline"
+"load"      = "edsnlp.core.pipeline:load"
+"optimizer" = "edsnlp.training.optimizer:ScheduledOptimizer"
 
 [project.entry-points."spacy_factories"]
 # Core
@@ -304,7 +305,6 @@ where = ["."]
 
 [project.entry-points."spacy_misc"]
 "eds.span_context_getter" = "edsnlp.utils.span_getters:make_span_context_getter"
-"eds.scheduled_optimizer" = "edsnlp.training.optimizer:ScheduledOptimizer"
 
 [project.entry-points."spacy_languages"]
 "eds" = "edsnlp.language:EDSLanguage"

--- a/tests/training/ner_qlf_config.yml
+++ b/tests/training/ner_qlf_config.yml
@@ -1,5 +1,6 @@
 # 🤖 PIPELINE DEFINITION
 nlp:
+  "@core": pipeline
   lang: eds
 
   components:
@@ -58,8 +59,9 @@ scorer:
     span_getter: ${nlp.components.ner.target_span_getter}
 
 # 🎛️ OPTIMIZER
-optim:
-  cls: AdamW
+optimizer:
+  "@core": optimizer
+  optim: AdamW
   module: ${ nlp }
   groups:
     "^transformer": false
@@ -116,4 +118,4 @@ train:
   max_grad_norm: 1.0
   scorer: ${ scorer }
   num_workers: 0
-  optim: ${ optim }
+  optimizer: ${ optimizer }

--- a/tests/training/ner_qlf_diff_bert_config.yml
+++ b/tests/training/ner_qlf_diff_bert_config.yml
@@ -1,0 +1,126 @@
+# 🤖 PIPELINE DEFINITION
+nlp:
+  "@core": pipeline
+  lang: eds
+
+  components:
+    normalizer:
+      '@factory': eds.normalizer
+
+    sentencizer:
+      '@factory': eds.sentences
+
+    ner:
+      '@factory': eds.ner_crf
+      mode: "joint"
+      target_span_getter: "gold_spans"
+      # Set spans as both to ents and in separate `ent.label` groups
+      span_setter: [ "ents", "*" ]
+      infer_span_setter: true
+
+      embedding:
+        '@factory': eds.text_cnn
+        kernel_sizes: [ 3 ]
+
+        embedding:
+          '@factory': eds.transformer
+          model: hf-internal-testing/tiny-bert
+          window: 128
+          stride: 96
+          new_tokens: [ [ "(?:\\n\\s*)*\\n", "⏎" ] ]
+
+    qualifier:
+      '@factory': eds.span_classifier
+      attributes: { "_.negation": [ "sosy" ], "_.unit": [ "measure" ] }
+      span_getter: ["ents", "gold_spans"]
+
+      embedding:
+        '@factory': eds.span_pooler
+
+        embedding: # ${ nlp.components.ner.embedding }
+          '@factory': eds.text_cnn
+          kernel_sizes: [ 3 ]
+
+          embedding:
+            '@factory': eds.transformer
+            model: hf-internal-testing/tiny-bert
+            window: 128
+            stride: 96
+
+# 📈 SCORERS
+scorer:
+  speed: true
+  qual:
+    '@metrics': eds.span_attributes
+    span_getter: ${nlp.components.qualifier.span_getter}
+    qualifiers: ${nlp.components.qualifier.attributes}
+  ner:
+    '@metrics': eds.ner_exact
+    span_getter: ${nlp.components.ner.target_span_getter}
+
+# 🎛️ OPTIMIZER
+optimizer:
+  "@core": optimizer
+  optim: AdamW
+  module: ${ nlp }
+  groups:
+    "^transformer": false
+    ".*":
+      lr:
+          "@schedules": linear
+          start_value: 1e-3
+          max_value: 2e-3
+          warmup_rate: 0.5
+  total_steps: ${ train.max_steps }
+
+# 📚 DATA
+train_data:
+  - data:
+      '@readers': standoff
+      path: ./dataset/
+      converter:
+        - '@factory': eds.standoff_dict2doc
+          span_setter : 'gold_spans'
+          span_attributes : ['sosy', 'unit', 'negation']
+          bool_attributes : ['negation']  # default standoff to doc converter
+        - '@factory': eds.sentences
+          nlp: ${nlp}
+        - '@factory': eds.split
+          nlp: null
+          max_length: 2000
+          regex: '\n\n+'
+    shuffle: dataset
+    batch_size: 8 docs
+    pipe_names: [ "ner" ]
+  - data:
+      '@readers': standoff
+      path: ./dataset/
+      converter:
+        - '@factory': eds.standoff_dict2doc
+          span_setter : 'gold_spans'
+          span_attributes : ['sosy', 'unit', 'negation']
+          bool_attributes : ['negation']  # default standoff to doc converter
+    shuffle: dataset
+    batch_size: 16 spans
+    pipe_names: [ "qualifier" ]
+
+val_data:
+  '@readers': standoff
+  path: ./dataset/
+  converter:
+    - '@factory': eds.standoff_dict2doc
+      span_setter : 'gold_spans'
+      span_attributes : ['sosy', 'unit', 'negation']
+      bool_attributes : ['negation']  # default standoff to doc converter
+
+# 🚀 TRAIN SCRIPT OPTIONS
+train:
+  nlp: ${ nlp }
+  train_data: ${ train_data }
+  val_data: ${ val_data }
+  max_steps: 40
+  validation_interval: 10
+  max_grad_norm: 1.0
+  scorer: ${ scorer }
+  num_workers: 0
+  optimizer: ${ optimizer }

--- a/tests/training/ner_qlf_same_bert_config.yml
+++ b/tests/training/ner_qlf_same_bert_config.yml
@@ -41,11 +41,7 @@ nlp:
           '@factory': eds.text_cnn
           kernel_sizes: [ 3 ]
 
-          embedding:
-            '@factory': eds.transformer
-            model: hf-internal-testing/tiny-bert
-            window: 128
-            stride: 96
+          embedding: ${ nlp.components.ner.embedding.embedding }
 
 # 📈 SCORERS
 scorer:

--- a/tests/training/qlf_config.yml
+++ b/tests/training/qlf_config.yml
@@ -41,7 +41,7 @@ scorer:
 
 # 🎛️ OPTIMIZER
 # (disabled to test the default optimizer)
-# optim:
+# optimizer:
 #   "@optimizers": adam
 #   groups:
 #     "*.transformer.*":

--- a/tests/training/test_optimizer.py
+++ b/tests/training/test_optimizer.py
@@ -63,7 +63,7 @@ def net():
 )
 def test_old_parameter_selection(net, groups):
     optim = ScheduledOptimizer(
-        cls="adamw",
+        optim="adamw",
         module=net,
         groups=groups,
         total_steps=10,
@@ -107,7 +107,7 @@ def test_old_parameter_selection(net, groups):
 
 def test_serialization(net):
     optim = ScheduledOptimizer(
-        cls="adamw",
+        optim="adamw",
         module=net,
         groups={
             "fc1[.].*": {
@@ -141,7 +141,7 @@ def test_serialization(net):
 
 def test_repr(net):
     optim = ScheduledOptimizer(
-        cls="adamw",
+        optim="adamw",
         module=net,
         groups={
             "fc1[.].*": {

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -106,7 +106,7 @@ def test_qualif_train(run_in_test_dir, tmp_path):
     config = Config.from_disk("qlf_config.yml")
     shutil.rmtree(tmp_path, ignore_errors=True)
     kwargs = Config.resolve(config["train"], registry=registry, root=config)
-    nlp = train(**kwargs, output_path=tmp_path, cpu=True)
+    nlp = train(**kwargs, output_dir=tmp_path, cpu=True)
     scorer = GenericScorer(**kwargs["scorer"])
     val_data = kwargs["val_data"]
     last_scores = scorer(nlp, val_data)

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -84,9 +84,26 @@ class CustomSampleGenerator:
         return doc
 
 
-def test_ner_qualif_train(run_in_test_dir, tmp_path):
+def test_ner_qualif_train_diff_bert(run_in_test_dir, tmp_path):
     set_seed(42)
-    config = Config.from_disk("ner_qlf_config.yml")
+    config = Config.from_disk("ner_qlf_diff_bert_config.yml")
+    shutil.rmtree(tmp_path, ignore_errors=True)
+    kwargs = Config.resolve(config["train"], registry=registry, root=config)
+    nlp = train(**kwargs, output_dir=tmp_path, cpu=True)
+    scorer = GenericScorer(**kwargs["scorer"])
+    val_data = kwargs["val_data"]
+    last_scores = scorer(nlp, val_data)
+
+    # Check empty doc
+    nlp("")
+
+    assert last_scores["ner"]["micro"]["f"] > 0.4
+    assert last_scores["qual"]["micro"]["f"] > 0.4
+
+
+def test_ner_qualif_train_same_bert(run_in_test_dir, tmp_path):
+    set_seed(42)
+    config = Config.from_disk("ner_qlf_same_bert_config.yml")
     shutil.rmtree(tmp_path, ignore_errors=True)
     kwargs = Config.resolve(config["train"], registry=registry, root=config)
     nlp = train(**kwargs, output_dir=tmp_path, cpu=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- ScheduledOptimizer now accepts schedules directly in place of parameters, and easy parameter selection:

    ```python
    ScheduledOptimizer(
        optim="adamw",
        module=nlp,
        total_steps=2000,
        groups={
            "^transformer": {
                # lr will go from 0 to 5e-5 then to 0 for params matching "transformer"
                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0 "max_value": 5e-5,},
            },
            "": {
                # lr will go from 3e-4 during 200 steps then to 0 for params matching "ner"
                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4 "max_value": 3e-4,},
            },
        },
    )
    ```

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
