### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
-          PIP_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cpu"
+          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -4,6 +4,7 @@
 
 name: Test Build
 
+
 on:
   workflow_dispatch:
   pull_request:
@@ -27,6 +28,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ENVIRONMENT: PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
+
 
   build_sdist:
     name: Build source distribution

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.13.1
+pip install edsnlp==0.14.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.13.1"
+pip install "edsnlp[ml]==0.14.0"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.14.0 (2024-11-14)
 
 ### Added
 

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -60,12 +60,42 @@ To create your first EDS-NLP pipeline, run the following code. We provide severa
     nlp.add_pipe("eds.negation")
     ```
 
-=== "From a config file"
+=== "From a YAML config file"
+
+    You can also create a pipeline from a configuration file. This is useful when you plan on changing the pipeline configuration often.
+
+    ```{ .yaml title="config.yml" }
+    nlp:
+      "@core": pipeline
+      lang: eds
+      components:
+        sentences:
+          "@factory": eds.sentences
+
+        matcher:
+          "@factory": eds.matcher
+          regex:
+            smoker: ["fume", "clope"]
+
+        negation:
+          "@factory": eds.negation
+    ```
+
+    and then load the pipeline with:
+
+    ```{ .python .no-check }
+    import edsnlp
+
+    nlp = edsnlp.load("config.yml")
+    ```
+
+=== "From a INI config file"
 
     You can also create a pipeline from a configuration file. This is useful when you plan on changing the pipeline configuration often.
 
     ```{ .cfg title="config.cfg" }
     [nlp]
+    @core = "pipeline"
     lang = "eds"
     pipeline = ["sentences", "matcher", "negation"]
 
@@ -100,7 +130,7 @@ from pathlib import Path
 nlp("Le patient ne fume pas")
 
 # Processing multiple documents
-model.pipe([text1, text2])
+nlp.pipe([text1, text2])
 ```
 
 For more information on how to use the pipeline, refer to the [Inference](/inference) page.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.13.1
+pip install edsnlp==0.14.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.13.1"
+pip install "edsnlp[ml]==0.14.0"
 ```
 
 ### A first pipeline

--- a/docs/scripts/clickable_snippets.py
+++ b/docs/scripts/clickable_snippets.py
@@ -184,7 +184,7 @@ class ClickableSnippetsPlugin(BasePlugin):
 
         # Re-insert soups into the output
         for soup, start, end in reversed(soups):
-            output = output[:start] + str(soup) + output[end:]
+            output = output[:start] + str(soup.find("code")) + output[end:]
 
         output = regex.sub(HREF_REGEX, replace_link, output)
 
@@ -202,7 +202,7 @@ class ClickableSnippetsPlugin(BasePlugin):
         cls, html_content: str
     ) -> Tuple[BeautifulSoup, str, list, list]:
         pre_html_content = "<pre>" + html_content + "</pre>"
-        soup = BeautifulSoup(pre_html_content, "html5lib")
+        soup = list(BeautifulSoup(pre_html_content, "html5lib").children)[0]
         code_element = soup.find("code")
 
         line_lengths = [0]

--- a/docs/tutorials/make-a-training-script.md
+++ b/docs/tutorials/make-a-training-script.md
@@ -395,6 +395,7 @@ print(nlp.config.to_yaml_str())
 
 ```yaml title="config.yml"
 nlp:
+  "@core": "pipeline"
   lang: "eds"
   components:
     ner:

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -15,7 +15,7 @@ import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 from . import reducers
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 BASE_DIR = Path(__file__).parent
 

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -52,6 +52,10 @@ class AliasPathFinder(importlib.abc.MetaPathFinder):
             new_name = fullname.replace("span_qualifier", "span_classifier")
             spec = importlib.util.spec_from_loader(fullname, AliasLoader(new_name))
             return spec
+        if "measurements" in fullname.split("."):
+            new_name = fullname.replace("measurements", "quantities")
+            spec = importlib.util.spec_from_loader(fullname, AliasLoader(new_name))
+            return spec
 
 
 class AliasLoader(importlib.abc.Loader):

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -644,7 +644,6 @@ class EntsDoc2DictConverter:
 def get_dict2doc_converter(
     converter: Union[str, Callable], kwargs
 ) -> Tuple[Callable, Dict]:
-    kwargs_to_init = False
     if not callable(converter):
         available = edsnlp.registry.factory.get_available()
         try:
@@ -666,7 +665,7 @@ def get_dict2doc_converter(
                 f"Cannot find converter for format {converter}. "
                 f"Available converters are {', '.join(available)}"
             )
-    if isinstance(converter, type) or kwargs_to_init:
+    if isinstance(converter, type):
         return converter(**kwargs), {}
     return converter, validate_kwargs(converter, kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pysimstring>=1.2.1",
     "regex",
     "spacy>=3.2,<3.8",
-    "confit>=0.5.5",
+    "confit>=0.7.0",
     "tqdm",
     "umls-downloader>=0.1.1",
     "numpy>=1.15.0,<1.23.2; python_version<'3.8'",

--- a/tests/training/qlf_config.yml
+++ b/tests/training/qlf_config.yml
@@ -1,5 +1,7 @@
 # 🤖 PIPELINE DEFINITION
 nlp:
+  "@core": pipeline
+
   lang: eds
 
   components:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

### Added

- Support for setuptools based projects in `edsnlp.package` command
- Pipelines can now be instantiated directly from a config file (instead of having to cast a dict containing their arguments) by putting the @core = "pipeline" or "load" field in the pipeline section)
- `edsnlp.load` now correctly takes disable, enable and exclude parameters into account
- Pipeline now has a basic repr showing is base langage (mostly useful to know its tokenizer) and its pipes
- New `python -m edsnlp.evaluate` script to evaluate a model on a dataset
- Sentence detection can now be configured to change the minimum number of newlines to consider a newline-triggered sentence, and disable capitalization checking.
- New `eds.split` pipe to split a document into multiple documents based on a splitting pattern (useful for training)
- Allow `converter` argument of `edsnlp.data.read/from_...` to be a list of converters instead of a single converter
- New revamped and documented `edsnlp.train` script and API
- Support YAML config files (supported only CFG/INI files before)
- Most of EDS-NLP functions are now clickable in the documentation
- ScheduledOptimizer now accepts schedules directly in place of parameters, and easy parameter selection:

```
ScheduledOptimizer(
    optim="adamw",
    module=nlp,
    total_steps=2000,
    groups={
        "^transformer": {
            # lr will go from 0 to 5e-5 then to 0 for params matching "transformer"
            "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0 "max_value": 5e-5,},
        },
        "": {
            # lr will go from 3e-4 during 200 steps then to 0 for other params
            "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4 "max_value": 3e-4,},
        },
    },
)
```

### Changed

- `eds.span_context_getter`'s parameter `context_sents` is no longer optional and must be explicitly set to 0 to disable sentence context
- In multi-GPU setups, streams that contain torch components are now stripped of their parameter tensors when sent to CPU Workers since these workers only perform preprocessing and postprocessing and should therefore not need the model parameters.
- The `batch_size` argument of `Pipeline` is deprecated and is not used anymore. Use the `batch_size` argument of `stream.map_pipeline` instead.

### Fixed

- Sort files before iterating over a standoff or json folder to ensure reproducibility
- Sentence detection now correctly match capitalized letters + apostrophe
- We now ensure that the workers pool is properly closed whatever happens (exception, garbage collection, data ending) in the `multiprocessing` backend. This prevents some executions from hanging indefinitely at the end of the processing.
- Propagate torch sharing strategy to other workers in the `multiprocessing` backend. This is useful when the system is running out of file descriptors and `ulimit -n` is not an option. Torch sharing strategy can also be set via an environment variable `TORCH_SHARING_STRATEGY` (default is `file_descriptor`, [consider using `file_system` if you encounter issues](https://pytorch.org/docs/stable/multiprocessing.html#file-system-file-system)).

### Data API changes

- `LazyCollection` objects are now called `Stream` objects
- By default, `multiprocessing` backend now preserves the order of the input data. To disable this and improve performance, use `deterministic=False` in the `set_processing` method
- :rocket: Parallelized GPU inference throughput improvements !

    - For simple {pre-process → model → post-process} pipelines, GPU inference can be up to 30% faster in non-deterministic mode (results can be out of order) and up to 20% faster in deterministic mode (results are in order)
    - For multitask pipelines, GPU inference can be up to twice as fast (measured in a two-tasks BERT+NER+Qualif pipeline on T4 and A100 GPUs)

- The `.map_batches`, `.map_pipeline` and `.map_gpu` methods now support a specific `batch_size` and batching function, instead of having a single batch size for all pipes
- Readers now have a `loop` parameter to cycle over the data indefinitely (useful for training)
- Readers now have a `shuffle` parameter to shuffle the data before iterating over it
- In `multiprocessing` mode, file based readers now read the data in the workers (was an option before)
- We now support two new special batch sizes

    - "fragment" in the case of parquet datasets: rows of a full parquet file fragment per batch
    - "dataset" which is mostly useful during training, for instance to shuffle the dataset at each epoch.
  These are also compatible in batched writer such as parquet, where each input fragment can be processed and mapped to a single matching output fragment.

- :boom: Breaking change: a `map` function returning a list or a generator won't be automatically flattened anymore. Use `flatten()` to flatten the output if needed. This shouldn't change the behavior for most users since most writers (to_pandas, to_polars, to_parquet, ...) still flatten the output
- :boom: Breaking change: the `chunk_size` and `sort_chunks` are now deprecated : to sort data before applying a transformation, use `.map_batches(custom_sort_fn, batch_size=...)`

### Training API changes

- We now provide a training script `python -m edsnlp.train --config config.cfg` that should fit many use cases. Check out the docs !
- In particular, we do not require pytorch's Dataloader for training and can rely solely on EDS-NLP stream/data API, which is better suited for large streamable datasets and dynamic preprocessing (ie different result each time we apply a noised preprocessing op on a sample).
- Each trainable component can now provide a `stats` field in its `preprocess` output to log info about the sample (number of words, tokens, spans, ...):

    - these stats are both used for batching (e.g., make batches of no more than "25000 tokens")
    - for logging
    - for computing correct loss means when accumulating gradients over multiple mini-mini-batches
    - for computing correct loss means in multi-GPU setups, since these stats are synchronized and accumulated across GPUs

- Support multi GPU training via hugginface `accelerate` and EDS-NLP `Stream` API consideration of env['WOLRD_SIZE'] and env['LOCAL_RANK'] environment variables


## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
