### PR TITLE
fix: try several paths to find current pip executable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 - `edsnlp.package` now correctly detect if a project uses an old-style poetry pyproject or a PEP621 pyproject.toml.
 - PEP621 projects containing nested directories (e.g., "my_project/pipes/foo.py") are now supported.
+- Try several paths to find current pip executable
 
 ## v0.16.0 (2025-0.3-26)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Try several paths to find current pip executable. This attempts as solving https://github.com/aphp/eds-pseudo/issues/18

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] ~~If this PR is a bug fix, the bug is documented in the test suite.~~
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
