### PR TITLE
Fix issue 372: resulting tuning config file now preserve comments

### DIFF
--- a/docs/tutorials/tuning.md
+++ b/docs/tutorials/tuning.md
@@ -39,8 +39,8 @@ dependencies = [
     "sentencepiece>=0.1.96",
     "optuna>=4.0.0",
     "plotly>=5.18.0",
-    "ruamel.yaml<0.18.0",
-    "configobj",
+    "ruamel.yaml>=0.18.0",
+    "configobj>=5.0.9",
 ]
 
 [project.optional-dependencies]

--- a/docs/tutorials/tuning.md
+++ b/docs/tutorials/tuning.md
@@ -36,7 +36,11 @@ requires-python = ">3.7.1,<4.0"
 
 dependencies = [
     "edsnlp[ml]>=0.15.0",
-    "sentencepiece>=0.1.96"
+    "sentencepiece>=0.1.96",
+    "optuna>=4.0.0",
+    "plotly>=5.18.0",
+    "ruamel.yaml<0.18.0",
+    "configobj",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ dev = [
     "edsnlp[ml]",
     "optuna>=4.0.0",
     "plotly>=5.18.0", # required by optuna viz
+    "ruamel.yaml>=0.18.0",
+    "configobj>=5.0.9",
+
 ]
 setup = [
     "typer"

--- a/tests/tuning/config.cfg
+++ b/tests/tuning/config.cfg
@@ -1,2 +1,3 @@
+# My usefull comment
 [train]
 param1 = 1

--- a/tests/tuning/config.cfg
+++ b/tests/tuning/config.cfg
@@ -1,0 +1,2 @@
+[train]
+param1 = 1

--- a/tests/tuning/config.yml
+++ b/tests/tuning/config.yml
@@ -1,3 +1,4 @@
+# My usefull comment
 # 🤖 PIPELINE DEFINITION
 nlp:
   "@core": pipeline

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -171,6 +171,12 @@ def test_process_results(study, tmpdir, viz, config_path):
         config_file = os.path.join(output_dir, "config.cfg")
     assert os.path.exists(config_file), f"Expected file {config_file} not found"
 
+    with open(config_file, "r", encoding="utf-8") as f:
+        content = f.read()
+    assert (
+        "# My usefull comment" in content
+    ), f"Expected comment not found in {config_file}"
+
     if viz:
         optimization_history_file = os.path.join(
             output_dir, "optimization_history.html"

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -144,9 +144,9 @@ def test_process_results(study, tmpdir, viz):
             "step": 2,
         },
     }
-
+    config_path = "tests/tuning/config.yml"
     best_params, importances = process_results(
-        study, output_dir, viz, config, hyperparameters
+        study, output_dir, viz, config, config_path, hyperparameters
     )
 
     assert isinstance(best_params, dict)

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -125,7 +125,10 @@ def test_compute_importances(study):
 
 
 @pytest.mark.parametrize("viz", [True, False])
-def test_process_results(study, tmpdir, viz):
+@pytest.mark.parametrize(
+    "config_path", ["tests/tuning/config.yml", "tests/tuning/config.cfg"]
+)
+def test_process_results(study, tmpdir, viz, config_path):
     output_dir = tmpdir.mkdir("output")
     config = {
         "train": {
@@ -144,7 +147,6 @@ def test_process_results(study, tmpdir, viz):
             "step": 2,
         },
     }
-    config_path = "tests/tuning/config.yml"
     best_params, importances = process_results(
         study, output_dir, viz, config, config_path, hyperparameters
     )
@@ -163,7 +165,10 @@ def test_process_results(study, tmpdir, viz):
         assert "Params" in content
         assert "Importances" in content
 
-    config_file = os.path.join(output_dir, "config.yml")
+    if config_path.endswith("yml") or config_path.endswith("yaml"):
+        config_file = os.path.join(output_dir, "config.yml")
+    else:
+        config_file = os.path.join(output_dir, "config.cfg")
     assert os.path.exists(config_file), f"Expected file {config_file} not found"
 
     if viz:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Resulting tuning config file now preserve comments from original config file.

## Changes

- `tune.py`:  add `write_final_config` method that read original config with ruamel.yaml, update it with optimal hyperparameters found during tuning, then write it in `output_dir`.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
