### PR TITLE
fix: correct town name typo (berck.sur.mer)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 - Fixed mini-batch accumulation for multi-task training
 - Fixed a pickling error when applying a pipeline in multiprocessing mode. This occurred in some cases when one of the pipes was declared in a "difficultly importable" module (e.g., causing a "PicklingWarning: Cannot locate reference to <class...").
+- Fixed typo in `eds.consultation_dates` towns: `berck.sur.mer`.
 
 ## v0.17.0 (2025-04-15)
 

--- a/edsnlp/pipes/misc/consultation_dates/patterns.py
+++ b/edsnlp/pipes/misc/consultation_dates/patterns.py
@@ -28,7 +28,7 @@ town_mention = [
     "bondy",
     "colombes",
     "hendaye",
-    "herck.sur.mer",
+    "berck.sur.mer",
     "labruyere",
     "garches",
     "sevran",

--- a/tests/pipelines/misc/test_consultation_date.py
+++ b/tests/pipelines/misc/test_consultation_date.py
@@ -71,7 +71,18 @@ def test_cons_dates(date_pipeline, example, blank_nlp):
 
     assert len(doc.spans["consultation_dates"]) == len(example["result"])
 
-    for span, result in zip(doc.spans["consultation_dates"], example["result"]):
-        assert all(
-            [span._.consultation_date.model_dump()[k] == result[k] for k in result]
-        )
+
+def test_consultation_date_berck_sur_mer(blank_nlp):
+    text = "Berck-sur-Mer, le 30/04/2025"
+    blank_nlp.add_pipe(
+        "eds.normalizer",
+        config=dict(lowercase=True, accents=True, quotes=True, pollution=False),
+    )
+    blank_nlp.add_pipe("eds.consultation_dates", config=dict(town_mention=True))
+    blank_nlp.add_pipe("eds.dates")
+    doc = blank_nlp(text)
+    assert len(doc.spans["consultation_dates"]) == 1
+    date = doc.spans["consultation_dates"][0]._.consultation_date
+    assert date.year == 2025
+    assert date.month == 4
+    assert date.day == 30


### PR DESCRIPTION
## Description 

This pull request fixes a typo in the town (#405) name `berck.sur.mer`.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
