### PR TITLE
chore: bump version to 0.17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.17.0
+pip install edsnlp==0.17.1
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.17.0"
+pip install "edsnlp[ml]==0.17.1"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.17.1 (2025-05-26)
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.17.0
+pip install edsnlp==0.17.1
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.17.0"
+pip install "edsnlp[ml]==0.17.1"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -15,7 +15,7 @@ import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 from . import reducers
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 BASE_DIR = Path(__file__).parent
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Changelog

### Added

- Added grad spike detection to the `edsnlp.train` script, and per weight layer gradient logging.
### Fixed
- Fixed mini-batch accumulation for multi-task training
- Fixed a pickling error when applying a pipeline in multiprocessing mode. This occurred in some cases when one of the pipes was declared in a "difficultly importable" module (e.g., causing a "PicklingWarning: Cannot locate reference to <class...").
- Fixed typo in `eds.consultation_dates` towns: `berck.sur.mer`.
- Fixed a bug where relative date expressions with bounds (e.g. 'depuis hier') raised an error when converted to durations.
- Fixed pipe ADICAP to deal with cases where not code is found after 'codification'/'adicap'
- Support "00"-like hours and minutes in the `eds.dates` component
- Fix arc minutes, arc seconds and degree unit scales in `eds.quantities`, used when converting between different time (or angle) units

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
