### PR TITLE
chore: bump version to 0.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.17.1
+pip install edsnlp==0.17.2
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.17.1"
+pip install "edsnlp[ml]==0.17.2"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.17.2 (2025-06-25)
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.17.1
+pip install edsnlp==0.17.2
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.17.1"
+pip install "edsnlp[ml]==0.17.2"
 ```
 
 ### A first pipeline

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -15,7 +15,7 @@ import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 from . import reducers
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"
 
 BASE_DIR = Path(__file__).parent
 


### PR DESCRIPTION
## v0.17.2 (2025-06-25)

### Added

- Handling intra-word linebreak as pollution : adds a pollution pattern that detects intra-word linebreak, which can then be removed in the `get_text` method
- Qualifiers can process `Span` or `Doc` : this feature especially makes it easier to nest qualifiers components in other components
- New label_weights parameter in eds.span_classifier`, which allows the user to set per label-value loss weights during training

### Fixed

- Various disorders/behaviors patches

### Changed

- Deduplicate spans between doc.ents and doc.spans during train: previously, a `span_getter` requesting entities from both `ents` and `spans` could yield duplicates.

