### PR TITLE
fix: improve various aspect of stream shuffling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,11 @@
 - Support packaging with poetry 2.0
 - Solve pickling issues with multiprocessing when pytorch is installed
 - Allow deep attributes like `a.b.c` for `span_attributes` in Standoff and OMOP doc2dict converters
+- Fixed various aspects of stream shuffling:
+
+  - Ensure the Parquet reader shuffles the data when `shuffle=True`
+  - Ensure we don't overwrite the RNG of the data reader when calling `stream.shuffle()` with no seed
+  - Raise an error if the batch size in `stream.shuffle(batch_size=...)` is not compatible with the stream
 
 # v0.15.0 (2024-12-13)
 

--- a/edsnlp/data/parquet.py
+++ b/edsnlp/data/parquet.py
@@ -77,8 +77,10 @@ class ParquetReader(FileBasedReader):
     def read_records(self) -> Iterable[Any]:
         while True:
             files = self.fragments
+            if self.shuffle:
+                files = shuffle(files, self.rng)
             if self.shuffle == "fragment":
-                for file in shuffle(files, self.rng):
+                for file in files:
                     if self.work_unit == "fragment":
                         yield file
                     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Fixed various aspects of stream shuffling:

  - Ensure the Parquet reader shuffles the data when `shuffle=True`
  - Ensure we don't overwrite the RNG of the data reader when calling `stream.shuffle()` with no seed
  - Raise an error if the batch size in `stream.shuffle(batch_size=...)` is not compatible with the stream

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
