### PR TITLE
Fix packaging

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v2
 
@@ -74,17 +74,27 @@ jobs:
       - name: Install dependencies
         run: |
           pip install poetry
-          pip install -e '.[dev,setup]' pytest-xdist pip
-        if: matrix.python-version != '3.10'
+          pip install -e '.[dev]' pytest-xdist pip
+        if: matrix.python-version != '3.9' && matrix.python-version != '3.10' && matrix.python-version != '3.11' && matrix.python-version != '3.12'
 #          uv venv
 #          source .venv/bin/activate
-#          uv pip install -e '.[dev,setup]' pytest-xdist pip
+#          uv pip install -e '.[dev]' pytest-xdist pip
 
       - name: Install dependencies
         run: |
           pip install poetry
-          pip install -e '.[dev-no-ml,setup]' pytest-xdist pip
-        if: matrix.python-version == '3.10'
+          pip install -e '.[dev,setup]' pytest-xdist pip
+        if: matrix.python-version == '3.9'
+#          uv venv
+#          source .venv/bin/activate
+#          uv pip install -e '.[dev]' pytest-xdist pip
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          pip install -e '.[dev-no-ml]' pytest-xdist pip
+        # skip ML tests for 3.10 and 3.11
+        if: matrix.python-version == '3.10' || matrix.python-version == '3.11' || matrix.python-version == '3.12'
 
       - name: Test with Pytest on Python ${{ matrix.python-version }}
         env:

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Support for numpy>2.0, and formal support for Python 3.11 and Python 3.12
+
 ### Fixed
 
 - `edsnlp.package` now correctly detect if a project uses an old-style poetry pyproject or a PEP621 pyproject.toml.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `edsnlp.package` now correctly detect if a project uses an old-style poetry pyproject or a PEP621 pyproject.toml.
+- PEP621 projects containing nested directories (e.g., "my_project/pipes/foo.py") are now supported.
+
 ## v0.16.0 (2025-0.3-26)
 
 ### Added

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -102,7 +102,7 @@ class Pipeline(Validated):
         create_tokenizer: Optional[Callable[[Self], Tokenizer]] = None,
         vocab: Union[bool, Vocab] = True,
         batch_size: Optional[int] = None,
-        vocab_config: Type[BaseDefaults] = None,
+        vocab_config: Optional[Type[BaseDefaults]] = None,
         meta: Dict[str, Any] = None,
         pipeline: Optional[Sequence[str]] = None,
         components: Dict[str, Any] = {},

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -89,7 +89,9 @@ def validate_kwargs(func, kwargs):
         model = vd.init_model_instance(
             **{k: v for k, v in kwargs.items() if k in spec.args}
         )
-        fields = model.__fields__ if pydantic.__version__ < "2" else model.model_fields
+        fields = (
+            model.__fields__ if pydantic.__version__ < "2" else vd.model.model_fields
+        )
         d = {
             k: v
             for k, v in model.__dict__.items()

--- a/edsnlp/package.py
+++ b/edsnlp/package.py
@@ -1,20 +1,11 @@
 import os
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import warnings
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Mapping,
-    Optional,
-    Sequence,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Union
 
 import build
 import confit
@@ -23,26 +14,10 @@ import toml
 from build.__main__ import build_package, build_package_via_sdist
 from confit import Cli
 from loguru import logger
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal
 
 import edsnlp
 from edsnlp.utils.typing import AsList, Validated
-
-PoetryConstraint = TypedDict(
-    "PoetryConstraint",
-    {
-        "version": str,
-        "extras": Optional[Sequence[str]],
-        "markers": Optional[str],
-        "url": Optional[str],
-        "path": Optional[str],
-        "git": Optional[str],
-        "ref": Optional[str],
-        "branch": Optional[str],
-        "tag": Optional[str],
-    },
-    total=False,
-)
 
 logger.remove()
 logger.add(
@@ -83,41 +58,6 @@ class ModuleName(str, Validated):
 if TYPE_CHECKING:
     ModuleName = str  # noqa F811
 
-POETRY_SNIPPET = """\
-from poetry.core.masonry.builders.sdist import SdistBuilder
-from poetry.factory import Factory
-try:
-    from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
-except ImportError:
-    from poetry.core.masonry.utils.module import ModuleOrPackageNotFoundError as ModuleOrPackageNotFound
-import sys
-# Initialize the Poetry object for the current project
-poetry = Factory().create_poetry("__root_dir__")
-
-# Initialize the builder
-try:
-    builder = SdistBuilder(poetry)
-    # Get the list of files to include
-    files = builder.find_files_to_add()
-except ModuleOrPackageNotFound:
-    if not poetry.package.packages:
-        print([])
-        sys.exit(0)
-
-print([
-    {k: v for k, v in {
-    "include": getattr(include, '_include'),
-    "from": getattr(include, 'source', None),
-    "formats": getattr(include, 'formats', None),
-    }.items() if v}
-    for include in builder._module.includes
-])
-
-
-# Print the list of files
-for file in files:
-    print(file.path)
-"""  # noqa E501
 
 INIT_PY = """
 # -----------------------------------------
@@ -162,303 +102,6 @@ def replace_with_dict(content: str, replacements: dict):
 
 
 class Packager:
-    def __init__(
-        self,
-        *,
-        name: ModuleName,
-        pyproject: Optional[Dict[str, Any]],
-        pipeline: Union[Path, "edsnlp.Pipeline"],
-        version: Optional[str],
-        root_dir: Path = ".",
-        build_dir: Optional[Path] = None,
-        dist_dir: Path,
-        artifacts_name: ModuleName,
-        exclude: AsList[str],
-        readme_replacements: Dict[str, str] = {},
-        file_paths: Sequence[Path],
-    ):
-        self.name = name
-        self.version = version
-        assert name == pyproject["project"]["name"]
-        assert version == pyproject["project"]["version"]
-        self.root_dir = root_dir.resolve()
-        self.pipeline = pipeline
-        self.artifacts_name = artifacts_name
-        self.dist_dir = (
-            dist_dir if Path(dist_dir).is_absolute() else self.root_dir / dist_dir
-        )
-        self.build_dir = build_dir
-        self.readme_replacements = readme_replacements
-        self.exclude = exclude
-        self.file_paths = file_paths
-        self.pyproject = pyproject
-
-        logger.info(f"root_dir: {root_dir}")
-        logger.info(f"artifacts_name: {artifacts_name}")
-        logger.info(f"name: {name}")
-
-    def build(
-        self,
-        distributions: Sequence[str] = (),
-        config_settings: Optional[build.ConfigSettingsType] = None,
-        isolation: bool = True,
-        skip_dependency_check: bool = False,
-    ):
-        logger.info("Building package")
-
-        if distributions:
-            build_call = build_package
-        else:
-            build_call = build_package_via_sdist
-            distributions = ["wheel"]
-        build_call(  # type: ignore
-            srcdir=self.build_dir,
-            outdir=self.dist_dir,
-            distributions=distributions,
-            config_settings=config_settings,
-            isolation=isolation,
-            skip_dependency_check=skip_dependency_check,
-        )
-
-    # def update_pyproject(self):
-    #     # Adding artifacts to include in pyproject.toml
-    #     snake_name = snake_case(self.name.lower())
-    #     included = self.pyproject["tool"]["poetry"].setdefault("include", [])
-    #     included.append(f"{snake_name}/{self.artifacts_name}/**")
-    #     packages = list(self.packages)
-    #     packages.append({"include": snake_name})
-    #     self.pyproject["tool"]["poetry"]["packages"] = packages
-
-    def make_src_dir(self):
-        snake_name = snake_case(self.name.lower())
-        package_dir = self.build_dir / snake_name
-
-        shutil.rmtree(package_dir, ignore_errors=True)
-        os.makedirs(package_dir, exist_ok=True)
-        build_artifacts_dir = self.build_dir / self.artifacts_name
-        for file_path in self.file_paths:
-            dest_path = self.build_dir / Path(file_path).relative_to(self.root_dir)
-            if isinstance(self.pipeline, Path) and self.pipeline in file_path.parents:
-                raise Exception(
-                    f"Pipeline ({self.artifacts_name}) is already "
-                    "included in the package's data, you should "
-                    "remove it from the pyproject.toml metadata."
-                )
-            os.makedirs(dest_path.parent, exist_ok=True)
-            shutil.copy(file_path, dest_path)
-
-        # self.update_pyproject()
-
-        # Write pyproject.toml
-        (self.build_dir / "pyproject.toml").write_text(toml.dumps(self.pyproject))
-        if "readme" in self.pyproject["project"]:
-            readme = (self.root_dir / self.pyproject["project"]["readme"]).read_text()
-            readme = replace_with_dict(readme, self.readme_replacements)
-            (self.build_dir / "README.md").write_text(readme)
-
-        if isinstance(self.pipeline, Path):
-            # self.pipeline = edsnlp.load(self.pipeline)
-            shutil.copytree(
-                self.pipeline,
-                build_artifacts_dir,
-            )
-        else:
-            self.pipeline.to_disk(build_artifacts_dir, exclude=set())
-
-        # After building wheel, artifacts will be placed inside the
-        # package dir, not next to it as in source distribution so
-        # we let the load script test both locations
-        with open(package_dir / "__init__.py", mode="a") as f:
-            f.write(
-                INIT_PY.format(
-                    __version__=repr(self.version),
-                    artifacts_dir=os.path.relpath(build_artifacts_dir, package_dir),
-                    artifacts_dir_inside=self.artifacts_name,
-                )
-            )
-
-        # Print all the files that will be included in the package
-        for file in self.build_dir.rglob("*"):
-            if file.is_file():
-                rel = file.relative_to(self.build_dir)
-                if not any(rel.match(e) for e in self.exclude):
-                    logger.info(f"INCLUDE {rel}")
-                else:
-                    file.unlink()
-                    logger.info(f"SKIP {rel}")
-
-
-class PoetryPackager(Packager):
-    def __init__(
-        self,
-        *,
-        name: ModuleName,
-        pyproject: Optional[Dict[str, Any]],
-        pipeline: Union[Path, "edsnlp.Pipeline"],
-        version: Optional[str],
-        root_dir: Path = ".",
-        build_dir: Optional[Path] = None,
-        dist_dir: Path,
-        artifacts_name: ModuleName,
-        metadata: Optional[Dict[str, Any]] = {},
-        exclude: AsList[str],
-        readme_replacements: Dict[str, str] = {},
-    ):
-        try:
-            version = version or pyproject["tool"]["poetry"]["version"]
-        except (KeyError, TypeError):  # pragma: no cover
-            version = "0.1.0"
-        name = name or pyproject["tool"]["poetry"]["name"]
-        main_package = (
-            snake_case(pyproject["tool"]["poetry"]["name"].lower())
-            if pyproject is not None
-            else None
-        )
-        model_package = snake_case(name.lower())
-
-        root_dir = root_dir.resolve()
-        dist_dir = dist_dir if Path(dist_dir).is_absolute() else root_dir / dist_dir
-
-        build_dir = Path(tempfile.mkdtemp()) if build_dir is None else build_dir
-
-        new_pyproject: Dict[str, Any] = {
-            "build-system": {
-                "requires": ["hatchling"],
-                "build-backend": "hatchling.build",
-            },
-            "tool": {"hatch": {"build": {}}},
-            "project": {
-                "name": model_package,
-                "version": version,
-                "requires-python": ">=3.7",
-            },
-        }
-        file_paths = []
-
-        if pyproject is not None:
-            poetry = pyproject["tool"]["poetry"]
-
-            # Extract packages
-            poetry_bin_path = (
-                subprocess.run(["which", "poetry"], stdout=subprocess.PIPE)
-                .stdout.decode()
-                .strip()
-            )
-            python_executable = Path(poetry_bin_path).read_text().split("\n")[0][2:]
-            result = subprocess.run(
-                [
-                    *python_executable.split(),
-                    "-c",
-                    POETRY_SNIPPET.replace("__root_dir__", str(root_dir)),
-                ],
-                stdout=subprocess.PIPE,
-                cwd=root_dir,
-            )
-            if result.returncode != 0:
-                raise Exception()
-            out = result.stdout.decode().strip().split("\n")
-            file_paths = [root_dir / file_path for file_path in out[1:]]
-            packages = {
-                main_package,
-                model_package,
-                *(package["include"] for package in eval(out[0])),
-            }
-            packages = sorted([p for p in packages if p])
-            new_pyproject["tool"]["hatch"]["build"] = {
-                "packages": [*packages, artifacts_name],
-                "exclude": ["__pycache__/", "*.pyc", "*.pyo", ".ipynb_checkpoints"],
-                "artifacts": [artifacts_name],
-                "targets": {
-                    "wheel": {
-                        "sources": {
-                            f"{artifacts_name}": f"{model_package}/{artifacts_name}"
-                        },
-                    },
-                },
-            }
-            if "description" in poetry:  # pragma: no cover
-                new_pyproject["project"]["description"] = poetry["description"]
-            if "classifiers" in poetry:  # pragma: no cover
-                new_pyproject["project"]["classifiers"] = poetry["classifiers"]
-            if "keywords" in poetry:  # pragma: no cover
-                new_pyproject["project"]["keywords"] = poetry["keywords"]
-            if "license" in poetry:  # pragma: no cover
-                new_pyproject["project"]["license"] = {"text": poetry["license"]}
-            if "readme" in poetry:  # pragma: no cover
-                new_pyproject["project"]["readme"] = poetry["readme"]
-            if "authors" in poetry:  # pragma: no cover
-                new_pyproject["project"]["authors"] = parse_authors(poetry["authors"])
-            if "plugins" in poetry:  # pragma: no cover
-                new_pyproject["project"]["entry-points"] = poetry["plugins"]
-            if "scripts" in poetry:  # pragma: no cover
-                new_pyproject["project"]["scripts"] = poetry["scripts"]
-
-            # Dependencies
-            deps = []
-            poetry_deps = poetry["dependencies"]
-            for dep_name, constraint in poetry_deps.items():
-                dep = dep_name
-                constraint: PoetryConstraint = (
-                    dict(constraint)
-                    if isinstance(constraint, dict)
-                    else {"version": constraint}
-                )
-                try:
-                    dep += f"[{','.join(constraint.pop('extras'))}]"
-                except KeyError:
-                    pass
-                if "version" in constraint:
-                    dep_version = constraint.pop("version")
-                    assert not dep_version.startswith(
-                        "^"
-                    ), "Packaging models with ^ dependencies is not supported"
-                    dep += (
-                        ""
-                        if dep_version == "*"
-                        else dep_version
-                        if not dep_version[0].isdigit()
-                        else f"=={dep_version}"
-                    )
-                try:
-                    dep += f"; {constraint.pop('markers')}"
-                except KeyError:
-                    pass
-                assert (
-                    not constraint
-                ), f"Unsupported constraints for dependency {dep_name}: {constraint}"
-                if dep_name == "python":
-                    new_pyproject["project"]["requires-python"] = dep.replace(
-                        "python", ""
-                    )
-                    continue
-                deps.append(dep)
-
-            new_pyproject["project"]["dependencies"] = deps
-
-        if "authors" in metadata:
-            metadata["authors"] = parse_authors(metadata["authors"])
-        metadata["name"] = model_package
-        metadata["version"] = version
-
-        new_pyproject = confit.Config(new_pyproject).merge({"project": metadata})
-
-        # Use hatch
-        super().__init__(
-            name=model_package,
-            pyproject=new_pyproject,
-            pipeline=pipeline,
-            version=version,
-            root_dir=root_dir,
-            build_dir=build_dir,
-            dist_dir=dist_dir,
-            artifacts_name=artifacts_name,
-            exclude=exclude,
-            readme_replacements=readme_replacements,
-            file_paths=file_paths,
-        )
-
-
-class SetuptoolsPackager(Packager):
     def __init__(
         self,
         *,
@@ -523,7 +166,10 @@ class SetuptoolsPackager(Packager):
         packages = sorted([p for p in packages if p])
         file_paths = []
         for package in packages:
-            file_paths.extend((root_dir / package).rglob("*"))
+            for path in (root_dir / package).rglob("*"):
+                if "__pycache__" in path.parts or path.is_dir():
+                    continue
+                file_paths.append(path)
 
         new_pyproject["tool"]["hatch"]["build"] = {
             "packages": [*packages, artifacts_name],
@@ -543,21 +189,108 @@ class SetuptoolsPackager(Packager):
         metadata["name"] = model_package
         metadata["version"] = version
 
-        new_pyproject = new_pyproject.merge({"project": metadata})
+        pyproject = new_pyproject.merge({"project": metadata})
 
-        super().__init__(
-            name=model_package,
-            pyproject=new_pyproject,
-            pipeline=pipeline,
-            version=version,
-            root_dir=root_dir,
-            build_dir=build_dir,
-            dist_dir=dist_dir,
-            artifacts_name=artifacts_name,
-            exclude=exclude,
-            readme_replacements=readme_replacements,
-            file_paths=file_paths,
+        self.name = model_package
+        self.version = version
+        assert model_package == pyproject["project"]["name"]
+        assert version == pyproject["project"]["version"]
+        self.root_dir = root_dir.resolve()
+        self.pipeline = pipeline
+        self.artifacts_name = artifacts_name
+        self.dist_dir = (
+            dist_dir if Path(dist_dir).is_absolute() else self.root_dir / dist_dir
         )
+        self.build_dir = build_dir
+        self.readme_replacements = readme_replacements
+        self.exclude = exclude
+        self.file_paths = file_paths
+        self.pyproject = pyproject
+
+        logger.info(f"root_dir: {root_dir}")
+        logger.info(f"artifacts_name: {artifacts_name}")
+        logger.info(f"name: {model_package}")
+
+    def build(
+        self,
+        distributions: Sequence[str] = (),
+        config_settings: Optional[build.ConfigSettingsType] = None,
+        isolation: bool = True,
+        skip_dependency_check: bool = False,
+    ):
+        logger.info("Building package")
+
+        if distributions:
+            build_call = build_package
+        else:
+            build_call = build_package_via_sdist
+            distributions = ["wheel"]
+        build_call(  # type: ignore
+            srcdir=self.build_dir,
+            outdir=self.dist_dir,
+            distributions=distributions,
+            config_settings=config_settings,
+            isolation=isolation,
+            skip_dependency_check=skip_dependency_check,
+        )
+
+    def make_src_dir(self):
+        snake_name = snake_case(self.name.lower())
+        package_dir = self.build_dir / snake_name
+
+        shutil.rmtree(package_dir, ignore_errors=True)
+        os.makedirs(package_dir, exist_ok=True)
+        build_artifacts_dir = self.build_dir / self.artifacts_name
+        for file_path in self.file_paths:
+            dest_path = self.build_dir / Path(file_path).relative_to(self.root_dir)
+            if isinstance(self.pipeline, Path) and self.pipeline in file_path.parents:
+                raise Exception(
+                    f"Pipeline ({self.artifacts_name}) is already "
+                    "included in the package's data, you should "
+                    "remove it from the pyproject.toml metadata."
+                )
+            os.makedirs(dest_path.parent, exist_ok=True)
+            shutil.copy(file_path, dest_path)
+
+        # self.update_pyproject()
+
+        # Write pyproject.toml
+        (self.build_dir / "pyproject.toml").write_text(toml.dumps(self.pyproject))
+        if "readme" in self.pyproject["project"]:
+            readme = (self.root_dir / self.pyproject["project"]["readme"]).read_text()
+            readme = replace_with_dict(readme, self.readme_replacements)
+            (self.build_dir / "README.md").write_text(readme)
+
+        if isinstance(self.pipeline, Path):
+            # self.pipeline = edsnlp.load(self.pipeline)
+            shutil.copytree(
+                self.pipeline,
+                build_artifacts_dir,
+            )
+        else:
+            self.pipeline.to_disk(build_artifacts_dir, exclude=set())
+
+        # After building wheel, artifacts will be placed inside the
+        # package dir, not next to it as in source distribution so
+        # we let the load script test both locations
+        with open(package_dir / "__init__.py", mode="a") as f:
+            f.write(
+                INIT_PY.format(
+                    __version__=repr(self.version),
+                    artifacts_dir=os.path.relpath(build_artifacts_dir, package_dir),
+                    artifacts_dir_inside=self.artifacts_name,
+                )
+            )
+
+        # Print all the files that will be included in the package
+        for file in self.build_dir.rglob("*"):
+            if file.is_file():
+                rel = file.relative_to(self.build_dir)
+                if not any(rel.match(e) for e in self.exclude):
+                    logger.info(f"INCLUDE {rel}")
+                else:
+                    file.unlink()
+                    logger.info(f"SKIP {rel}")
 
 
 @app.command(name="package")
@@ -580,7 +313,20 @@ def package(
     exclude: Optional[AsList[str]] = None,
     readme_replacements: Dict[str, str] = {},
 ):
-    # root_dir = Path(".").resolve()
+    """
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+
+    """
+    if project_type is not None:
+        warnings.warn(
+            "Project_type is deprecated, only PEP621 pyproject.toml is supported",
+            DeprecationWarning,
+        )
     exclude = exclude or ["artifacts/vocab/*"]
     pyproject_path = root_dir / "pyproject.toml"
 
@@ -601,23 +347,7 @@ def package(
     if pyproject_path.exists():
         pyproject = toml.loads((root_dir / "pyproject.toml").read_text())
 
-    package_managers = {"setuptools", "poetry", "hatch", "pdm"} & set(
-        (pyproject or {}).get("tool", {})
-    )
-    package_managers = package_managers or {"setuptools"}  # default
-    try:
-        if project_type is None:
-            [project_type] = package_managers
-        packager_cls = {
-            "poetry": PoetryPackager,
-            "setuptools": SetuptoolsPackager,
-        }[project_type]
-    except Exception:  # pragma: no cover
-        raise ValueError(
-            "Could not infer project type, only poetry and setuptools based projects "
-            "are supported for now"
-        )
-    packager = packager_cls(
+    packager = Packager(
         pyproject=pyproject,
         pipeline=pipeline,
         name=name,

--- a/edsnlp/pipes/core/endlines/model.py
+++ b/edsnlp/pipes/core/endlines/model.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Iterable
 
 import numpy as np
 import pandas as pd
-from numpy.lib.function_base import iterable
 from pandas.api.types import CategoricalDtype
 from pandas.core.groupby import DataFrameGroupBy
 from spacy.strings import StringStore
@@ -239,9 +238,9 @@ class EndLinesModel:
         df[new_col] = df[col].astype(cat_type_A)
         df[new_col] = df[new_col].cat.codes
         # Ensure that not known values are coded as OTHER
-        df.loc[
-            ~df[col].isin(self.vocabulary["A3A4"].keys()), new_col
-        ] = self.vocabulary["A3A4"]["OTHER"]
+        df.loc[~df[col].isin(self.vocabulary["A3A4"].keys()), new_col] = (
+            self.vocabulary["A3A4"]["OTHER"]
+        )
         return df
 
     def _convert_B(self, df: pd.DataFrame, col: str) -> pd.DataFrame:
@@ -594,7 +593,7 @@ class EndLinesModel:
         return dfg
 
     @classmethod
-    def _create_vocabulary(cls, x: iterable) -> dict:
+    def _create_vocabulary(cls, x: Iterable) -> dict:
         """Function to create a vocabulary for attributes in the training set.
 
         Parameters

--- a/edsnlp/pipes/misc/dates/models.py
+++ b/edsnlp/pipes/misc/dates/models.py
@@ -4,11 +4,23 @@ from typing import Any, Dict, Optional, Union
 
 import pydantic
 from pandas._libs.tslibs.nattype import NaTType
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import BaseModel, Field
 from pytz import timezone
 from spacy.tokens import Span
 
 from edsnlp.pipes.misc.dates.patterns.relative import specific_dict
+
+try:
+    from pydantic import field_validator, model_validator
+
+    def validator(x, allow_reuse=True, pre=False):
+        return field_validator(x, mode="before" if pre else "after")
+
+    def root_validator(allow_reuse=True, pre=False):
+        return model_validator(mode="before" if pre else "after")
+
+except ImportError:
+    from pydantic import root_validator, validator
 
 
 class Direction(str, Enum):

--- a/edsnlp/pipes/ner/scores/charlson/factory.py
+++ b/edsnlp/pipes/ner/scores/charlson/factory.py
@@ -24,7 +24,6 @@ DEFAULT_CONFIG = dict(
     "eds.charlson",
     assigns=["doc.ents", "doc.spans"],
     deprecated=[
-        "eds.charlson",
         "charlson",
     ],
 )

--- a/edsnlp/tune.py
+++ b/edsnlp/tune.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import joblib
 import optuna
 import optuna.visualization as vis
+import pydantic
 from configobj import ConfigObj
 from confit import Cli, Config
 from confit.utils.collections import split_path
@@ -49,6 +50,9 @@ class HyperparameterConfig(BaseModel):
     class Config:
         extra = "forbid"
 
+    if pydantic.VERSION < "2":
+        model_dump = BaseModel.dict
+
     def to_dict(self) -> dict:
         """
         Convert the hyperparameter configuration to a dictionary.
@@ -57,7 +61,7 @@ class HyperparameterConfig(BaseModel):
         Returns:
             dict: A dictionary representation of the hyperparameter configuration.
         """
-        return self.dict(exclude_unset=True, exclude_defaults=True)
+        return self.model_dump(exclude_unset=True, exclude_defaults=True)
 
 
 def setup_logging():
@@ -598,7 +602,7 @@ def tune(
     output_dir: str,
     checkpoint_dir: str,
     gpu_hours: confloat(gt=0) = DEFAULT_GPU_HOUR,
-    n_trials: conint(gt=0) = None,
+    n_trials: Optional[conint(gt=0)] = None,
     two_phase_tuning: bool = False,
     seed: int = 42,
     metric="ner.micro.f",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,16 @@ dependencies = [
     "pytz",
     "pysimstring>=1.2.1",
     "regex",
-    "spacy>=3.2,<3.8",
-    "thinc<8.2.5",  # we don't need thinc but spacy depdends on it 8.2.5 cause binary issues
+    # spacy doesn't provide binaries for python<3.9 from 3.8.2 so we need to cap it ourself
+    "spacy>=3.2,<3.8.2; python_version<'3.9'",
+    "spacy>=3.8.5,<4.0.0; python_version>='3.9'",
+    # thinc doesn't provide binaries for python<3.9 from 8.2.5 so we need to cap it ourself
+    "thinc<8.2.5; python_version<'3.9'",
+    "thinc>=8.2.5; python_version>='3.9'",
     "confit>=0.7.3",
     "tqdm",
     "umls-downloader>=0.1.1",
-    "numpy>=1.15.0,<1.23.2; python_version<'3.8'",
-    "numpy>=1.15.0,<2.0.0; python_version>='3.8'",
+    "numpy>=1.15.0",
     "pandas>=1.1.0; python_version<'3.8'",
     "pandas>=1.4.0; python_version>='3.8'",
     "typing-extensions>=4.0.0",
@@ -49,8 +52,7 @@ dev-no-ml = [
     "pyspark",
     "polars",
 
-    "mlconjug3<3.9.0; python_version<'3.12'",
-    "scikit-learn>=1.0.0",
+    "scikit-learn",
 
     "edsnlp[docs-no-ml]",
 ]
@@ -75,7 +77,7 @@ docs-no-ml = [
 ml = [
     "rich-logger>=0.3.1",
     "torch>=1.13.0",
-    "foldedtensor>=0.3.4",
+    "foldedtensor>=0.4.0",
     "safetensors>=0.3.0; python_version>='3.8'",
     "safetensors>=0.3.0,<0.5.0; python_version<'3.8'",
     "transformers>=4.0.0,<5.0.0",
@@ -92,10 +94,11 @@ dev = [
     "plotly>=5.18.0", # required by optuna viz
     "ruamel.yaml>=0.18.0",
     "configobj>=5.0.9",
-
+    "scikit-learn",
 ]
 setup = [
-    "typer"
+    "mlconjug3<3.9.0",  # bug https://github.com/Ars-Linguistica/mlconjug3/pull/506
+    "numpy<2",  # mlconjug has scikit-learn dep which doesn't support for numpy 2 yet
 ]
 
 [project.urls]
@@ -312,7 +315,11 @@ where = ["."]
 requires = [
     "setuptools",
     "cython>=0.25",
-    "spacy>=3.2,<3.8",
+    "spacy>=3.2,!=3.8.2; python_version<'3.9'",
+    "spacy>=3.2,!=3.8.2,<4.0.0; python_version>='3.9'",
+    # thinc doesn't provide binaries for python<3.9 from 8.2.5 so we need to cap it ourselves
+    "thinc<8.2.5; python_version<'3.9'",
+    "thinc>=8.2.5; python_version>='3.9'",
     # to update from https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     # while setting numpy >= 1.15.0 due to spacy reqs
     "numpy==1.15.0; python_version=='3.7' and platform_machine not in 'arm64|aarch64|loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
@@ -324,19 +331,12 @@ requires = [
     "numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
     "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.19.3; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
-    "numpy==1.19.3; python_version=='3.9' and platform_system not in 'OS400' and platform_machine not in 'arm64|loongarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
     "numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'",
     "numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'",
-    "numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'",
-    "numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64'",
-    "numpy==1.22.2; platform_machine=='loongarch64' and python_version>='3.8' and python_version<'3.11' and platform_python_implementation!='PyPy'",
+    "numpy==1.22.2; python_version>='3.8' and python_version<'3.9' and platform_machine=='loongarch64' and platform_python_implementation!='PyPy'",
     "numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'",
-    "numpy==1.23.2; python_version=='3.11'",
-    "numpy==1.23.3; python_version=='3.9' and platform_system=='OS400' and platform_machine!='loongarch64' and platform_python_implementation!='PyPy'",
-    "numpy==1.25.0; python_version=='3.9' and platform_python_implementation=='PyPy'",
-    "numpy==1.26.1; python_version=='3.12'",
+    "numpy>=2.0; python_version>='3.9'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev-no-ml = [
     "pyspark",
     "polars",
 
-    "mlconjug3<3.9.0",
+    "mlconjug3<3.9.0; python_version<'3.12'",
     "scikit-learn>=1.0.0",
 
     "edsnlp[docs-no-ml]",

--- a/tests/tuning/config.yml
+++ b/tests/tuning/config.yml
@@ -125,3 +125,4 @@ train:
   scorer: ${ scorer }
   num_workers: 0
   optimizer: ${ optimizer }
+  cpu: true

--- a/tests/utils/test_package.py
+++ b/tests/utils/test_package.py
@@ -48,6 +48,7 @@ def test_package_with_files(nlp, tmp_path, package_name, manager):
 
     ((tmp_path / "test_model").mkdir(parents=True))
     (tmp_path / "test_model" / "__init__.py").write_text('print("Hello World!")\n')
+    (tmp_path / "test_model" / "empty_folder").mkdir()
     (tmp_path / "README.md").write_text(
         """\
 <!-- INSERT -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- `edsnlp.package` now correctly detect if a project uses an old-style poetry pyproject or a PEP621 pyproject.toml.
- PEP621 projects containing nested directories (e.g., "my_project/pipes/foo.py") are now supported.

Additionally, fix some typing and pydantic related errors and warnings, and test for py311, py312 and py313.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
