### PR TITLE
fix: error when converting relative date expressions with bounds to durations

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+First, when starting to develop, install the project with
+
+```bash
+pip install -e ".[dev]"
+pre-commit install
+```
+
+Then, when fixing an issue, add a new test to reproduce it. If the issue concerns an existing
+component, add the test to the corresponding test file, or create a new test file (only when needed, this should not be the most common scenario).
+
+Create a new branch (or checkout the auto-created branch for the issue).
+
+Then update the codebase to fix the issue, and run the new test to check that everything is working as expected.
+
+Update the changelog.md file with a concise explanation of the change/fix/new feature.
+
+Before commiting, stash, checkout master and pull to ensure you have the latest version of master, then checkout the branch you were working on and rebase it on top of master.
+If the rebase has changed something to the codebase, rerun the edited tests to ensure everything is still working as expected.
+
+Finally, run git log to look at the commit messages and get an idea of what the commit messages should look like (concise, neutral, conventional commits messages).
+
+```bash
+git log --no-pager
+```
+
+Finally commit the changes.
+
+!!! note
+
+    Whenever you run a command, ensure that you do it without making it prompt the user for input (ie, use --no-edit in git rebase, --no-pager, --yes, etc. when possible).

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Fixed mini-batch accumulation for multi-task training
 - Fixed a pickling error when applying a pipeline in multiprocessing mode. This occurred in some cases when one of the pipes was declared in a "difficultly importable" module (e.g., causing a "PicklingWarning: Cannot locate reference to <class...").
 - Fixed typo in `eds.consultation_dates` towns: `berck.sur.mer`.
+- Fixed a bug where relative date expressions with bounds (e.g. 'depuis hier') raised an error when converted to durations.
 
 ## v0.17.0 (2025-04-15)
 

--- a/edsnlp/pipes/misc/dates/models.py
+++ b/edsnlp/pipes/misc/dates/models.py
@@ -270,6 +270,7 @@ class Relative(BaseDate):
         direction = -1 if direction == Direction.PAST else 1
 
         d.pop("mode", None)
+        d.pop("bound", None)
 
         d = {f"{k}s": v for k, v in d.items()}
 


### PR DESCRIPTION
Fixes a bug where relative date expressions with bounds (e.g. 'depuis hier') raised an error when converted to durations. Also adds a regression test and updates the changelog.