### PR TITLE
Fix streams

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - Seed random states (instead of using `random.RandomState()`) when shuffling in data readers : this is important for
   1. reproducibility
   2. in multiprocessing mode, ensure that the same data is shuffled in the same way in all workers
+- Bubble BaseComponent instantiation errors correctly
 
 ## v0.14.0 (2024-11-14)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+### Added
+
+- `edsnlp.data.read_parquet` now accept a `work_unit="fragment"` option to split tasks between workers by parquet fragment instead of row. When this is enabled, workers do not read every fragment while skipping 1 in n rows, but read all rows of 1/n fragments, which should be faster.
+
 ### Fixed
 
 - Fix `join_thread` missing attribute in `SimpleQueue` when cleaning a multiprocessing executor

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 - Fix `join_thread` missing attribute in `SimpleQueue` when cleaning a multiprocessing executor
 - Support huggingface transformers that do not set `cls_token_id` and `sep_token_id` (we now also look for these tokens in the `special_tokens_map` and `vocab` mappings)
 - Fix changing scorers dict size issue when evaluating during training
+- Seed random states (instead of using `random.RandomState()`) when shuffling in data readers : this is important for
+  1. reproducibility
+  2. in multiprocessing mode, ensure that the same data is shuffled in the same way in all workers
 
 ## v0.14.0 (2024-11-14)
 

--- a/edsnlp/core/stream.py
+++ b/edsnlp/core/stream.py
@@ -791,6 +791,12 @@ class Stream(metaclass=MetaStream):
                 else False
             )
         stream = self
+        # Ensure that we have a "deterministic" random seed, meaning
+        # if the user sets a global seed before in the program and execute the
+        # same program twice, the shuffling should be the same in both cases.
+        # This is not garanteed by just creating random.Random() which does not
+        # account
+        seed = seed if seed is not None else random.getrandbits(32)
         if shuffle_reader:
             if shuffle_reader not in self.reader.emitted_sentinels:
                 raise ValueError(f"Cannot shuffle by {shuffle_reader}")

--- a/edsnlp/data/json.py
+++ b/edsnlp/data/json.py
@@ -40,7 +40,6 @@ class JsonReader(FileBasedReader):
     ):
         super().__init__()
         self.shuffle = shuffle
-        self.rng = random.Random(seed)
         self.write_in_worker = write_in_worker
         self.emitted_sentinels = {"dataset"}
         self.loop = loop
@@ -57,6 +56,7 @@ class JsonReader(FileBasedReader):
         self.keep_ipynb_checkpoints = keep_ipynb_checkpoints
         self.shuffle = shuffle
         self.loop = loop
+        seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         for file in self.files:
             if not self.fs.exists(file):

--- a/edsnlp/data/pandas.py
+++ b/edsnlp/data/pandas.py
@@ -27,6 +27,7 @@ class PandasReader(MemoryBasedReader):
     ):
         super().__init__()
         self.shuffle = shuffle
+        seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         self.emitted_sentinels = {"dataset"}
         self.loop = loop

--- a/edsnlp/data/parquet.py
+++ b/edsnlp/data/parquet.py
@@ -38,6 +38,7 @@ class ParquetReader(FileBasedReader):
         self.emitted_sentinels = {"dataset"} | (
             set() if shuffle == "dataset" else {"fragment"}
         )
+        seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         self.loop = loop
         # Either the filesystem has not been passed
@@ -64,8 +65,7 @@ class ParquetReader(FileBasedReader):
                     yield FragmentEndSentinel(file.path)
             elif self.shuffle == "dataset":
                 records = (line for file in files for line in self.read_fragment(file))
-                records = shuffle(records, self.rng)
-                yield from records
+                yield from shuffle(records, self.rng)
             else:
                 for file in files:
                     records = list(self.read_fragment(file))

--- a/edsnlp/data/polars.py
+++ b/edsnlp/data/polars.py
@@ -29,6 +29,7 @@ class PolarsReader(MemoryBasedReader):
         super().__init__()
         self.shuffle = shuffle
         self.emitted_sentinels = {"dataset"}
+        seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         self.loop = loop
 

--- a/edsnlp/data/spark.py
+++ b/edsnlp/data/spark.py
@@ -39,6 +39,7 @@ class SparkReader(MemoryBasedReader):
         self.data = data
         self.shuffle = shuffle
         self.emitted_sentinels = {"dataset"}
+        seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         self.loop = loop
         assert isinstance(

--- a/edsnlp/data/standoff.py
+++ b/edsnlp/data/standoff.py
@@ -292,6 +292,7 @@ class StandoffReader(FileBasedReader):
         super().__init__()
         self.shuffle = shuffle
         self.emitted_sentinels = {"dataset"}
+        seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         self.loop = loop
         self.fs, self.path = normalize_fs_path(filesystem, path)

--- a/edsnlp/pipes/base.py
+++ b/edsnlp/pipes/base.py
@@ -44,16 +44,22 @@ class BaseComponentMeta(abc.ABCMeta):
         # If this component is missing the nlp argument, we curry it with the
         # provided arguments and return a CurriedFactory object.
         sig = inspect.signature(cls.__init__)
-        bound = sig.bind_partial(None, nlp, *args, **kwargs)
-        bound.arguments.pop("self", None)
-        if (
-            "nlp" in sig.parameters
-            and sig.parameters["nlp"].default is sig.empty
-            and bound.arguments.get("nlp", sig.empty) is sig.empty
-        ):
-            return CurriedFactory(cls, bound.arguments)
-        if nlp is inspect.Signature.empty:
-            bound.arguments.pop("nlp", None)
+        try:
+            bound = sig.bind_partial(None, nlp, *args, **kwargs)
+            bound.arguments.pop("self", None)
+            if (
+                "nlp" in sig.parameters
+                and sig.parameters["nlp"].default is sig.empty
+                and bound.arguments.get("nlp", sig.empty) is sig.empty
+            ):
+                return CurriedFactory(cls, bound.arguments)
+            if nlp is inspect.Signature.empty:
+                bound.arguments.pop("nlp", None)
+        except TypeError:  # pragma: no cover
+            if nlp is inspect.Signature.empty:
+                super().__call__(*args, **kwargs)
+            else:
+                super().__call__(nlp, *args, **kwargs)
         return super().__call__(**bound.arguments)
 
 

--- a/edsnlp/processing/simple.py
+++ b/edsnlp/processing/simple.py
@@ -66,6 +66,15 @@ def execute_simple_backend(stream: Stream):
 
         with bar, stream.eval():
             items = reader.read_records()
+            items = (
+                task
+                for item in items
+                for task in (
+                    (item,)
+                    if isinstance(item, StreamSentinel)
+                    else reader.extract_task(item)
+                )
+            )
 
             for stage_idx, stage in enumerate(stages):
                 for op in stage.cpu_ops:

--- a/edsnlp/processing/spark.py
+++ b/edsnlp/processing/spark.py
@@ -80,7 +80,7 @@ def execute_spark_backend(
         df = reader.data
         assert not reader.loop, "Looping is not supported with Spark backend."
         df = (
-            df.sample(fraction=1.0, seed=reader.rng.randbytes(32))
+            df.sample(fraction=1.0, seed=reader.rng.getrandbits(32))
             if reader.shuffle
             else df
         )

--- a/edsnlp/processing/spark.py
+++ b/edsnlp/processing/spark.py
@@ -120,6 +120,8 @@ def execute_spark_backend(
         else:
             items = (item.asDict(recursive=True) for item in items)
 
+        items = (task for item in items for task in stream.reader.extract_task(item))
+
         for stage_idx, stage in enumerate(stages):
             for op in stage.cpu_ops:
                 items = op(items)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- `edsnlp.data.read_parquet` now accept a `work_unit="fragment"` option to split tasks between workers by parquet fragment instead of row. When this is enabled, workers do not read every fragment while skipping 1 in n rows, but read all rows of 1/n fragments, which should be faster.

### Fixed

- Seed random states (instead of using `random.RandomState()`) when shuffling in data readers : this is important for
  1. reproducibility
  2. in multiprocessing mode, ensure that the same data is shuffled in the same way in all workers
- Bubble BaseComponent instantiation errors correctly

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
