### PR TITLE
feat: add ner confidence score

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,13 +3,10 @@
 ## Unreleased
 
 ### Added
-- `edsnlp/tune.py`: New hyperparameters tuning script.
 - Hyperparameter Tuning for EDS-NLP: Introduced a new script `edsnlp.tune` for hyperparameter tuning using Optuna. This feature allows users to efficiently optimize model parameters with options for single-phase or two-phase tuning strategies. Includes support for parameter importance analysis, visualization, pruning, and automatic handling of GPU time budgets.
-- `tests/tuning/*.py`: Unit tests for the tuning script.
-- Added a new unit test suite to validate the tuning script.
-- `docs/tutorials/tuning.md`: New tutorial for hyperparameter tuning.
 - Provided a [detailed tutorial](./docs/tutorials/tuning.md) on hyperparameter tuning, covering usage scenarios and configuration options.
 - `ScheduledOptimizer` (e.g., `@core: "optimizer"`) now supports importing optimizers using their qualified name (e.g., `optim: "torch.optim.Adam"`).
+- `edsnlp/ner_crf.` now compute confidence score on spans.
 
 ### Changed
 

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -121,7 +121,7 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
     Extensions
     ----------
 
-!!! warning "Experimental Confidence Score"
+    !!! warning "Experimental Confidence Score"
 
         The NER confidence score feature is experimental and the API and underlying
         algorithm may change.

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -120,30 +120,33 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
 
     Extensions
     ----------
-    WARNING: THIS SECTION IS EXERIMENTAL AND MAY CHANGE!
+    !!! warning "Experimental"
+        This feature is experimental and the API and underlying algorithm may change.
+
     The `eds.ner_crf` pipeline declares one extension on the `Span` object:
 
-    - the `span._.ner_prob`: The confidence score of the Named Entity Recognition
-    (NER) model for the given span.
+    - the `span._.ner_confidence_score`: The confidence score of the Named Entity
+    Recognition (NER) model for the given span.
 
-    The `ner_prob` is computed based on the Average Entity Confidence Score using
-    the following formula:
+    The `ner_confidence_score` is computed based on the Average Entity Confidence
+    Score using the following formula:
 
     $$ \text{Average Entity Confidence Score} = \frac{1}{n}
     \\sum_{i \\in \text{tokens}}1-p(O)_i
     $$
+
     Where:
     - $n$ is the number of tokens.
     - $\text{tokens}$ refers to the tokens within the span.
     - $p(O)_i$ represents the probability of token $i$ belonging to class 'O'
     (Outside entity).
 
-    By default, the confidence score is computed. However, if you don't need it, you
-    can disable its computation with:
-    ```{ .python }
-    nlp.pipes.ner.compute_prob = False
-    ```
-
+    !!! warning "Confidence score is not computed by default"
+        By default, the confidence score is not computed, as it adds around 5% to
+        inference time. You can enable its computation with:
+        ```{ .python }
+        nlp.pipes.ner.compute_confidence_score = True
+        ```
 
     Parameters
     ----------
@@ -266,15 +269,15 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
             Callable[[Doc], Iterable[Span]],
         ] = target_span_getter
 
-        self.compute_prob: bool = True
+        self.compute_confidence_score: bool = False
 
     def set_extensions(self) -> None:
         """
         Set spaCy extensions
         """
         super().set_extensions()
-        if not Span.has_extension("ner_prob"):
-            Span.set_extension("ner_prob", default={})
+        if not Span.has_extension("ner_confidence_score"):
+            Span.set_extension("ner_confidence_score", default={})
 
     def post_init(self, docs: Iterable[Doc], exclude: Set[str]):
         """
@@ -477,7 +480,9 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
         num_contexts, num_words = embeddings.shape[:-1]
         num_labels = len(self.labels)
         scores = self.linear(embeddings).view((num_contexts, num_words, num_labels, 5))
-        probs = torch.nn.functional.softmax(scores, dim=-1)
+        probs = None
+        if self.compute_confidence_score:
+            probs = torch.nn.functional.softmax(scores, dim=-1)
         loss = tags = None
         if "targets" in batch:
             if self.mode == "independent":
@@ -547,20 +552,19 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
         spans: Dict[Doc, list[Span]] = defaultdict(list)
         contexts = [ctx for sample in inputs for ctx in sample["$contexts"]]
         tags = results["tags"]
-        if self.compute_prob:
+        if self.compute_confidence_score:
             probs = results["probs"]
 
         for ctx, label, start, end in self.crf.tags_to_spans(tags).tolist():
             span = contexts[ctx][start:end]
             span.label_ = self.labels[label]
-            if self.compute_prob:
+            if self.compute_confidence_score:
                 span_probs = probs[ctx, start:end, label, :]
                 average_entity_confidence_score = torch.mean(
                     1 - span_probs[:, 0]
                 ).item()
-                span._.ner_prob["average_entity_confidence_score"] = (
-                    average_entity_confidence_score
-                )
+                span._.ner_confidence_score = average_entity_confidence_score
+
             spans[span.doc].append(span)
         for doc in docs:
             self.set_spans(doc, spans.get(doc, []))

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -126,19 +126,17 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
     - the `span._.ner_prob`: The confidence score of the Named Entity Recognition
     (NER) model for the given span.
 
-    The `ner_prob` is computed based on the Average Token Confidence Score using
+    The `ner_prob` is computed based on the Average Entity Confidence Score using
     the following formula:
 
-    $$ \text{Average Token Confidence Score} = \frac{1}{n}
-    \\sum_{i \\in \text{tokens}} \\max_{c \\in \text{BIOUL}} p(c)_i
+    $$ \text{Average Entity Confidence Score} = \frac{1}{n}
+    \\sum_{i \\in \text{tokens}}1-p(O)_i
     $$
     Where:
     - $n$ is the number of tokens.
     - $\text{tokens}$ refers to the tokens within the span.
-    - $p(c)_i$ represents the probability of token $i$ belonging to class
-    $c \\in \\{\text{B, I, O, U, L}\\}$.
-    - $\\max_{c \\in \text{BIOUL}} p(c)_i$ is the maximum probability over all classes
-    for token $i$.
+    - $p(O)_i$ represents the probability of token $i$ belonging to class 'O'
+    (Outside entity).
 
     By default, the confidence score is computed. However, if you don't need it, you
     can disable its computation with:

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -121,8 +121,9 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
     Extensions
     ----------
 
-    !!! warning "Experimental"
-        This feature is experimental and the API and underlying algorithm may change.
+!!! warning "Experimental Confidence Score"
+
+        The NER confidence score feature is experimental and the API and underlying algorithm may change.
 
     The `eds.ner_crf` pipeline declares one extension on the `Span` object:
 

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -120,31 +120,34 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
 
     Extensions
     ----------
+
     !!! warning "Experimental"
         This feature is experimental and the API and underlying algorithm may change.
 
     The `eds.ner_crf` pipeline declares one extension on the `Span` object:
 
-    - the `span._.ner_confidence_score`: The confidence score of the Named Entity
+    - `span._.ner_confidence_score`: The confidence score of the Named Entity
     Recognition (NER) model for the given span.
 
     The `ner_confidence_score` is computed based on the Average Entity Confidence
     Score using the following formula:
 
-    $$ \text{Average Entity Confidence Score} = \frac{1}{n}
-    \\sum_{i \\in \text{tokens}}1-p(O)_i
+    $$
+    \\text{Average Entity Confidence Score} =
+    \\frac{1}{n} \\sum_{i \\in \\text{tokens}} (1 - p(O)_i)
     $$
 
     Where:
+
     - $n$ is the number of tokens.
-    - $\text{tokens}$ refers to the tokens within the span.
+    - $\\text{tokens}$ refers to the tokens within the span.
     - $p(O)_i$ represents the probability of token $i$ belonging to class 'O'
     (Outside entity).
 
     !!! warning "Confidence score is not computed by default"
         By default, the confidence score is not computed, as it adds around 5% to
         inference time. You can enable its computation with:
-        ```{ .python }
+        ```python
         nlp.pipes.ner.compute_confidence_score = True
         ```
 

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -123,7 +123,8 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
 
 !!! warning "Experimental Confidence Score"
 
-        The NER confidence score feature is experimental and the API and underlying algorithm may change.
+        The NER confidence score feature is experimental and the API and underlying
+        algorithm may change.
 
     The `eds.ner_crf` pipeline declares one extension on the `Span` object:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,6 +178,8 @@ extra_javascript:
   - https://cdn.jsdelivr.net/npm/vega-lite@5
   - https://cdn.jsdelivr.net/npm/vega-embed@6
   - assets/termynal/termynal.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 watch:
   - contributing.md
@@ -243,6 +245,8 @@ markdown_extensions:
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
+  - pymdownx.arithmatex:
+      generic: true
   - footnotes
   - md_in_html
   - attr_list

--- a/tests/pipelines/trainable/test_ner.py
+++ b/tests/pipelines/trainable/test_ner.py
@@ -35,7 +35,7 @@ def test_ner(ner_mode, window):
             window=window,
         ),
     )
-
+    nlp.pipes.ner.compute_confidence_score = True
     ner = nlp.get_pipe("ner")
     ner.update_labels([])
     doc = nlp(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

This pull request adds a new extension to NER-extracted entities: `ner_confidence_score`.

The `ner_confidence_score` is computed based on the Average Entity Confidence Score using the following formula:

$$ \text{Average Entity Confidence Score} = \frac{1}{n} 
\\sum_{i \\in \text{tokens}}1-p(O)_i 
$$

Where:
  - $n$ is the number of tokens.
  - $\text{tokens}$ refers to the tokens within the span.
  - $p(O)_i$ represents the probability of token $i$ belonging to class 'O' (Outside entity).

## Changes
`ner_crf.py` : 
- Added `ner_confidence_score` extension to compute the average token confidence score for NER spans.
- Introduced a `compute_confidence_score` parameter to enable/disable score calculation.
- Updated `postprocess` to calculate and store the confidence score.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
