### PR TITLE
fix: check join_thread attribute in queue when cleaning mp exec

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+### Fixed
+
+- Fix `join_thread` missing attribute in `SimpleQueue` when cleaning a multiprocessing executor
+
 ## v0.14.0 (2024-11-14)
 
 ### Added

--- a/edsnlp/processing/multiprocessing.py
+++ b/edsnlp/processing/multiprocessing.py
@@ -452,7 +452,8 @@ class Worker:
             for stage in self.stages_to_run:
                 for name, queue in self.consumer_queues(stage):
                     queue.close()
-                    queue.join_thread()
+                    if hasattr(queue, "join_thread"):
+                        queue.join_thread()
 
             self.final_barrier.wait()
 
@@ -1182,7 +1183,8 @@ class MultiprocessingStreamExecutor:
                 if q is queue:
                     queue.put(STOP)
             queue.close()
-            queue.join_thread()
+            if hasattr(queue, "join_thread"):
+                queue.join_thread()
 
     def dequeue_notifications(self):
         while True:


### PR DESCRIPTION
## Checklist

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
