### PR TITLE
fix: allow deep attributes in Standoff and OMOP doc2dict converters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 - Support packaging with poetry 2.0
 - Solve pickling issues with multiprocessing when pytorch is installed
+- Allow deep attributes like `a.b.c` for `span_attributes` in Standoff and OMOP doc2dict converters
 
 # v0.15.0 (2024-12-13)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Allow deep attributes like `a.b.c` for `span_attributes` in Standoff and OMOP doc2dict converters

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
