### PR TITLE
feat: compute eds.ner_crf loss as mean over words

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,11 @@
 - Provided a [detailed tutorial](./docs/tutorials/tuning.md) on hyperparameter tuning, covering usage scenarios and configuration options.
 - `ScheduledOptimizer` (e.g., `@core: "optimizer"`) now supports importing optimizers using their qualified name (e.g., `optim: "torch.optim.Adam"`).
 
+### Changed
+
+- The loss of `eds.ner_crf` is now computed as the mean over the words instead of the sum. This change is compatible with multi-gpu training.
+- Having multiple stats keys matching a batching pattern now warns instead of raising an error.
+
 ### Fixed
 
 - Support packaging with poetry 2.0

--- a/edsnlp/pipes/trainable/extractive_qa/extractive_qa.py
+++ b/edsnlp/pipes/trainable/extractive_qa/extractive_qa.py
@@ -217,8 +217,9 @@ class TrainableExtractiveQA(TrainableNerCrf):
         questions = [x[0] for x in prompt_contexts_and_labels]
         labels = [x[1] for x in prompt_contexts_and_labels]
         ctxs = [x[2] for x in prompt_contexts_and_labels]
+        lengths = [len(ctx) for ctx in ctxs]
         return {
-            "lengths": [len(ctx) for ctx in ctxs],
+            "lengths": lengths,
             "$labels": labels,
             "$contexts": ctxs,
             "embedding": self.embedding.preprocess(
@@ -227,6 +228,7 @@ class TrainableExtractiveQA(TrainableNerCrf):
                 prompts=questions,
                 **kwargs,
             ),
+            "stats": {"ner_words": sum(lengths)},
         }
 
     def preprocess_supervised(self, doc, **kwargs):

--- a/edsnlp/utils/batching.py
+++ b/edsnlp/utils/batching.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -435,9 +436,15 @@ def stat_batchify(key):
             if exact_key is None:
                 candidates = [k for k in item if "/stats/" in k and key in k]
                 if len(candidates) != 1:
-                    raise ValueError(
-                        f"Batching key {key!r} should match exactly one "
+                    warnings.warn(
+                        f"Batching key {key!r} should match one "
                         f"candidate in {[k for k in item if '/stats/' in k]}"
+                    )
+                if len(candidates) == 0:
+                    stat_keys = [k for k in item if "/stats/"]
+                    raise ValueError(
+                        f"Pattern {key!r} doesn't match any key in {stat_keys} "
+                        " to determine the batch size."
                     )
                 exact_key = candidates[0]
             value = item[exact_key]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- The loss of `eds.ner_crf` is now computed as the mean over the words instead of the sum. This change is compatible with multi-gpu training.
- Having multiple stats keys matching a batching pattern now warns instead of raising an error.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
