### PR TITLE
fix: use_sections in eds.history should now work

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+## Fixed
+
+- `use_section` in `eds.history` should now correctly handle cases when there are other sections following history sections.
+
+## Changed
+
+- Sections cues in `eds.history` are now section titles, and not the full section.
+
 ## v0.17.2 (2025-06-25)
 
 ### Added

--- a/edsnlp/pipes/qualifiers/history/history.py
+++ b/edsnlp/pipes/qualifiers/history/history.py
@@ -374,6 +374,17 @@ class HistoryQualifier(RuleBasedQualifier):
                 birth_datetime = None
 
         terminations = [m for m in matches if m.label_ == "termination"]
+
+        sections = []
+        if self.sections:
+            sections = [
+                section
+                for section in doc.spans["sections"]
+                if section.label_ in sections_history
+            ]
+            # History contexts should start/stop around section starts too
+            terminations.extend([s._.section_title for s in doc.spans["sections"]])
+
         boundaries = self._boundaries(doc_like, terminations)
 
         # Removes duplicate matches and pseudo-expressions in one statement
@@ -383,14 +394,6 @@ class HistoryQualifier(RuleBasedQualifier):
         sub_sections = None
         sub_recent_dates = None
         sub_history_dates = None
-
-        sections = []
-        if self.sections:
-            sections = [
-                Span(doc, section.start, section.end, label="ATCD")
-                for section in doc.spans["sections"]
-                if section.label_ in sections_history
-            ]
 
         history_dates = []
         recent_dates = []
@@ -560,7 +563,7 @@ class HistoryQualifier(RuleBasedQualifier):
             recent_cues = []
 
             if self.sections:
-                history_cues.extend(sub_sections)
+                history_cues.extend([s._.section_title for s in sub_sections])
 
             if self.dates:
                 history_cues.extend(

--- a/tests/pipelines/qualifiers/test_history.py
+++ b/tests/pipelines/qualifiers/test_history.py
@@ -22,7 +22,12 @@ Antécédents médicaux :
 Premier épisode: il a été hospitalisé pour asthme cette semaine-ci,
 il y a 3 jours, le 13 août 2020.
 Hier, le patient est venu pour une toux dont les symptômes,
-seraient apparus il y a 2 mois."""
+seraient apparus il y a 2 mois.
+L'asthme est critique
+
+MODE DE VIE
+Rien à signaler.
+"""
 
 
 @mark.parametrize("use_sections", [True, False])
@@ -70,6 +75,7 @@ def test_history(lang, use_sections, use_dates, exclude_birthdate, on_ents_only)
         on_ents_only=on_ents_only,
     )
     doc = history_nlp(doc)
+    assert [t.text for t in doc.ents] == ["toux", "asthme", "asthme", "toux", "asthme"]
 
     if use_dates:
         assert doc.ents[0]._.history is not exclude_birthdate
@@ -80,9 +86,16 @@ def test_history(lang, use_sections, use_dates, exclude_birthdate, on_ents_only)
 
     if use_sections:
         assert doc.ents[2]._.history is not use_dates
-        assert doc.ents[2]._.history_cues[0].label_ == "ATCD"
+        assert doc.ents[2]._.history_cues[0].label_ == "antécédents"
         if use_dates:
             assert doc.ents[2]._.recent_cues[0].label_ == "relative_date"
+        # If we use date, the first asthme entity of the ANTÉCÉDENTS section
+        # will be considered to recent => not history. Otherwise, it's in the
+        # ANTÉCÉDENTS section, so it is considered history.
+        assert doc.ents[2]._.history == (not use_dates)
+        # Same as above, but now the date is "Hier"
+        assert doc.ents[3]._.history == (not use_dates)
+        assert doc.ents[4]._.history  # Default behavior of ANTÉCÉDENTS section
 
 
 def test_on_span(blank_nlp):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- `use_section` in `eds.history` should now correctly handle cases when there are other sections following a given *history* section.
- should fix #431 

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
