### PR TITLE
Training loggers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Provided a [detailed tutorial](./docs/tutorials/tuning.md) on hyperparameter tuning, covering usage scenarios and configuration options.
 - Added grad spike detection to the `edsnlp.train` script, and per weight layer gradient logging.
 - Added support for multiple loggers (`tensorboard`, `wandb`, `comet_ml`, `aim`, `mlflow`, `clearml`, `dvclive`, `csv`, `json`, `rich`) in `edsnlp.train` via the `logger` parameter. Default is [`json` and `rich`] for backward compatibility.
+- Added clickable snippets in the documentation for more registered functions
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - `docs/tutorials/tuning.md`: New tutorial for hyperparameter tuning.
 - Provided a [detailed tutorial](./docs/tutorials/tuning.md) on hyperparameter tuning, covering usage scenarios and configuration options.
 - Added grad spike detection to the `edsnlp.train` script, and per weight layer gradient logging.
+- Added support for multiple loggers (`tensorboard`, `wandb`, `comet_ml`, `aim`, `mlflow`, `clearml`, `dvclive`, `csv`, `json`, `rich`) in `edsnlp.train` via the `logger` parameter. Default is [`json` and `rich`] for backward compatibility.
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,11 +9,13 @@
 - Added a new unit test suite to validate the tuning script.
 - `docs/tutorials/tuning.md`: New tutorial for hyperparameter tuning.
 - Provided a [detailed tutorial](./docs/tutorials/tuning.md) on hyperparameter tuning, covering usage scenarios and configuration options.
+- Added grad spike detection to the `edsnlp.train` script, and per weight layer gradient logging.
 
 ### Fixed
 
 - Support packaging with poetry 2.0
 - Solve pickling issues with multiprocessing when pytorch is installed
+- Fixed mini-batch accumulation for multi-task training
 
 # v0.15.0 (2024-12-13)
 

--- a/docs/scripts/clickable_snippets.py
+++ b/docs/scripts/clickable_snippets.py
@@ -1,7 +1,7 @@
 # Based on https://github.com/darwindarak/mdx_bib
 import os
-import re
 from bisect import bisect_right
+from collections import defaultdict
 from typing import Tuple
 
 import jedi
@@ -22,11 +22,7 @@ except ImportError:
 
 from bs4 import BeautifulSoup
 
-BRACKET_RE = re.compile(r"\[([^\[]+)\]")
-CITE_RE = re.compile(r"@([\w_:-]+)")
-DEF_RE = re.compile(r"\A {0,3}\[@([\w_:-]+)\]:\s*(.*)")
-INDENT_RE = re.compile(r"\A\t| {4}(.*)")
-
+# Used to match href in HTML to replace with a relative path
 HREF_REGEX = (
     r"(?<=<\s*(?:a[^>]*href|img[^>]*src)=)"
     r'(?:"([^"]*)"|\'([^\']*)|[ ]*([^ =>]*)(?![a-z]+=))'
@@ -39,6 +35,15 @@ HTML_PIPE_REGEX = r"""(?x)
 <span[^>]*>eds<\/span>
 <span[^>]*>[.]<\/span>
 <span[^>]*>([a-zA-Z0-9._-]*)<\/span>
+(?![a-zA-Z0-9._-])
+"""
+
+REGISTRY_REGEX = r"""(?x)
+(?<![a-zA-Z0-9._-])
+<span[^>]*>(?:"|&\#39;|&quot;)@([a-zA-Z0-9._-]*)(?:"|&\#39;|&quot;)<\/span>\s*
+<span[^>]*>:<\/span>\s*
+<span[^>]*>\s*<\/span>\s*
+<span[^>]*>(?:"|&\#39;|&quot;)?([a-zA-Z0-9._-]*)(?:"|&\#39;|&quot;)?<\/span>
 (?![a-zA-Z0-9._-])
 """
 
@@ -62,11 +67,11 @@ class ClickableSnippetsPlugin(BasePlugin):
         plugin.load_config(plugin_config)
 
     @classmethod
-    def get_ep_namespace(cls, ep, namespace):
+    def get_ep_namespace(cls, ep, namespace=None):
         if hasattr(ep, "select"):
-            return ep.select(group=namespace)
+            return ep.select(group=namespace) if namespace else list(ep._all)
         else:  # dict
-            return ep.get(namespace, [])
+            return ep.get(namespace, []) if namespace else ep.values()
 
     @mkdocs.plugins.event_priority(-1000)
     def on_post_page(
@@ -94,18 +99,26 @@ class ClickableSnippetsPlugin(BasePlugin):
         autorefs: AutorefsPlugin = config["plugins"]["autorefs"]
         ep = entry_points()
         page_url = os.path.join("/", page.file.url)
-        spacy_factories_entry_points = {
+        factories_entry_points = {
             ep.name: ep.value
             for ep in (
                 *self.get_ep_namespace(ep, "spacy_factories"),
                 *self.get_ep_namespace(ep, "edsnlp_factories"),
             )
         }
+        all_entry_points = defaultdict(dict)
+        for ep in self.get_ep_namespace(ep):
+            if ep.group.startswith("edsnlp_") or ep.group.startswith("spacy_"):
+                group = ep.group.split("_", 1)[1]
+                all_entry_points[group][ep.name] = ep.value
 
-        def replace_component(match):
-            full_group = match.group(0)
+        # This method is meant for replacing any component that
+        # appears in a "eds.component" format, no matter if it is
+        # preceded by a "@factory" or not.
+        def replace_factory_component(match):
+            full_match = match.group(0)
             name = "eds." + match.group(1)
-            ep = spacy_factories_entry_points.get(name)
+            ep = factories_entry_points.get(name)
             preceding = output[match.start(0) - 50 : match.start(0)]
             if ep is not None and "DEFAULT:" not in preceding:
                 try:
@@ -114,7 +127,27 @@ class ClickableSnippetsPlugin(BasePlugin):
                     pass
                 else:
                     return f"<a href={url}>{name}</a>"
-            return full_group
+            return full_match
+
+        # This method is meant for replacing any component that
+        # appears in a "@registry": "component" format
+        def replace_any_registry_component(match):
+            full_match = match.group(0)
+            group = match.group(1)
+            name = match.group(2)
+            ep = all_entry_points[group].get(name)
+            preceding = output[match.start(0) - 50 : match.start(0)]
+            if ep is not None and "DEFAULT:" not in preceding:
+                try:
+                    url = autorefs.get_item_url(ep.replace(":", "."))
+                except KeyError:
+                    pass
+                else:
+                    repl = f'<a href={url} class="discrete-link">{name}</a>'
+                    before = full_match[: match.start(2) - match.start(0)]
+                    after = full_match[match.end(2) - match.start(0) :]
+                    return before + repl + after
+            return full_match
 
         def replace_link(match):
             relative_url = url = match.group(1) or match.group(2) or match.group(3)
@@ -122,8 +155,9 @@ class ClickableSnippetsPlugin(BasePlugin):
                 relative_url = os.path.relpath(url, page_url)
             return f'"{relative_url}"'
 
-        output = regex.sub(PIPE_REGEX, replace_component, output)
-        output = regex.sub(HTML_PIPE_REGEX, replace_component, output)
+        output = regex.sub(PIPE_REGEX, replace_factory_component, output)
+        output = regex.sub(HTML_PIPE_REGEX, replace_factory_component, output)
+        output = regex.sub(REGISTRY_REGEX, replace_any_registry_component, output)
 
         all_snippets = ""
         all_offsets = []

--- a/docs/training/loggers.md
+++ b/docs/training/loggers.md
@@ -1,0 +1,144 @@
+# Loggers
+
+When training a model, it is important to keep track of the training process, model performance at different stages, and statistics about the training data over time. This is where loggers come in. Loggers are used to store such information to be able to analyze and visualize it later.
+
+The EDS-NLP training API (`edsnlp.train`) relies on `accelerate` integration of popular loggers, as well as a few custom loggers.
+You can configure loggers in `edsnlp.train` via the `logger` parameter of the `train` function by specifying:
+
+- a string or a class instance or partially initialized class instance of a logger, e.g.
+
+    === "Via the Python API"
+        ```{ .python .no-check }
+        from edsnlp.training.loggers import CSVLogger
+        from edsnlp.training import train
+
+        logger = CSVLogger()
+        train(..., logger=logger)
+        # or train(..., logger="csv")
+        ```
+
+    === "Via a config file"
+        ```yaml
+        train:
+          ...
+          logger:
+            "@loggers": csv
+            ...
+        ```
+
+
+- or a list of string / logger instances, e.g.
+
+    === "Via the Python API"
+        ```{ .python .no-check }
+        from edsnlp.training.loggers import CSVLogger
+        from edsnlp.training import train
+
+        loggers = ["tensorboard", CSVLogger(...)]
+        train(..., logger=loggers)
+        ```
+
+    === "Via a config file"
+        ```yaml
+        train:
+          ...
+          logger:
+              - tensorboard  # as a string
+              - "@loggers": csv  # as a (partially) instanciated logger
+                ...
+        ```
+
+`edsnlp.train` will provide a default project name and logging dir for loggers that require these parameters, but it is
+recommended to set the project name explicitly in the logger configuration.
+
+The supported loggers are listed below.
+
+### RichLogger {: #edsnlp.training.loggers.RichLogger }
+
+::: edsnlp.training.loggers.RichLogger.__init__
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### CSVLogger {: #edsnlp.training.loggers.CSVLogger }
+
+::: edsnlp.training.loggers.CSVLogger.__init__
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### JSONLogger {: #edsnlp.training.loggers.JSONLogger }
+
+::: edsnlp.training.loggers.JSONLogger.__init__
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### TensorBoardLogger {: #edsnlp.training.loggers.TensorBoardLogger }
+
+::: edsnlp.training.loggers.TensorBoardLogger
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### AimLogger {: #edsnlp.training.loggers.AimLogger }
+
+::: edsnlp.training.loggers.AimLogger
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### WandBLogger {: #edsnlp.training.loggers.WandBLogger }
+
+::: edsnlp.training.loggers.WandBLogger
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### MLflowLogger {: #edsnlp.training.loggers.MLflowLogger }
+
+::: edsnlp.training.loggers.MLflowLogger
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### CometMLLogger {: #edsnlp.training.loggers.CometMLLogger }
+
+::: edsnlp.training.loggers.CometMLLogger
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true
+
+### DVCLiveLogger {: #edsnlp.training.loggers.DVCLiveLogger }
+
+::: edsnlp.training.loggers.DVCLiveLogger
+    options:
+        sections: ["text", "parameters"]
+        heading_level: 4
+        show_bases: false
+        show_source: false
+        only_class_level: true

--- a/docs/tutorials/training.md
+++ b/docs/tutorials/training.md
@@ -179,7 +179,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
       val_data: ${ val_data }
       max_steps: 2000
       validation_interval: ${ train.max_steps//10 }
-      max_grad_norm: 1.0
+      grad_max_norm: 1.0
       scorer: ${ scorer }
       optimizer: ${ optimizer }
       # Do preprocessing in parallel on 1 worker
@@ -284,7 +284,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         val_data=val_data,
         scorer={"ner": ner_metric},
         optimizer=optimizer,
-        max_grad_norm=1.0,
+        grad_max_norm=1.0,
         output_dir="artifacts",
         # Do preprocessing in parallel on 1 worker
         num_workers=1,

--- a/docs/tutorials/training.md
+++ b/docs/tutorials/training.md
@@ -1,4 +1,4 @@
-# Training API
+# Training API {: #edsnlp.training.trainer.train }
 
 In this tutorial, we'll see how we can quickly train a deep learning model with EDS-NLP using the `edsnlp.train` function.
 
@@ -170,6 +170,30 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         - '@factory': eds.standoff_dict2doc
           span_setter: 'gold_spans'
 
+    logger:
+        - '@loggers': csv
+        - '@loggers': rich
+          fields:
+              step: {}
+              (.*)loss:
+                  goal: lower_is_better
+                  format: "{:.2e}"
+                  goal_wait: 2
+              lr:
+                  format: "{:.2e}"
+              speed/(.*):
+                  format: "{:.2f}"
+                  name: \1
+              "(.*?)/micro/(f|r|p)$":
+                  goal: higher_is_better
+                  format: "{:.2%}"
+                  goal_wait: 1
+                  name: \1_\2
+              grad_norm/__all__:
+                  format: "{:.2e}"
+                  name: grad_norm
+        # - wandb  # enable if you can and want to track with wandb
+
     # 🚀 TRAIN SCRIPT OPTIONS
     # -> python -m edsnlp.train --config configs/config.yml
     train:
@@ -182,6 +206,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
       grad_max_norm: 1.0
       scorer: ${ scorer }
       optimizer: ${ optimizer }
+      logger: ${ logger }
       # Do preprocessing in parallel on 1 worker
       num_workers: 1
       # Enable on Mac OS X or if you don't want to use available GPUs
@@ -214,6 +239,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
     import edsnlp
     from edsnlp.training import train, ScheduledOptimizer, TrainingData
     from edsnlp.metrics.ner import NerExactMetric
+    from edsnlp.training.loggers import CSVLogger, RichLogger, WandbLogger
     import edsnlp.pipes as eds
     import torch
 
@@ -270,6 +296,22 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         },
     )
 
+    #
+    logger = [
+        CSVLogger(),
+        RichLogger(
+            fields={
+                "step": {},
+                "(.*)loss": {"goal": "lower_is_better", "format": "{:.2e}", "goal_wait": 2},
+                "lr": {"format": "{:.2e}"},
+                "speed/(.*)": {"format": "{:.2f}", "name": "\\1"},
+                "(.*?)/micro/(f|r|p)$": {"goal": "higher_is_better", "format": "{:.2%}", "goal_wait": 1, "name": "\\1_\\2"},
+                "grad_norm/__all__": {"format": "{:.2e}", "name": "grad_norm"},
+            }
+        ),
+        # WandBLogger(),  #  if you can and want to track with Weights & Biases
+    ]
+
     # 🚀 TRAIN
     train(
         nlp=nlp,
@@ -286,6 +328,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         optimizer=optimizer,
         grad_max_norm=1.0,
         output_dir="artifacts",
+        loggers
         # Do preprocessing in parallel on 1 worker
         num_workers=1,
         # Enable on Mac OS X or if you don't want to use available GPUs

--- a/docs/tutorials/tuning.md
+++ b/docs/tutorials/tuning.md
@@ -230,7 +230,7 @@ train:
   val_data: ${ val_data }
   max_steps: 400
   validation_interval: ${ train.max_steps//2 }
-  max_grad_norm: 1.0
+  grad_max_norm: 1.0
   scorer: ${ scorer }
   optimizer: ${ optimizer }
   num_workers: 2

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -44,7 +44,7 @@ from spacy.util import get_lang_class
 from spacy.vocab import Vocab, create_vocab
 from typing_extensions import Literal, Self
 
-from ..core.registries import PIPE_META, CurriedFactory, FactoryMeta, registry
+from ..core.registries import PIPE_META, FactoryMeta, PartialPipeFactory, registry
 from ..utils.collections import (
     FrozenDict,
     FrozenList,
@@ -238,9 +238,9 @@ class Pipeline(Validated):
                     **(config if config is not None else {}),
                 }
             ).resolve(registry=registry)
-            if isinstance(pipe, CurriedFactory):
+            if isinstance(pipe, PartialPipeFactory):
                 if name is None:
-                    name = signature(pipe.factory).parameters.get("name").default
+                    name = signature(pipe.func).parameters.get("name").default
                 if name is None or name == Parameter.empty:
                     name = factory
                 pipe = pipe.instantiate(nlp=self, path=(name,))
@@ -297,7 +297,7 @@ class Pipeline(Validated):
                 raise ValueError(
                     "Can't pass config or name with an instantiated component",
                 )
-            if isinstance(factory, CurriedFactory):
+            if isinstance(factory, PartialPipeFactory):
                 name = name or factory.kwargs.get("name")
                 factory = factory.instantiate(nlp=self, path=(name,))
 
@@ -585,13 +585,13 @@ class Pipeline(Validated):
     def _add_pipes(
         self,
         pipeline: Sequence[str],
-        components: Dict[str, CurriedFactory],
+        components: Dict[str, PartialPipeFactory],
         exclude: Container[str],
         enable: Container[str],
         disable: Container[str],
     ):
         try:
-            components = CurriedFactory.instantiate(components, nlp=self)
+            components = PartialPipeFactory.instantiate(components, nlp=self)
         except ConfitValidationError as e:
             e = ConfitValidationError(
                 e.raw_errors,

--- a/edsnlp/core/registries.py
+++ b/edsnlp/core/registries.py
@@ -2,13 +2,24 @@ import inspect
 import types
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 from weakref import WeakKeyDictionary
 
 import catalogue
 import spacy
 from confit import Config, Registry, RegistryCollection, set_default_registry
 from confit.errors import ConfitValidationError, patch_errors
+from confit.registry import Partial
 from spacy.pipe_analysis import validate_attrs
 
 import edsnlp
@@ -57,14 +68,17 @@ class FactoryMeta:
     default_config: Dict
 
 
-class CurriedFactory:
+T = TypeVar("T")
+
+
+class PartialPipeFactory(Partial[T]):
     def __init__(self, func, kwargs):
-        self.kwargs = kwargs
-        self.factory = func
+        super().__init__(func, kwargs)
+        self.func = func
         self.instantiated = None
         self.error = None
 
-    def maybe_nlp(self) -> Union["CurriedFactory", Any]:
+    def maybe_nlp(self) -> Union["PartialPipeFactory", Any]:
         """
         If the factory requires an nlp argument and the user has explicitly
         provided it (this is unusual, we usually expect the factory to be
@@ -73,11 +87,11 @@ class CurriedFactory:
 
         Returns
         -------
-        Union["CurriedFactory", Any]
+        Union["PartialFactory", Any]
         """
         from edsnlp.core.pipeline import Pipeline, PipelineProtocol
 
-        sig = inspect.signature(self.factory)
+        sig = inspect.signature(self.func)
         if (
             not (
                 "nlp" in sig.parameters
@@ -88,12 +102,12 @@ class CurriedFactory:
             )
             or "nlp" in self.kwargs
         ) and not self.search_curried_factory(self.kwargs):
-            return self.factory(**self.kwargs)
+            return self.func(**self.kwargs)
         return self
 
     @classmethod
     def search_curried_factory(cls, obj):
-        if isinstance(obj, CurriedFactory):
+        if isinstance(obj, PartialPipeFactory):
             return obj
         elif isinstance(obj, dict):
             for value in obj.values():
@@ -108,7 +122,7 @@ class CurriedFactory:
         return None
 
     def instantiate(
-        obj: Any,
+        self,
         nlp: "edsnlp.Pipeline",
         path: Optional[Sequence[str]] = (),
     ):
@@ -117,51 +131,51 @@ class CurriedFactory:
         passing in the nlp object and name to factories. Since they can be
         nested, we need to add them to every factory in the config.
         """
-        if isinstance(obj, CurriedFactory):
-            if obj.error is not None:
-                raise obj.error
+        if isinstance(self, PartialPipeFactory):
+            if self.error is not None:
+                raise self.error
 
-            if obj.instantiated is not None:
-                return obj.instantiated
+            if self.instantiated is not None:
+                return self.instantiated
 
             name = path[0] if len(path) == 1 else None
             parameters = (
-                inspect.signature(obj.factory.__init__).parameters
-                if isinstance(obj.factory, type)
-                else inspect.signature(obj.factory).parameters
+                inspect.signature(self.func.__init__).parameters
+                if isinstance(self.func, type)
+                else inspect.signature(self.func).parameters
             )
             kwargs = {
-                key: CurriedFactory.instantiate(
-                    obj=value,
+                key: PartialPipeFactory.instantiate(
+                    self=value,
                     nlp=nlp,
                     path=(*path, key),
                 )
-                for key, value in obj.kwargs.items()
+                for key, value in self.kwargs.items()
             }
             try:
                 if nlp and "nlp" in parameters:
                     kwargs["nlp"] = nlp
                 if name and "name" in parameters:
                     kwargs["name"] = name
-                obj.instantiated = obj.factory(**kwargs)
+                self.instantiated = self.func(**kwargs)
             except ConfitValidationError as e:
-                obj.error = e
+                self.error = e
                 raise ConfitValidationError(
                     patch_errors(e.raw_errors, path, model=e.model),
                     model=e.model,
-                    name=obj.factory.__module__ + "." + obj.factory.__qualname__,
+                    name=self.func.__module__ + "." + self.func.__qualname__,
                 )  # .with_traceback(None)
             # except Exception as e:
             #     obj.error = e
             #     raise ConfitValidationError([ErrorWrapper(e, path)])
-            return obj.instantiated
-        elif isinstance(obj, dict):
+            return self.instantiated
+        elif isinstance(self, dict):
             instantiated = {}
             errors = []
-            for key, value in obj.items():
+            for key, value in self.items():
                 try:
-                    instantiated[key] = CurriedFactory.instantiate(
-                        obj=value,
+                    instantiated[key] = PartialPipeFactory.instantiate(
+                        self=value,
                         nlp=nlp,
                         path=(*path, key),
                     )
@@ -170,41 +184,30 @@ class CurriedFactory:
             if errors:
                 raise ConfitValidationError(errors)
             return instantiated
-        elif isinstance(obj, (tuple, list)):
+        elif isinstance(self, (tuple, list)):
             instantiated = []
             errors = []
-            for i, value in enumerate(obj):
+            for i, value in enumerate(self):
                 try:
                     instantiated.append(
-                        CurriedFactory.instantiate(value, nlp, (*path, str(i)))
+                        PartialPipeFactory.instantiate(value, nlp, (*path, str(i)))
                     )
                 except ConfitValidationError as e:  # pragma: no cover
                     errors.append(e.raw_errors)
             if errors:
                 raise ConfitValidationError(errors)
-            return type(obj)(instantiated)
+            return type(self)(instantiated)
         else:
-            return obj
+            return self
 
-    def _raise_curried_factory_error(self):
+    def _raise_partial_error(self):
         raise TypeError(
-            f"This component CurriedFactory({self.factory}) has not been instantiated "
+            f"This component PartialFactory({self.func}) has not been instantiated "
             f"yet, likely because it was missing an `nlp` pipeline argument. You "
             f"should either:\n"
             f"- add it to a pipeline: `pipe = nlp.add_pipe(pipe)`\n"
             f"- or fill its `nlp` argument: `pipe = factory(nlp=nlp, ...)`"
         )
-
-    def __call__(self, *args, **kwargs):
-        self._raise_curried_factory_error()
-
-    def __getattr__(self, name):
-        if name.startswith("__"):
-            raise AttributeError(name)
-        self._raise_curried_factory_error()
-
-    def __repr__(self):
-        return f"CurriedFactory({self.factory})"
 
 
 glob = []
@@ -274,7 +277,9 @@ class FactoryRegistry(Registry):
 
             if catalogue.check_exists(*registry_path):
                 func = catalogue._get(registry_path)
-                return lambda **kwargs: CurriedFactory(func, kwargs=kwargs).maybe_nlp()
+                return lambda **kwargs: PartialPipeFactory(
+                    func, kwargs=kwargs
+                ).maybe_nlp()
 
         # Steps 1 & 2
         func = check_and_return()
@@ -427,7 +432,7 @@ class FactoryRegistry(Registry):
 
             @wraps(fn)
             def curried_registered_fn(**kwargs):
-                return CurriedFactory(registered_fn, kwargs).maybe_nlp()
+                return PartialPipeFactory(registered_fn, kwargs).maybe_nlp()
 
             return (
                 curried_registered_fn
@@ -453,6 +458,7 @@ class registry(RegistryCollection):
     core = Registry(("edsnlp", "core"), entry_points=True)
     optimizers = Registry(("edsnlp", "optimizers"), entry_points=True)
     schedules = Registry(("edsnlp", "schedules"), entry_points=True)
+    loggers = Registry(("edsnlp", "loggers"), entry_points=True)
 
 
 set_default_registry(registry)

--- a/edsnlp/pipes/base.py
+++ b/edsnlp/pipes/base.py
@@ -12,7 +12,7 @@ from typing import (
 from spacy.tokens import Doc, Span
 
 from edsnlp.core import PipelineProtocol
-from edsnlp.core.registries import CurriedFactory
+from edsnlp.core.registries import PartialPipeFactory
 from edsnlp.utils.span_getters import (
     SpanGetter,  # noqa: F401
     SpanGetterArg,  # noqa: F401
@@ -42,7 +42,7 @@ class BaseComponentMeta(abc.ABCMeta):
 
     def __call__(cls, nlp=inspect.Signature.empty, *args, **kwargs):
         # If this component is missing the nlp argument, we curry it with the
-        # provided arguments and return a CurriedFactory object.
+        # provided arguments and return a PartialFactory object.
         sig = inspect.signature(cls.__init__)
         try:
             bound = sig.bind_partial(None, nlp, *args, **kwargs)
@@ -52,7 +52,7 @@ class BaseComponentMeta(abc.ABCMeta):
                 and sig.parameters["nlp"].default is sig.empty
                 and bound.arguments.get("nlp", sig.empty) is sig.empty
             ):
-                return CurriedFactory(cls, bound.arguments)
+                return PartialPipeFactory(cls, bound.arguments)
             if nlp is inspect.Signature.empty:
                 bound.arguments.pop("nlp", None)
         except TypeError:  # pragma: no cover

--- a/edsnlp/training/loggers.py
+++ b/edsnlp/training/loggers.py
@@ -1,0 +1,503 @@
+import csv
+import json
+import os
+import warnings
+from typing import Any, Dict, Optional, Union
+
+import accelerate.tracking
+from accelerate.state import logger
+from rich_logger import RichTablePrinter
+
+import edsnlp
+
+
+@edsnlp.registry.loggers.register("csv", allow_partial=True)
+class CSVLogger(accelerate.tracking.GeneralTracker):
+    name = "csv"
+    requires_logging_directory = True
+
+    @accelerate.tracking.on_main_process
+    def __init__(
+        self,
+        *,
+        logging_dir: Union[str, os.PathLike],
+        file_name: str = "metrics.csv",
+        **kwargs,
+    ):
+        """
+        A simple CSV-based logger that writes logs to a CSV file. By default,
+        with `edsnlp.train` the CSV file is located under a local directory
+        `${CWD}/artifact/metrics.csv`.
+
+        !!! warning "Consistent Keys"
+
+            This logger expects that the `values` dictionary passed to `log` has
+            consistent keys across all calls. If a new key is encountered in a
+            subsequent call, it will be ignored and a warning will be issued.
+
+        Parameters
+        ----------
+        logging_dir : str or os.PathLike
+          Directory in which to store the CSV.
+        file_name : str, optional
+          Name of the CSV file. Defaults to "metrics.csv".
+        """
+        super().__init__()
+        self.logging_dir = logging_dir
+        os.makedirs(self.logging_dir, exist_ok=True)
+
+        self.file_path = os.path.join(self.logging_dir, file_name)
+
+        self._file = open(self.file_path, mode="a", newline="")
+        self._writer = csv.writer(self._file)
+        self._columns = None
+        self._has_header = False
+
+        logger.debug(f"Initialized CSVTracker. Logging to: {self.file_path}")
+
+    @property
+    def tracker(self):
+        return None
+
+    @accelerate.tracking.on_main_process
+    def store_init_configuration(self, values: Dict[str, Any]):
+        pass
+
+    @accelerate.tracking.on_main_process
+    def log(self, values: Dict[str, Any], step: Optional[int] = None):
+        """
+        Logs `values` to the CSV file, at an optional `step`.
+
+        - If it's the first call, the columns are inferred from the keys in `values`
+          plus a "step" column if the user provides `step`.
+        - All subsequent calls must use the same columns. Any missing columns get
+          written as empty, any new columns generate a warning.
+        """
+        # Ensure we have columns set
+        if self._columns is None:
+            # Create the list of columns. We'll always reserve "step" as first if step
+            # is provided.
+            self._columns = list({**{"step": None}, **values}.keys())
+            self._writer.writerow(self._columns)
+            self._has_header = True
+
+        # Build a row in the order of self._columns
+        row = []
+        for col in self._columns:
+            if col == "step":
+                row.append(step if step is not None else "")
+            else:
+                if col not in values and col != "step":
+                    row.append("")
+                else:
+                    row.append(values.get(col, ""))
+
+        for extra_key in values.keys():
+            if extra_key not in self._columns:
+                warnings.warn(
+                    f"CSVTracker: encountered a new field '{extra_key}' that was not in"
+                    f"the field keys of the first logged step. It will not be logged."
+                )
+
+        self._writer.writerow(row)
+        self._file.flush()
+
+    @accelerate.tracking.on_main_process
+    def finish(self):
+        self._file.close()
+        logger.debug("CSVTracker finished writing and closed the file.")
+
+
+@edsnlp.registry.loggers.register("json", allow_partial=True)
+class JSONLogger(accelerate.tracking.GeneralTracker):
+    name = "json"
+    requires_logging_directory = True
+
+    @accelerate.tracking.on_main_process
+    def __init__(
+        self,
+        logging_dir: Union[str, os.PathLike],
+        file_name: str = "metrics.json",
+        **kwargs,
+    ):
+        """
+        A simple JSON-based logger that writes logs to a JSON file as a
+        list of dictionaries. By default, with `edsnlp.train` the JSON file
+        is located under a local directory `${CWD}/artifact/metrics.json`.
+
+        This method is not recommended for large and frequent logging, as it
+        re-writes the entire JSON file on every call. Prefer
+        [`CSVLogger`][edsnlp.training.loggers.CSVLogger] for frequent
+        and heavy logging.
+
+        Parameters
+        ----------
+        logging_dir : str or os.PathLike
+            Directory in which to store the JSON file.
+        file_name : str, optional
+            Name of the JSON file. Defaults to "metrics.json".
+        """
+        super().__init__()
+        self.logging_dir = logging_dir
+        os.makedirs(self.logging_dir, exist_ok=True)
+
+        self._file_path = os.path.join(self.logging_dir, file_name)
+        self._logs = []
+
+        logger.debug(f"Initialized JSONTracker. Logging to: {self._file_path}")
+
+    @property
+    def tracker(self):
+        return None
+
+    @accelerate.tracking.on_main_process
+    def store_init_configuration(self, values: Dict[str, Any]):
+        pass
+
+    @accelerate.tracking.on_main_process
+    def log(self, values: Dict[str, Any], step: Optional[int] = None):
+        """
+        Logs `values` along with a `step` (if provided).
+
+        On every call, we:
+          1. Append a new record to our in-memory list.
+          2. Write out the entire JSON file containing all records.
+        """
+        log_entry = {"step": step, **values}
+        self._logs.append(log_entry)
+
+        with open(self._file_path, mode="w") as f:
+            json.dump(self._logs, f, indent=2)
+
+    @accelerate.tracking.on_main_process
+    def finish(self):
+        pass
+
+
+@edsnlp.registry.loggers.register("rich")
+class RichLogger(accelerate.tracking.GeneralTracker):
+    DEFAULT_FIELDS = {
+        "step": {},
+        "(.*)loss": {
+            "goal": "lower_is_better",
+            "format": "{:.2e}",
+            "goal_wait": 2,
+        },
+        "lr": {"format": "{:.2e}"},
+        "speed/(.*)": {"format": "{:.2f}", r"name": r"\1"},
+        "(.*?)/micro/(f|r|p)$": {
+            "goal": "higher_is_better",
+            "format": "{:.2%}",
+            "goal_wait": 1,
+            "name": r"\1_\2",
+        },
+        "(.*?)/(uas|las)": {
+            "goal": "higher_is_better",
+            "format": "{:.2%}",
+            "goal_wait": 1,
+            "name": r"\1_\2",
+        },
+        "grad_norm/__all__": {
+            "format": "{:.2e}",
+            "name": "grad_norm",
+        },
+    }
+
+    name = "rich"
+    requires_logging_directory = False
+
+    @accelerate.tracking.on_main_process
+    def __init__(
+        self,
+        run_name: Optional[str] = None,
+        fields: Dict[str, Union[Dict, bool]] = None,
+        key: Optional[str] = None,
+        hijack_tqdm: bool = True,
+        **kwargs,
+    ):
+        """
+        A logger that displays logs in a Rich-based table using
+        [rich-logger](https://github.com/percevalw/rich-logger).
+        This logger is also available via the loggers registry as `rich`.
+
+        !!! warning "No Disk Logging"
+
+            This logger doesn't save logs to disk. It's meant for displaying
+            logs in a pretty table during training. If you need to save logs
+            to disk, consider combining this logger with any other logger.
+
+        Parameters
+        ----------
+        fields: Dict[str, Union[Dict, bool]]
+            Field descriptors containing goal ("lower_is_better" or "higher_is_better"),
+             format and display name
+            The key is a regex that will be used to match the fields to log
+            Each entry of the dictionary should match the following scheme:
+
+            - key: a regex to match columns
+            - value: either a Dict or False to hide the column, the dict format is
+                - name: the name of the column
+                - goal: "lower_is_better" or "higher_is_better"
+
+            This defaults to a set of metrics and stats that are commonly
+            logged during EDS-NLP training.
+        key: Optional[str]
+            Key to group the logs
+        hijack_tqdm: bool
+            Whether to replace the tqdm progress bar with a rich progress bar.
+            Indeed, rich progress bars integrate better with the rich table.
+        """
+        super().__init__()
+
+        self.run_name = run_name
+        fields = fields if fields is not None else self.DEFAULT_FIELDS
+        self.fields = fields or {}
+
+        self.printer = RichTablePrinter(key=key, fields=self.fields)
+
+        if hijack_tqdm:
+            self.printer.hijack_tqdm()
+
+        logger.debug(f"Initialized RichTableTracker with run name '{self.run_name}'.")
+
+    @property
+    def tracker(self):
+        return self.printer
+
+    @accelerate.tracking.on_main_process
+    def store_init_configuration(self, values: Dict[str, Any]):
+        pass
+
+    @accelerate.tracking.on_main_process
+    def log(self, values: Dict[str, Any], step: Optional[int] = None):
+        """
+        Logs values in the Rich table. If `step` is provided, we include it in the
+        logged data.
+        """
+        combined = {"step": step, **values}
+        self.printer.log_metrics(combined)
+
+    @accelerate.tracking.on_main_process
+    def finish(self):
+        """
+        Finalize the table (e.g., stop rendering).
+        """
+        self.printer.finalize()
+
+
+@edsnlp.registry.loggers.register("tensorboard", allow_partial=True)
+def TensorBoardLogger(
+    project_name: str,
+    logging_dir: Optional[Union[str, os.PathLike]] = None,
+    **kwargs,
+) -> "accelerate.tracking.TensorBoardTracker":  # pragma: no cover
+    """
+    Logger for [TensorBoard](https://github.com/tensorflow/tensorboard).
+    This logger is also available via the loggers registry as `tensorboard`.
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the project.
+    logging_dir: Union[str, os.PathLike]
+        Directory in which to store the TensorBoard logs. Logs of different runs
+        will be stored in `logging_dir/project_name`. If not provided, the
+        environment variable `TENSORBOARD_LOGGING_DIR` will be used.
+    kwargs: Dict
+        Additional keyword arguments to pass to `tensorboard.SummaryWriter`.
+
+    Returns
+    -------
+    accelerate.tracking.TensorBoardTracker
+    """
+    logging_dir = logging_dir or os.environ.get("TENSORBOARD_LOGGING_DIR", None)
+    assert (
+        logging_dir is not None
+    ), "Please provide a logging directory or set TENSORBOARD_LOGGING_DIR"
+
+    return accelerate.tracking.TensorBoardTracker(project_name, logging_dir, **kwargs)
+
+
+@edsnlp.registry.loggers.register("aim", allow_partial=True)
+def AimLogger(
+    project_name: str,
+    logging_dir: Optional[Union[str, os.PathLike]] = None,
+    **kwargs,
+) -> "accelerate.tracking.AimTracker":  # pragma: no cover
+    """
+    Logger for [Aim](https://github.com/aimhubio/aim).
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the project.
+    logging_dir: Optional[Union[str, os.PathLike]]
+        Directory in which to store the Aim logs. If not provided, the environment
+        variable `AIM_LOGGING_DIR` will be used.
+
+    Returns
+    -------
+    accelerate.tracking.AimTracker
+    """
+    logging_dir = logging_dir or os.environ.get("AIM_LOGGING_DIR", None)
+    assert (
+        logging_dir is not None
+    ), "Please provide a logging directory or set AIM_LOGGING_DIR"
+
+    return accelerate.tracking.AimTracker(project_name, logging_dir, **kwargs)
+
+
+@edsnlp.registry.loggers.register("wandb", allow_partial=True)
+def WandBLogger(
+    project_name: str,
+    **kwargs,
+) -> "accelerate.tracking.WandBTracker":  # pragma: no cover
+    """
+    Logger for [Weights & Biases](https://docs.wandb.ai/quickstart/).
+    This logger is also available via the loggers registry as `wandb`.
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the project. This will become the `project`
+        parameter in `wandb.init`.
+    kwargs: Dict
+        Additional keyword arguments to pass to the WandB init function.
+
+    Returns
+    -------
+    accelerate.tracking.WandBTracker
+    """
+    return accelerate.tracking.WandBTracker(project_name, **kwargs)
+
+
+@edsnlp.registry.loggers.register("clearml", allow_partial=True)
+def ClearMLLogger(
+    project_name: str,
+    **kwargs,
+) -> "accelerate.tracking.ClearMLTracker":  # pragma: no cover
+    """
+    Logger for
+    [ClearML](https://clear.ml/docs/latest/docs/getting_started/ds/ds_first_steps/).
+    This logger is also available via the loggers registry as `clearml`.
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the experiment. Environment variables `CLEARML_PROJECT` and
+        `CLEARML_TASK` have priority over this argument.
+    kwargs: Dict
+        Additional keyword arguments to pass to the ClearML Task object.
+
+    Returns
+    -------
+    accelerate.tracking.ClearMLTracker
+    """
+    return accelerate.tracking.ClearMLTracker(project_name, **kwargs)
+
+
+@edsnlp.registry.loggers.register("mlflow", allow_partial=True)
+def MLflowLogger(
+    project_name: str,
+    logging_dir: Optional[Union[str, os.PathLike]] = None,
+    run_id: Optional[str] = None,
+    tags: Optional[Union[Dict[str, Any], str]] = None,
+    nested_run: Optional[bool] = False,
+    run_name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> "accelerate.tracking.MLflowTracker":  # pragma: no cover
+    """
+    Logger for
+    [MLflow](https://mlflow.org/docs/latest/getting-started/intro-quickstart/).
+    This logger is also available via the loggers registry as `mlflow`.
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the project. This will become the mlflow experiment name.
+    logging_dir: Optional[Union[str, os.PathLike]]
+        Directory in which to store the MLflow logs.
+    run_id: Optional[str]
+        If specified, get the run with the specified UUID and log parameters and metrics
+        under that run. The run’s end time is unset and its status is set to running,
+        but the run’s other attributes (source_version, source_type, etc.) are not
+        changed. Environment variable MLFLOW_RUN_ID has priority over this argument.
+    tags: Optional[Union[Dict[str, Any], str]]
+        An optional `dict` of `str` keys and values, or a `str` dump from a `dict`, to
+        set as tags on the run. If a run is being resumed, these tags are set on the
+        resumed run. If a new run is being created, these tags are set on the new run.
+        Environment variable MLFLOW_TAGS has priority over this argument.
+    nested_run: Optional[bool]
+        Controls whether run is nested in parent run. True creates a nested run.
+        Environment variable MLFLOW_NESTED_RUN has priority over this argument.
+    run_name: Optional[str]
+        Name of new run (stored as a mlflow.runName tag). Used only when `run_id` is
+        unspecified.
+    description: Optional[str]
+        An optional string that populates the description box of the run. If a run is
+        being resumed, the description is set on the resumed run. If a new run is being
+        created, the description is set on the new run.
+
+    Returns
+    -------
+    accelerate.tracking.MLflowTracker
+    """
+    return accelerate.tracking.MLflowTracker(
+        project_name,
+        logging_dir=logging_dir,
+        run_id=run_id,
+        tags=tags,
+        nested_run=nested_run,
+        run_name=run_name,
+        description=description,
+    )
+
+
+@edsnlp.registry.loggers.register("cometml", allow_partial=True)
+def CometMLLogger(
+    project_name: str,
+    **kwargs,
+) -> "accelerate.tracking.CometMLTracker":  # pragma: no cover
+    """
+    Logger for [CometML](https://www.comet.com/docs/).
+    This logger is also available via the loggers registry as `cometml`.
+
+    Parameters
+    ----------
+    project_name: str
+        Name of the project.
+    kwargs: Dict
+        Additional keyword arguments to pass to the CometML Experiment
+        object.
+
+    Returns
+    -------
+    accelerate.tracking.CometMLTracker
+    """
+    return accelerate.tracking.CometMLTracker(project_name, **kwargs)
+
+
+@edsnlp.registry.loggers.register("dvclive", allow_partial=True)
+def DVCLiveLogger(
+    project_name: Optional[str] = None,
+    live: Any = None,
+    **kwargs,
+) -> "accelerate.tracking.DVCLiveTracker":
+    """
+    Logger for [DVC Live](https://dvc.org/doc/dvclive).
+    This logger is also available via the loggers registry as `dvclive`.
+
+    Parameters
+    ----------
+    project_name: str
+        Unused project name.
+    live: dvclive.Live
+        An instance of `dvclive.Live` to use for logging.
+    kwargs: Dict
+        Additional keyword arguments to pass to the `dvclive.Live` constructor.
+
+    Returns
+    -------
+    accelerate.tracking.DVCLiveTracker
+    """
+    return accelerate.tracking.DVCLiveTracker(project_name, live=live, **kwargs)

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import time
 import warnings
@@ -31,10 +32,13 @@ from edsnlp import Pipeline, registry
 from edsnlp.core.stream import Stream
 from edsnlp.metrics.ner import NerMetric
 from edsnlp.metrics.span_attributes import SpanAttributeMetric
-from edsnlp.pipes.base import BaseNERComponent, BaseSpanAttributeClassifierComponent
+from edsnlp.pipes.base import (
+    BaseNERComponent,
+    BaseSpanAttributeClassifierComponent,
+)
 from edsnlp.utils.batching import BatchSizeArg, stat_batchify
 from edsnlp.utils.bindings import BINDING_SETTERS
-from edsnlp.utils.collections import chain_zip, flatten, ld_to_dl
+from edsnlp.utils.collections import chain_zip, flatten, flatten_once, ld_to_dl
 from edsnlp.utils.span_getters import get_spans
 from edsnlp.utils.typing import AsList
 
@@ -61,6 +65,10 @@ LOGGER_FIELDS = {
         "format": "{:.2%}",
         "goal_wait": 1,
         "name": r"\1_\2",
+    },
+    "grad_norm/__all__": {
+        "format": "{:.2e}",
+        "name": "grad_norm",
     },
 }
 
@@ -206,6 +214,47 @@ class GenericScorer:
 
 if TYPE_CHECKING:
     GenericScorer = Union[GenericScorer, Dict]
+
+
+def ewm_moments(x, window, adjust=True, bias=False, state=None):
+    if state is None:
+        alpha = 2.0 / (window + 1)
+        decay = 1 - alpha
+        fresh_weight = 1 if adjust else alpha
+        mean_val = x
+        var_val = 0.0
+        sum_w = 1.0
+        sum_w2 = 1.0
+        old_w = 1.0
+        return (
+            mean_val,
+            float("nan"),
+            [decay, fresh_weight, mean_val, var_val, sum_w, sum_w2, old_w],
+        )
+    else:
+        decay, fresh_weight, mean_val, var_val, sum_w, sum_w2, old_w = state
+
+    sum_w *= decay
+    sum_w2 *= decay * decay
+    old_w *= decay
+    old_m = mean_val
+    denom = old_w + fresh_weight
+    mean_val = (old_w * old_m + fresh_weight * x) / denom
+    d1 = old_m - mean_val
+    d2 = x - mean_val
+    var_val = (old_w * (var_val + d1 * d1) + fresh_weight * d2 * d2) / denom
+    sum_w += fresh_weight
+    sum_w2 += fresh_weight * fresh_weight
+    old_w += fresh_weight
+
+    state = [decay, fresh_weight, mean_val, var_val, sum_w, sum_w2, old_w]
+
+    if not bias:
+        num = sum_w * sum_w
+        den = num - sum_w2
+        var_val = var_val * (num / den) if den > 0 else float("nan")
+
+    return mean_val, var_val, state
 
 
 def default_optim(
@@ -362,7 +411,10 @@ def train(
     optimizer: Union[ScheduledOptimizer, torch.optim.Optimizer] = None,
     validation_interval: Optional[int] = None,
     checkpoint_interval: Optional[int] = None,
-    max_grad_norm: float = 5.0,
+    grad_max_norm: float = 5.0,
+    grad_ewm_window: int = 100,
+    grad_dev_policy: Optional[Literal["clip_mean", "clip_threshold", "skip"]] = None,
+    grad_max_dev: float = 7.0,
     loss_scales: Dict[str, float] = {},
     scorer: GenericScorer = GenericScorer(),
     num_workers: int = 0,
@@ -372,8 +424,9 @@ def train(
     output_model_dir: Optional[Union[Path, str]] = None,
     save_model: bool = True,
     logger: bool = True,
-    config_meta: Optional[Dict] = None,
+    log_weight_grads: bool = False,
     on_validation_callback: Optional[Callable[[Dict], None]] = None,
+    config_meta: Optional[Dict] = None,
     **kwargs,
 ):
     """
@@ -418,8 +471,26 @@ def train(
         The number of steps between each evaluation. Defaults to 1/10 of max_steps
     checkpoint_interval: Optional[int]
         The number of steps between each model save. Defaults to validation_interval
-    max_grad_norm: float
+    grad_max_norm: float
         The maximum gradient norm
+    grad_dev_policy: Optional[Literal["clip_mean", "clip_threshold"]]
+        The policy to apply when a gradient spike is detected, ie. when the
+        gradient norm is higher than the mean + std * grad_max_dev. Can be:
+
+        - "clip_mean": clip the gradients to the mean gradient norm
+        - "clip_threshold": clip the gradients to the mean + std * grad_max_dev
+        - "skip": skip the step
+
+        These do not apply to `grad_max_norm` that is always enforced when it is not
+        None, since `grad_max_norm` is not adaptive and would most likely prohibit
+        the model from learning during the early stages of training when gradients are
+        expected to be high.
+    grad_ewm_window: int
+        Approximately how many steps should we look back to compute the average
+        gradient norm and variance to detect gradient deviation spikes.
+    grad_max_dev: float
+        The threshold to apply to detect gradient spikes. A spike is detected
+        when the value is higher than the mean + variance * threshold.
     loss_scales: Dict[str, float]
         The loss scales for each component (useful for multi-task learning)
     scorer: GenericScorer
@@ -455,6 +526,8 @@ def train(
         spending time dumping the model weights to the disk.
     logger: bool
         Whether to log the validation metrics in a rich table.
+    log_weight_grads: bool
+        Whether to log the weight gradients during training.
     on_validation_callback: Optional[Callable[[Dict], None]]
         A callback function invoked during validation steps to handle custom logic.
     kwargs: Dict
@@ -471,11 +544,18 @@ def train(
     is_main_process = accelerator.is_main_process
     device = accelerator.device
 
+    if "max_grad_norm" in kwargs:
+        warnings.warn(
+            "The 'max_grad_norm' argument is deprecated. Use 'grad_max_norm' instead."
+        )
+        grad_max_norm = kwargs.pop("max_grad_norm")
+
     output_dir = Path(output_dir or Path.cwd() / "artifacts")
-    output_model_dir = output_model_dir or output_dir / "model-last"
+    output_model_dir = Path(output_model_dir or output_dir / "model-last")
     train_metrics_path = output_dir / "train_metrics.json"
     if is_main_process:
         os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(output_model_dir, exist_ok=True)
         if config_meta is not None:  # pragma: no cover
             print(config_meta["unresolved_config"].to_yaml_str())
             config_meta["unresolved_config"].to_disk(output_dir / "train_config.yml")
@@ -517,7 +597,8 @@ def train(
     nlp.post_init(chain_zip([td.data for td in train_data if td.post_init]))
 
     for phase_i, pipe_names in enumerate(phases):
-        trained_pipes = PipeDict({n: nlp.get_pipe(n) for n in pipe_names}, loss_scales)
+        trained_pipes_local = {n: nlp.get_pipe(n) for n in pipe_names}
+        trained_pipes = PipeDict(trained_pipes_local, loss_scales)
         trained_pipes_params = set(trained_pipes.parameters())
         phase_training_data = [
             td
@@ -572,7 +653,9 @@ def train(
             if hasattr(accel_optim.optimizer, "initialize"):
                 accel_optim.optimizer.initialize()
 
-            cumulated_data = defaultdict(lambda: 0.0, count=0)
+            ewm_state = grad_mean = grad_var = None
+            default_metrics = dict(count=0, spikes=0)
+            cumulated_data = defaultdict(lambda: 0, **default_metrics)
             all_metrics = []
             set_seed(seed)
             with (
@@ -591,33 +674,32 @@ def train(
                     smoothing=0.3,
                 ):
                     if (
+                        save_model
+                        and is_main_process
+                        and (step % checkpoint_interval) == 0
+                    ):
+                        # torch.save(nlp, output_model_dir / "model.pt")
+                        nlp.to_disk(output_model_dir)
+                    if (
                         is_main_process
                         and step > 0
                         and (step % validation_interval) == 0
                     ):
                         scores = scorer(nlp, val_docs) if val_docs else {}
-                        all_metrics.append(
-                            {
-                                "step": step,
-                                "lr": accel_optim.param_groups[0]["lr"],
-                                **cumulated_data,
-                                **scores,
-                            }
-                        )
-                        cumulated_data.clear()
+                        metrics = {
+                            "step": step,
+                            "lr": accel_optim.param_groups[0]["lr"],
+                            **cumulated_data,
+                            **scores,
+                        }
+                        all_metrics.append(metrics)
+                        cumulated_data = defaultdict(lambda: 0, **default_metrics)
                         train_metrics_path.write_text(json.dumps(all_metrics, indent=2))
                         if logger:
-                            logger.log_metrics(flatten_dict(all_metrics[-1]))
+                            logger.log_metrics(flatten_dict(metrics))
 
                         if on_validation_callback:
-                            on_validation_callback(all_metrics[-1])
-
-                    if (
-                        save_model
-                        and is_main_process
-                        and (step % checkpoint_interval) == 0
-                    ):
-                        nlp.to_disk(output_model_dir)
+                            on_validation_callback(metrics)
 
                     if step == max_steps:
                         break
@@ -626,7 +708,7 @@ def train(
 
                     batches = list(next(iterator))
                     batches_pipe_names = list(
-                        flatten(
+                        flatten_once(
                             [
                                 [td.pipe_names or pipe_names] * len(b)
                                 for td, b in zip(phase_training_data, batches)
@@ -636,17 +718,15 @@ def train(
                     batches = list(flatten(batches))
 
                     # Synchronize stats between sub-batches across workers
-                    batch_stats = {}
+                    local_batch_stats = {}
                     for b in batches:
-                        fill_flat_stats(b, result=batch_stats)
-                    batch_stats = {
-                        k: sum(v)
-                        for k, v in ld_to_dl(gather_object([batch_stats])).items()
-                    }
+                        fill_flat_stats(b, result=local_batch_stats)
+                    batch_stats = gather_object([local_batch_stats])
+                    batch_stats = {k: sum(v) for k, v in ld_to_dl(batch_stats).items()}
                     for b in batches:
                         set_flat_stats(b, batch_stats)
 
-                    res_stats = defaultdict(lambda: 0.0)
+                    local_res_stats = defaultdict(lambda: 0.0)
                     for idx, (batch, batch_pipe_names) in enumerate(
                         zip(batches, batches_pipe_names)
                     ):
@@ -658,29 +738,43 @@ def train(
                             if idx < len(batches) - 1
                             else nullcontext()
                         )
-                        with cache_ctx, no_sync_ctx:
-                            all_res, loss = trained_pipes(
-                                batch,
-                                enable=batch_pipe_names,
+                        try:
+                            with cache_ctx, no_sync_ctx:
+                                all_res, loss = trained_pipes(
+                                    batch,
+                                    enable=batch_pipe_names,
+                                )
+                                for name, res in all_res.items():
+                                    for k, v in res.items():
+                                        if (
+                                            isinstance(v, (float, int))
+                                            or isinstance(v, torch.Tensor)
+                                            and v.ndim == 0
+                                        ):
+                                            local_res_stats[k] += float(v)
+                                        del k, v
+                                    del res
+                                del all_res
+                                if (
+                                    isinstance(loss, torch.Tensor)
+                                    and loss.requires_grad
+                                ):
+                                    accelerator.backward(loss)
+                        except torch.cuda.OutOfMemoryError:
+                            print(
+                                "Out of memory error encountered when processing a "
+                                "batch with the following statistics:"
                             )
-                            for name, res in all_res.items():
-                                for k, v in res.items():
-                                    if (
-                                        isinstance(v, (float, int))
-                                        or isinstance(v, torch.Tensor)
-                                        and v.ndim == 0
-                                    ):
-                                        res_stats[k] += float(v)
-                                    del k, v
-                                del res
-                            del all_res
-                            accelerator.backward(loss)
+                            print(local_batch_stats)
+                            raise
                         del loss
 
                     # Sync output stats after forward such as losses, supports, etc.
                     res_stats = {
                         k: sum(v)
-                        for k, v in ld_to_dl(gather_object([dict(res_stats)])).items()
+                        for k, v in ld_to_dl(
+                            gather_object([dict(local_res_stats)])
+                        ).items()
                     }
                     if is_main_process:
                         for k, v in batch_stats.items():
@@ -689,8 +783,53 @@ def train(
                             cumulated_data[k] += v
 
                     del batch_stats, res_stats
-                    accelerator.clip_grad_norm_(grad_params, max_grad_norm)
-                    accel_optim.step()
+                    accelerator.unscale_gradients()
+
+                    # Log gradients
+                    if log_weight_grads:
+                        for pipe_name, pipe in trained_pipes_local.items():
+                            for param_name, param in pipe.named_parameters():
+                                if param.grad is not None:
+                                    cumulated_data[
+                                        f"grad_norm/{pipe_name}/{param_name}"
+                                    ] += param.grad.norm().item()
+                                    cumulated_data[
+                                        f"param_norm/{pipe_name}/{param_name}"
+                                    ] += param.norm().item()
+
+                    grad_norm = torch.nn.utils.clip_grad_norm_(
+                        grad_params, grad_max_norm, norm_type=2
+                    ).item()
+
+                    # Detect grad spikes and skip the step if necessary
+                    if grad_dev_policy is not None:
+                        if step > grad_ewm_window and (
+                            grad_norm - grad_mean
+                        ) > grad_max_dev * math.sqrt(grad_var):
+                            spike = True
+                            cumulated_data["spikes"] += 1
+                        else:
+                            grad_mean, grad_var, ewm_state = ewm_moments(
+                                grad_norm, grad_ewm_window, state=ewm_state
+                            )
+                            spike = False
+
+                        if spike and grad_dev_policy == "clip_mean":
+                            torch.nn.utils.clip_grad_norm_(
+                                grad_params, grad_mean, norm_type=2
+                            )
+                        elif spike and grad_dev_policy == "clip_threshold":
+                            torch.nn.utils.clip_grad_norm_(
+                                grad_params,
+                                grad_mean + math.sqrt(grad_var) * grad_max_dev,
+                                norm_type=2,
+                            )
+
+                    if grad_dev_policy != "skip" or not spike:
+                        accel_optim.step()
+
+                    cumulated_data["count"] += 1
+                    cumulated_data["grad_norm/__all__"] += grad_norm
 
                 del iterator
 

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -1,4 +1,3 @@
-import json
 import math
 import os
 import time
@@ -20,14 +19,16 @@ from typing import (
 )
 
 import torch
-from accelerate import Accelerator
+from accelerate import Accelerator, PartialState
+from accelerate.tracking import GeneralTracker
 from accelerate.utils import gather_object
 from confit import validate_arguments
+from confit.registry import Partial
 from confit.utils.random import set_seed
-from rich_logger import RichTablePrinter
 from tqdm import tqdm, trange
 from typing_extensions import Literal
 
+import edsnlp
 from edsnlp import Pipeline, registry
 from edsnlp.core.stream import Stream
 from edsnlp.metrics.ner import NerMetric
@@ -400,6 +401,23 @@ class PipeDict(torch.nn.ModuleDict):
         return all_results, loss
 
 
+def get_logger(
+    logger: Union[bool, AsList[Union[str, Partial[GeneralTracker], GeneralTracker]]],
+    project_name,
+    logging_dir,
+    **kwargs,
+):
+    logger = ["rich", "json"] if logger is True else [] if not logger else logger
+    logger = [
+        edsnlp.registry.loggers.get(n)() if isinstance(n, str) else n for n in logger
+    ]
+    logger = [
+        Partial.instantiate(obj, project_name=project_name, logging_dir=logging_dir)
+        for obj in logger
+    ]
+    return logger
+
+
 @validate_arguments(registry=registry)
 def train(
     *,
@@ -408,7 +426,11 @@ def train(
     val_data: AsList[Stream] = [],
     seed: int = 42,
     max_steps: int = 1000,
-    optimizer: Union[ScheduledOptimizer, torch.optim.Optimizer] = None,
+    optimizer: Union[
+        ScheduledOptimizer,
+        Partial[ScheduledOptimizer],
+        torch.optim.Optimizer,
+    ] = None,
     validation_interval: Optional[int] = None,
     checkpoint_interval: Optional[int] = None,
     grad_max_norm: float = 5.0,
@@ -423,7 +445,16 @@ def train(
     output_dir: Union[Path, str] = Path("artifacts"),
     output_model_dir: Optional[Union[Path, str]] = None,
     save_model: bool = True,
-    logger: bool = True,
+    logger: Union[
+        bool,
+        AsList[
+            Union[
+                str,
+                Partial[GeneralTracker],
+                GeneralTracker,
+            ]
+        ],
+    ] = True,
     log_weight_grads: bool = False,
     on_validation_callback: Optional[Callable[[Dict], None]] = None,
     config_meta: Optional[Dict] = None,
@@ -456,7 +487,7 @@ def train(
         The random seed
     max_steps: int
         The maximum number of training steps
-    optimizer: Union[ScheduledOptimizer, torch.optim.Optimizer]
+    optimizer: Union[ScheduledOptimizer, Partial[ScheduledOptimizer], torch.optim.Optimizer]
         The optimizer. If None, a default optimizer will be used.
 
         ??? note "`ScheduledOptimizer` object/dictionary"
@@ -524,8 +555,17 @@ def train(
         Whether to save the model or not. This can be useful if you are only
         interested in the metrics, but no the model, and want to avoid
         spending time dumping the model weights to the disk.
-    logger: bool
-        Whether to log the validation metrics in a rich table.
+    logger: Union[bool, AsList[Union[str, Partial[GeneralTracker], GeneralTracker]]]
+        The logger to use. Can be a boolean to use the default loggers (rich
+        and json), a list of logger names, or a list of logger objects.
+
+        You can use huggingface's accelerate integrated loggers (`tensorboard`,
+        `wandb`, `comet_ml`, `aim`, `mlflow`, `clearml`, `dvclive`), or
+        EDS-NLP simple loggers, or a combination of both:
+
+        - `csv`: logs to a CSV file in `output_dir` (`artifacts/metrics.csv`)
+        - `json`: logs to a JSON file in `output_dir` (`artifacts/metrics.json`)
+        - `rich`: logs to a rich table in the terminal
     log_weight_grads: bool
         Whether to log the weight gradients during training.
     on_validation_callback: Optional[Callable[[Dict], None]]
@@ -537,9 +577,22 @@ def train(
     -------
     Pipeline
         The trained pipeline
-    """
-    # Prepare paths
-    accelerator = Accelerator(cpu=cpu, mixed_precision=mixed_precision)
+    """  # noqa: E501
+    # hack to ensure cpu is set before the accelerator is indirectly initialized
+    # when creating the trackers
+    PartialState(cpu=cpu)
+    accelerator = Accelerator(
+        cpu=cpu,
+        mixed_precision=mixed_precision,
+        log_with=get_logger(
+            logger,
+            # default project name, the user can override this when creating the logger
+            project_name=str(
+                config_meta["config_path"][0] if config_meta is not None else Path.cwd()
+            ),
+            logging_dir=output_dir,
+        ),
+    )
     # accelerator.register_for_checkpointing(dataset)
     is_main_process = accelerator.is_main_process
     device = accelerator.device
@@ -552,13 +605,15 @@ def train(
 
     output_dir = Path(output_dir or Path.cwd() / "artifacts")
     output_model_dir = Path(output_model_dir or output_dir / "model-last")
-    train_metrics_path = output_dir / "train_metrics.json"
     if is_main_process:
         os.makedirs(output_dir, exist_ok=True)
         os.makedirs(output_model_dir, exist_ok=True)
+        unresolved_config = {}
         if config_meta is not None:  # pragma: no cover
-            print(config_meta["unresolved_config"].to_yaml_str())
-            config_meta["unresolved_config"].to_disk(output_dir / "train_config.yml")
+            unresolved_config = config_meta["unresolved_config"]
+            print(unresolved_config.to_yaml_str())
+            unresolved_config.to_disk(output_dir / "train_config.yml")
+        # TODO: handle config_meta is None
 
     validation_interval = validation_interval or max_steps // 10
     checkpoint_interval = checkpoint_interval or validation_interval
@@ -573,9 +628,10 @@ def train(
     all_params = set(nlp.parameters())
     optim = optimizer
     del optimizer
+    optim = Partial.instantiate(optim, module=nlp, total_steps=max_steps)
     if optim is None:
         warnings.warn(
-            "No optimizer provided, using default optimizer with default " "parameters"
+            "No optimizer provided, using default optimizer with default parameters"
         )
         optim = default_optim(
             [nlp.get_pipe(name) for name in trainable_pipe_names],
@@ -656,181 +712,158 @@ def train(
             ewm_state = grad_mean = grad_var = None
             default_metrics = dict(count=0, spikes=0)
             cumulated_data = defaultdict(lambda: 0, **default_metrics)
-            all_metrics = []
             set_seed(seed)
-            with (
-                RichTablePrinter(LOGGER_FIELDS, auto_refresh=False)
-                if is_main_process and logger
-                else nullcontext()
-            ) as logger:
-                # Training loop
-                for step in trange(
-                    max_steps + 1,
-                    desc="Training model",
-                    leave=True,
-                    mininterval=5.0,
-                    total=max_steps,
-                    disable=not is_main_process,
-                    smoothing=0.3,
-                ):
-                    if (
-                        save_model
-                        and is_main_process
-                        and (step % checkpoint_interval) == 0
-                    ):
-                        # torch.save(nlp, output_model_dir / "model.pt")
-                        nlp.to_disk(output_model_dir)
-                    if (
-                        is_main_process
-                        and step > 0
-                        and (step % validation_interval) == 0
-                    ):
-                        scores = scorer(nlp, val_docs) if val_docs else {}
-                        metrics = {
-                            "step": step,
-                            "lr": accel_optim.param_groups[0]["lr"],
-                            **cumulated_data,
-                            **scores,
-                        }
-                        all_metrics.append(metrics)
-                        cumulated_data = defaultdict(lambda: 0, **default_metrics)
-                        train_metrics_path.write_text(json.dumps(all_metrics, indent=2))
-                        if logger:
-                            logger.log_metrics(flatten_dict(metrics))
-
-                        if on_validation_callback:
-                            on_validation_callback(metrics)
-
-                    if step == max_steps:
-                        break
-
-                    accel_optim.zero_grad()
-
-                    batches = list(next(iterator))
-                    batches_pipe_names = list(
-                        flatten_once(
-                            [
-                                [td.pipe_names or pipe_names] * len(b)
-                                for td, b in zip(phase_training_data, batches)
-                            ]
-                        )
-                    )
-                    batches = list(flatten(batches))
-
-                    # Synchronize stats between sub-batches across workers
-                    local_batch_stats = {}
-                    for b in batches:
-                        fill_flat_stats(b, result=local_batch_stats)
-                    batch_stats = gather_object([local_batch_stats])
-                    batch_stats = {k: sum(v) for k, v in ld_to_dl(batch_stats).items()}
-                    for b in batches:
-                        set_flat_stats(b, batch_stats)
-
-                    local_res_stats = defaultdict(lambda: 0.0)
-                    for idx, (batch, batch_pipe_names) in enumerate(
-                        zip(batches, batches_pipe_names)
-                    ):
-                        cache_ctx = (
-                            nlp.cache() if len(batch_pipe_names) > 1 else nullcontext()
-                        )
-                        no_sync_ctx = (
-                            accelerator.no_sync(trained_pipes)
-                            if idx < len(batches) - 1
-                            else nullcontext()
-                        )
-                        try:
-                            with cache_ctx, no_sync_ctx:
-                                all_res, loss = trained_pipes(
-                                    batch,
-                                    enable=batch_pipe_names,
-                                )
-                                for name, res in all_res.items():
-                                    for k, v in res.items():
-                                        if (
-                                            isinstance(v, (float, int))
-                                            or isinstance(v, torch.Tensor)
-                                            and v.ndim == 0
-                                        ):
-                                            local_res_stats[k] += float(v)
-                                        del k, v
-                                    del res
-                                del all_res
-                                if (
-                                    isinstance(loss, torch.Tensor)
-                                    and loss.requires_grad
-                                ):
-                                    accelerator.backward(loss)
-                        except torch.cuda.OutOfMemoryError:
-                            print(
-                                "Out of memory error encountered when processing a "
-                                "batch with the following statistics:"
-                            )
-                            print(local_batch_stats)
-                            raise
-                        del loss
-
-                    # Sync output stats after forward such as losses, supports, etc.
-                    res_stats = {
-                        k: sum(v)
-                        for k, v in ld_to_dl(
-                            gather_object([dict(local_res_stats)])
-                        ).items()
+            # Training loop
+            for step in trange(
+                max_steps + 1,
+                desc="Training model",
+                leave=True,
+                mininterval=5.0,
+                total=max_steps,
+                disable=not is_main_process,
+                smoothing=0.3,
+            ):
+                if save_model and is_main_process and (step % checkpoint_interval) == 0:
+                    nlp.to_disk(output_model_dir)
+                if is_main_process and step > 0 and (step % validation_interval) == 0:
+                    scores = scorer(nlp, val_docs) if val_docs else {}
+                    metrics = {
+                        "step": step,
+                        "lr": accel_optim.param_groups[0]["lr"],
+                        **cumulated_data,
+                        **scores,
                     }
-                    if is_main_process:
-                        for k, v in batch_stats.items():
-                            cumulated_data[k] += v
-                        for k, v in res_stats.items():
-                            cumulated_data[k] += v
+                    cumulated_data = defaultdict(lambda: 0, **default_metrics)
+                    accelerator.log(flatten_dict(metrics), step=step)
 
-                    del batch_stats, res_stats
-                    accelerator.unscale_gradients()
+                    if on_validation_callback:
+                        on_validation_callback(metrics)
 
-                    # Log gradients
-                    if log_weight_grads:
-                        for pipe_name, pipe in trained_pipes_local.items():
-                            for param_name, param in pipe.named_parameters():
-                                if param.grad is not None:
-                                    cumulated_data[
-                                        f"grad_norm/{pipe_name}/{param_name}"
-                                    ] += param.grad.norm().item()
-                                    cumulated_data[
-                                        f"param_norm/{pipe_name}/{param_name}"
-                                    ] += param.norm().item()
+                if step == max_steps:
+                    break
 
-                    grad_norm = torch.nn.utils.clip_grad_norm_(
-                        grad_params, grad_max_norm, norm_type=2
-                    ).item()
+                accel_optim.zero_grad()
 
-                    # Detect grad spikes and skip the step if necessary
-                    if grad_dev_policy is not None:
-                        if step > grad_ewm_window and (
-                            grad_norm - grad_mean
-                        ) > grad_max_dev * math.sqrt(grad_var):
-                            spike = True
-                            cumulated_data["spikes"] += 1
-                        else:
-                            grad_mean, grad_var, ewm_state = ewm_moments(
-                                grad_norm, grad_ewm_window, state=ewm_state
+                batches = list(next(iterator))
+                batches_pipe_names = list(
+                    flatten_once(
+                        [
+                            [td.pipe_names or pipe_names] * len(b)
+                            for td, b in zip(phase_training_data, batches)
+                        ]
+                    )
+                )
+                batches = list(flatten(batches))
+
+                # Synchronize stats between sub-batches across workers
+                local_batch_stats = {}
+                for b in batches:
+                    fill_flat_stats(b, result=local_batch_stats)
+                batch_stats = gather_object([local_batch_stats])
+                batch_stats = {k: sum(v) for k, v in ld_to_dl(batch_stats).items()}
+                for b in batches:
+                    set_flat_stats(b, batch_stats)
+
+                local_res_stats = defaultdict(lambda: 0.0)
+                for idx, (batch, batch_pipe_names) in enumerate(
+                    zip(batches, batches_pipe_names)
+                ):
+                    cache_ctx = (
+                        nlp.cache() if len(batch_pipe_names) > 1 else nullcontext()
+                    )
+                    no_sync_ctx = (
+                        accelerator.no_sync(trained_pipes)
+                        if idx < len(batches) - 1
+                        else nullcontext()
+                    )
+                    try:
+                        with cache_ctx, no_sync_ctx:
+                            all_res, loss = trained_pipes(
+                                batch,
+                                enable=batch_pipe_names,
                             )
-                            spike = False
+                            for name, res in all_res.items():
+                                for k, v in res.items():
+                                    if (
+                                        isinstance(v, (float, int))
+                                        or isinstance(v, torch.Tensor)
+                                        and v.ndim == 0
+                                    ):
+                                        local_res_stats[k] += float(v)
+                                    del k, v
+                                del res
+                            del all_res
+                            if isinstance(loss, torch.Tensor) and loss.requires_grad:
+                                accelerator.backward(loss)
+                    except torch.cuda.OutOfMemoryError:
+                        print(
+                            "Out of memory error encountered when processing a "
+                            "batch with the following statistics:"
+                        )
+                        print(local_batch_stats)
+                        raise
+                    del loss
 
-                        if spike and grad_dev_policy == "clip_mean":
-                            torch.nn.utils.clip_grad_norm_(
-                                grad_params, grad_mean, norm_type=2
-                            )
-                        elif spike and grad_dev_policy == "clip_threshold":
-                            torch.nn.utils.clip_grad_norm_(
-                                grad_params,
-                                grad_mean + math.sqrt(grad_var) * grad_max_dev,
-                                norm_type=2,
-                            )
+                # Sync output stats after forward such as losses, supports, etc.
+                res_stats = {
+                    k: sum(v)
+                    for k, v in ld_to_dl(gather_object([dict(local_res_stats)])).items()
+                }
+                if is_main_process:
+                    for k, v in batch_stats.items():
+                        cumulated_data[k] += v
+                    for k, v in res_stats.items():
+                        cumulated_data[k] += v
 
-                    if grad_dev_policy != "skip" or not spike:
-                        accel_optim.step()
+                del batch_stats, res_stats
+                accelerator.unscale_gradients()
 
-                    cumulated_data["count"] += 1
-                    cumulated_data["grad_norm/__all__"] += grad_norm
+                # Log gradients
+                if log_weight_grads:
+                    for pipe_name, pipe in trained_pipes_local.items():
+                        for param_name, param in pipe.named_parameters():
+                            if param.grad is not None:
+                                cumulated_data[
+                                    f"grad_norm/{pipe_name}/{param_name}"
+                                ] += param.grad.norm().item()
+                                cumulated_data[
+                                    f"param_norm/{pipe_name}/{param_name}"
+                                ] += param.norm().item()
 
-                del iterator
+                grad_norm = torch.nn.utils.clip_grad_norm_(
+                    grad_params, grad_max_norm, norm_type=2
+                ).item()
+
+                # Detect grad spikes and skip the step if necessary
+                if grad_dev_policy is not None:
+                    if step > grad_ewm_window and (
+                        grad_norm - grad_mean
+                    ) > grad_max_dev * math.sqrt(grad_var):
+                        spike = True
+                        cumulated_data["spikes"] += 1
+                    else:
+                        grad_mean, grad_var, ewm_state = ewm_moments(
+                            grad_norm, grad_ewm_window, state=ewm_state
+                        )
+                        spike = False
+
+                    if spike and grad_dev_policy == "clip_mean":
+                        torch.nn.utils.clip_grad_norm_(
+                            grad_params, grad_mean, norm_type=2
+                        )
+                    elif spike and grad_dev_policy == "clip_threshold":
+                        torch.nn.utils.clip_grad_norm_(
+                            grad_params,
+                            grad_mean + math.sqrt(grad_var) * grad_max_dev,
+                            norm_type=2,
+                        )
+
+                if grad_dev_policy != "skip" or not spike:
+                    accel_optim.step()
+
+                cumulated_data["count"] += 1
+                cumulated_data["grad_norm/__all__"] += grad_norm
+
+            del iterator
 
     return nlp

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,8 @@ nav:
       - data/polars.md
       - data/spark.md
       - data/converters.md
+  - Training:
+      - training/loggers.md
   - Concepts:
       - concepts/pipeline.md
       - concepts/torch-component.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ docs = [
 dev = [
     "edsnlp[dev-no-ml]",
     "edsnlp[ml]",
+    "tensorboard",
     "optuna>=4.0.0",
     "plotly>=5.18.0", # required by optuna viz
 ]
@@ -289,6 +290,18 @@ where = ["."]
 "json" =     "edsnlp.data:write_json"
 "standoff" = "edsnlp.data:write_standoff"
 "brat"     = "edsnlp.data:write_brat"  # alias for standoff
+
+[project.entry-points."edsnlp_loggers"]
+"csv"         = "edsnlp.training.loggers:CSVLogger"
+"json"        = "edsnlp.training.loggers:JSONLogger"
+"rich"        = "edsnlp.training.loggers:RichLogger"
+"tensorboard" = "edsnlp.training.loggers:TensorboardLogger"
+"aim"         = "edsnlp.training.loggers:AimLogger"
+"wandb"       = "edsnlp.training.loggers:WandBLogger"
+"clearml"     = "edsnlp.training.loggers:ClearMLLogger"
+"mlflow"      = "edsnlp.training.loggers:MLflowLogger"
+"cometml"     = "edsnlp.training.loggers:CometMLLogger"
+"dvclive"     = "edsnlp.training.loggers:DvcLiveLogger"
 
 [project.entry-points."spacy_misc"]
 "eds.span_context_getter" = "edsnlp.utils.span_getters:make_span_context_getter"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,7 +12,7 @@ from spacy.tokens import Doc
 import edsnlp
 import edsnlp.pipes as eds
 from edsnlp import Pipeline, registry
-from edsnlp.core.registries import CurriedFactory
+from edsnlp.core.registries import PartialPipeFactory
 from edsnlp.pipes.base import BaseComponent
 
 try:
@@ -378,9 +378,9 @@ def test_curried_nlp_pipe():
     nlp.add_pipe(eds.sections(), name="sections")
     pipe = CustomComponent()
 
-    assert isinstance(pipe, CurriedFactory)
+    assert isinstance(pipe, PartialPipeFactory)
     err = (
-        f"This component CurriedFactory({pipe.factory}) has not been instantiated "
+        f"This component PartialFactory({pipe.func}) has not been instantiated "
         f"yet, likely because it was missing an `nlp` pipeline argument. You should "
         f"either:\n"
         "- add it to a pipeline: `pipe = nlp.add_pipe(pipe)`\n"

--- a/tests/training/dep_parser_config.yml
+++ b/tests/training/dep_parser_config.yml
@@ -57,3 +57,5 @@ train:
   scorer: ${ scorer }
   num_workers: 0
   optimizer: ${ optimizer }
+  grad_dev_policy: "clip_mean"
+  log_weight_grads: true

--- a/tests/training/ner_qlf_diff_bert_config.yml
+++ b/tests/training/ner_qlf_diff_bert_config.yml
@@ -124,3 +124,4 @@ train:
   scorer: ${ scorer }
   num_workers: 0
   optimizer: ${ optimizer }
+  grad_dev_policy: "skip"

--- a/tests/training/ner_qlf_diff_bert_config.yml
+++ b/tests/training/ner_qlf_diff_bert_config.yml
@@ -25,8 +25,8 @@ nlp:
         embedding:
           '@factory': eds.transformer
           model: hf-internal-testing/tiny-bert
-          window: 128
-          stride: 96
+          window: 256
+          stride: 128
           new_tokens: [ [ "(?:\\n\\s*)*\\n", "⏎" ] ]
 
     qualifier:
@@ -37,15 +37,15 @@ nlp:
       embedding:
         '@factory': eds.span_pooler
 
-        embedding: # ${ nlp.components.ner.embedding }
-          '@factory': eds.text_cnn
-          kernel_sizes: [ 3 ]
-
-          embedding:
-            '@factory': eds.transformer
-            model: hf-internal-testing/tiny-bert
-            window: 128
-            stride: 96
+        embedding: ${ nlp.components.ner.embedding }
+#          '@factory': eds.text_cnn
+#          kernel_sizes: [ 3 ]
+#
+#          embedding:
+#            '@factory': eds.transformer
+#            model: hf-internal-testing/tiny-bert
+#            window: 128
+#            stride: 96
 
 # 📈 SCORERS
 scorer:
@@ -125,3 +125,4 @@ train:
   num_workers: 0
   optimizer: ${ optimizer }
   grad_dev_policy: "skip"
+  logger: ["csv", "json", "rich"]

--- a/tests/training/ner_qlf_same_bert_config.yml
+++ b/tests/training/ner_qlf_same_bert_config.yml
@@ -116,3 +116,4 @@ train:
   num_workers: 0
   optimizer: ${ optimizer }
   grad_dev_policy: "clip_threshold"
+  logger: ["tensorboard", "rich"]

--- a/tests/training/ner_qlf_same_bert_config.yml
+++ b/tests/training/ner_qlf_same_bert_config.yml
@@ -115,3 +115,4 @@ train:
   scorer: ${ scorer }
   num_workers: 0
   optimizer: ${ optimizer }
+  grad_dev_policy: "clip_threshold"

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -1,4 +1,5 @@
 # ruff:noqa:E402
+import os.path
 
 import pytest
 
@@ -107,6 +108,10 @@ def test_ner_qualif_train_diff_bert(run_in_test_dir, tmp_path):
 
     assert last_scores["ner"]["micro"]["f"] > 0.4
     assert last_scores["qual"]["micro"]["f"] > 0.4
+
+    # Ensure we saved the metrics
+    assert os.path.exists(tmp_path / "metrics.json")
+    assert os.path.exists(tmp_path / "metrics.csv")
 
 
 def test_ner_qualif_train_same_bert(run_in_test_dir, tmp_path):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- Added support for multiple loggers (`tensorboard`, `wandb`, `comet_ml`, `aim`, `mlflow`, `clearml`, `dvclive`, `csv`, `json`, `rich`) in `edsnlp.train` via the `logger` parameter. Default is [`json` and `rich`] for backward compatibility.
- Added clickable snippets in the documentation for more registered functions

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
