### PR TITLE
Fix issue 368: Add `metric` parameter and write optimal `config.yml` at the end of tuning.

### DIFF
--- a/docs/tutorials/tuning.md
+++ b/docs/tutorials/tuning.md
@@ -331,6 +331,7 @@ python -m edsnlp.tune --config configs/config.yml --seed 42
 At the end of the tuning process, `edsnlp.tune` generates various results and saves them in the `output_dir` specified in the `config.yml` file:
 
 - **Tuning Summary**: `result_summary.txt`, a summary file containing details about the best training trial, the best overall metric, the optimal hyperparameter values, and the average importance of each hyperparameter across all trials.
+- **Optimal Configuration**: `config.yml`, containing the best hyperparameter values. ⚠ Warning: Since the Confit library does not preserve style and comments, these will be lost in the resulting configuration file. If you need to retain them, manually update your original `config.yml` using the information from `result_summary.txt`.
 - **Graphs and Visualizations**: Various graphics illustrating the tuning process, such as:
   - **Optimization History plot**: A line graph showing the performance of each trial over time, illustrating the optimization process and how the model's performance improves with each iteration.
   - **Empirical Distribution Function (EDF) plot**: A graph showing the cumulative distribution of the results, helping you understand the distribution of performance scores and providing insights into the variability and robustness of the tuning process.

--- a/docs/tutorials/tuning.md
+++ b/docs/tutorials/tuning.md
@@ -74,11 +74,13 @@ tuning:
   output_dir: 'results'
   # Number of gpu hours allowed for tuning.
   gpu_hours: 1.0
-  # Number of fixed trial to tune hyperparameters (override gpu_hours).
+  # Number of fixed trials to tune hyperparameters (override gpu_hours).
   n_trials: 4
   # Enable two-phase tuning. In the first phase, the script will tune all hyperparameters.
   # In the second phase, it will focus only on the top 50% most important hyperparameters.
   two_phase_tuning: True
+  # Metric used to evaluatate trials.
+  metric: "ner.micro.f"
   # Hyperparameters to tune.
   hyperparameters:
 ```
@@ -89,6 +91,7 @@ Let's detail the new parameters:
 - `gpu_hours`: Estimated total GPU time available for tuning, in hours. Given this time, the script will automatically compute for how many training trials we can tune hyperparameters. By default, `gpu_hours` is set to 1.
 - `n_trials`: Number of training trials for tuning. If provided, it will override `gpu_hours` and tune the model for exactly `n_trial` trials.
 - `two_phase_tuning`: If True, performs a two-phase tuning. In the first phase, all hyperparameters are tuned, and in the second phase, the top half (based on importance) are fine-tuned while freezing others. By default, `two_phase_tuning` is False.
+- `metric`: Metric used to evaluate trials. It corresponds to a path in the scorer results (depending on the scorer used in the config). By default `metric` is set to "ner.micro.f".
 - `hyperparameters`: The list of hyperparameters to tune and details about their tunings. We will discuss how it work in the following section.
 
 ### 2.2. Add hyperparameters to tune
@@ -247,6 +250,7 @@ tuning:
   output_dir: 'results'
   gpu_hours: 40.0
   two_phase_tuning: True
+  metric: "ner.micro.f"
   hyperparameters:
     "nlp.components.ner.embedding.embedding.hidden_dropout_prob":
       alias: "hidden_dropout"

--- a/edsnlp/tune.py
+++ b/edsnlp/tune.py
@@ -473,7 +473,7 @@ def tune(
     n_trials: conint(gt=0) = None,
     two_phase_tuning: bool = False,
     seed: int = 42,
-    metric="ner.micro.f1",
+    metric="ner.micro.f",
 ):
     """
     Perform hyperparameter tuning for a model using Optuna.
@@ -526,7 +526,7 @@ def tune(
 
     if not is_fixed_n_trials:
         logger.info(f"Computing number of trials for {gpu_hours} hours of GPU.")
-        study = optimize(config, hyperparameters, n_trials=1)
+        study = optimize(config, hyperparameters, n_trials=1, metric=metric)
         n_trials = compute_n_trials(gpu_hours, compute_time_per_trial(study)) - 1
 
     logger.info(f"Number of trials: {n_trials}")

--- a/edsnlp/tune.py
+++ b/edsnlp/tune.py
@@ -422,7 +422,9 @@ def tune_two_phase(
         f"Phase 2: Tuning {hyperparameters_to_keep} hyperparameters "
         f"({n_trials_2} trials). Other hyperparameters frozen to best values."
     )
-    study = optimize(updated_config, hyperparameters_phase_2, n_trials_2, metric, study=study)
+    study = optimize(
+        updated_config, hyperparameters_phase_2, n_trials_2, metric, study=study
+    )
     process_results(study, f"{output_dir}/phase_2", viz)
 
 
@@ -471,7 +473,7 @@ def tune(
     n_trials: conint(gt=0) = None,
     two_phase_tuning: bool = False,
     seed: int = 42,
-    metric = "ner.micro.f1",
+    metric="ner.micro.f1",
 ):
     """
     Perform hyperparameter tuning for a model using Optuna.

--- a/tests/tuning/test_end_to_end.py
+++ b/tests/tuning/test_end_to_end.py
@@ -29,6 +29,9 @@ def assert_results(output_dir):
         assert "Params" in content
         assert "Importances" in content
 
+    config_file = os.path.join(output_dir, "config.yml")
+    assert os.path.exists(config_file), f"Expected file {config_file} not found"
+
     optimization_history_file = os.path.join(output_dir, "optimization_history.html")
     assert os.path.exists(
         optimization_history_file

--- a/tests/tuning/test_end_to_end.py
+++ b/tests/tuning/test_end_to_end.py
@@ -52,13 +52,11 @@ def assert_results(output_dir):
 @pytest.mark.parametrize("n_trials", [7, None])
 @pytest.mark.parametrize("two_phase_tuning", [True, False])
 def test_tune(tmpdir, n_trials, two_phase_tuning):
-    print("Current Working Directory:", os.getcwd())
     config_meta = {"config_path": ["tests/tuning/config.yml"]}
     hyperparameters = {
         "optimizer.groups.'.*'.lr.start_value": {
             "alias": "start_value",
             "type": "float",
-            # "path": ["optimizer", "groups", ".*", "lr", "start_value"],
             "low": 1e-4,
             "high": 1e-3,
             "log": True,
@@ -66,7 +64,6 @@ def test_tune(tmpdir, n_trials, two_phase_tuning):
         "optimizer.groups.'.*'.lr.warmup_rate": {
             "alias": "warmup_rate",
             "type": "float",
-            # "path": ["optimizer", "groups", ".*", "lr", "warmup_rate"],
             "low": 0.0,
             "high": 0.3,
             "step": 0.05,
@@ -75,6 +72,7 @@ def test_tune(tmpdir, n_trials, two_phase_tuning):
     output_dir = "./results"
     gpu_hours = 0.015
     seed = 42
+    metric = "ner.micro.f"
     tune(
         config_meta=config_meta,
         hyperparameters=hyperparameters,
@@ -83,6 +81,7 @@ def test_tune(tmpdir, n_trials, two_phase_tuning):
         n_trials=n_trials,
         two_phase_tuning=two_phase_tuning,
         seed=seed,
+        metric=metric,
     )
     if two_phase_tuning:
         phase_1_dir = os.path.join(output_dir, "phase_1")

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -127,8 +127,27 @@ def test_compute_importances(study):
 @pytest.mark.parametrize("viz", [True, False])
 def test_process_results(study, tmpdir, viz):
     output_dir = tmpdir.mkdir("output")
+    config = {
+        "train": {
+            "param1": None,
+        },
+        ".lr": {
+            "param2": 0.01,
+        },
+    }
+    hyperparameters = {
+        "train.param1": {
+            "type": "int",
+            "alias": "param1",
+            "low": 2,
+            "high": 8,
+            "step": 2,
+        },
+    }
 
-    best_params, importances = process_results(study, output_dir, viz)
+    best_params, importances = process_results(
+        study, output_dir, viz, config, hyperparameters
+    )
 
     assert isinstance(best_params, dict)
     assert isinstance(importances, dict)
@@ -143,6 +162,9 @@ def test_process_results(study, tmpdir, viz):
         assert "Value" in content
         assert "Params" in content
         assert "Importances" in content
+
+    config_file = os.path.join(output_dir, "config.yml")
+    assert os.path.exists(config_file), f"Expected file {config_file} not found"
 
     if viz:
         optimization_history_file = os.path.join(

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -178,6 +178,7 @@ def test_compute_remaining_n_trials_possible(study):
 @pytest.mark.parametrize("has_study", [True, False])
 def test_optimize(mock_objective_with_param, mock_optimize_study, has_study, study):
     mock_objective_with_param.return_value = 0.9
+    metric = ("ner", "micro", "f")
 
     if has_study:
 
@@ -185,12 +186,16 @@ def test_optimize(mock_objective_with_param, mock_optimize_study, has_study, stu
             pass
 
         study.optimize = pass_fn
-        study = optimize("config_path", tuned_parameters={}, n_trials=1, study=study)
+        study = optimize(
+            "config_path", tuned_parameters={}, n_trials=1, metric=metric, study=study
+        )
         assert isinstance(study, Mock)
         assert len(study.trials) == 3
 
     else:
-        study = optimize("config_path", tuned_parameters={}, n_trials=1, study=None)
+        study = optimize(
+            "config_path", tuned_parameters={}, n_trials=1, metric=metric, study=None
+        )
         assert isinstance(study, optuna.study.Study)
         assert len(study.trials) == 0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Remove hardcoded f1 metric. Remplace it with a new `metric` parameter in `tune` method.
- At the end of tuning, write the optimal `config.yml` in the results directory.

<!--- Describe the changes. -->
## Changes
- `edsnlp/tune.py`: 
  - add a new `metric` parameter instead of hardcoded f1. 
  - `process_result` now write optimal config to `output_dir`.
- `docs/tutorials/tuning.md` : update tutorial
- `tests/tuning/*.py`: update unit tests

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
