### PR TITLE
Fix time.py in eds.dates

### DIFF
--- a/edsnlp/pipes/misc/dates/patterns/atomic/time.py
+++ b/edsnlp/pipes/misc/dates/patterns/atomic/time.py
@@ -1,11 +1,11 @@
-hour_pattern = r"(?<!\d)(?P<hour>0?[1-9]|1\d|2[0-3])(?!\d)"
+hour_pattern = r"(?<!\d)(?P<hour>0?[0-9]|1\d|2[0-3])(?!\d)"
 lz_hour_pattern = r"(?<!\d)(?P<hour>0[1-9]|[12]\d|3[01])(?!\d)"
 
 minute_pattern = r"(?<!\d)(?P<minute>0?[1-9]|[1-5]\d)(?!\d)"
-lz_minute_pattern = r"(?<!\d)(?P<minute>0[1-9]|[1-5]\d)(?!\d)"
+lz_minute_pattern = r"(?<!\d)(?P<minute>0[0-9]|[1-5]\d)(?!\d)"
 
 second_pattern = r"(?<!\d)(?P<second>0?[1-9]|[1-5]\d)(?!\d)"
-lz_second_pattern = r"(?<!\d)(?P<second>0[1-9]|[1-5]\d)(?!\d)"
+lz_second_pattern = r"(?<!\d)(?P<second>0[0-9]|[1-5]\d)(?!\d)"
 
 # The time pattern is always optional
 time_pattern = (

--- a/edsnlp/pipes/misc/quantities/patterns.py
+++ b/edsnlp/pipes/misc/quantities/patterns.py
@@ -301,9 +301,9 @@ units_config = {
     "hour":       {"dim": "time", "degree": 1, "scale": 3600, "terms": ["heure", "heures", "h"], "followed_by": "minute"},
     "minute":     {"dim": "time", "degree": 1, "scale": 60, "terms": ["mn", "min", "minute", "minutes"], "followed_by": "second"},
     "second":     {"dim": "time", "degree": 1, "scale": 1, "terms": ["seconde", "secondes", "s"], "followed_by": None},
-    "arc-minute": {"dim": "time", "degree": 1, "scale": 2, "terms": ["'"], "followed_by": "arc-second"},
-    "arc-second": {"dim": "time", "degree": 1, "scale": 0.03333333333333333, "terms": ['"', "''"], "followed_by": None},
-    "degree":     {"dim": "time", "degree": 1, "scale": 120, "terms": ["degre", "°", "deg"], "followed_by": "arc-minute"},
+    "arc-minute": {"dim": "time", "degree": 1, "scale": 60, "terms": ["'"], "followed_by": "arc-second"},
+    "arc-second": {"dim": "time", "degree": 1, "scale": 1, "terms": ['"', "''"], "followed_by": None},
+    "degree":     {"dim": "time", "degree": 1, "scale": 3600, "terms": ["degre", "°", "deg"], "followed_by": "arc-minute"},
 
     # Temperature
     "celsius": {"dim": "temperature", "degree": 1, "scale": 1, "terms": ["°C", "° celsius", "celsius"], "followed_by": None},


### PR DESCRIPTION
## eds.dates

Fixed regex patterns in order to match "00"-like hours and minutes (e.g. 17:00, 00:23) in the eds.dates pipeline. These timing are not currently matched, leaving the date alone.

## eds.quantities

Fixed arc-minute and arc-second scales in the Time dimension to better match the actual duration scale. Prior to this fix, durations expressed with arc-minutes and arc-seconds had odd values when converted to a given time unit (minute, second...).

**Without the fix :** 

5'45" converted to seconds with `._.value.second` would give 11.5

**With the fix :**

5'45" converted to seconds with `._.value.second` correctly gives 345
