### PR TITLE
Solve pickling issues with multiprocessing when pytorch is installed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Support packaging with poetry 2.0
+- Solve pickling issues with multiprocessing when pytorch is installed
 
 # v0.15.0 (2024-12-13)
 

--- a/edsnlp/utils/torch.py
+++ b/edsnlp/utils/torch.py
@@ -146,7 +146,7 @@ def dump(
         if AlignDevicesHook is not None:
             old = dill.Pickler.dispatch.get(AlignDevicesHook)
             dill.Pickler.dispatch[AlignDevicesHook] = save_align_devices_hook
-        dill.settings["recurse"] = True
+        dill.settings["recurse"] = False
         dill.settings["byref"] = True
         return torch.save(*args, pickle_module=dill, **kwargs)
     finally:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -346,7 +346,7 @@ def test_torch_save(ml_nlp):
     buffer = BytesIO()
     torch.save(ml_nlp, buffer)
     buffer.seek(0)
-    nlp = torch.load(buffer)
+    nlp = torch.load(buffer, weights_only=False)
     assert nlp.get_pipe("ner").labels == ["LOC", "PER"]
     assert len(list(nlp("Une phrase. Deux phrases.").sents)) == 2
 


### PR DESCRIPTION
## Description

There has been some issues regarding multiprocessing with edsnlp
These may occur when edsnlp is installed in editable, and more frequently when torch is installed, and more frequently when running in a notebook.
These may take the form: `Can't pickle AsList as it is not same same as AsList` similar.
These are due to our use of dill trying to pickle modules of functions defined in main and used in a pipeline, some of these modules containing types that are unpickleable. This PR fixes that by overriding dill behavior, and tries to test these cases.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
