### PR TITLE
Explode pipe + span classifier training tutorial

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - `use_section` in `eds.history` should now correctly handle cases when there are other sections following history sections.
 - Added clickable snippets in the documentation for more registered functions
 - Pyarrow dataset writing with multiprocessing should be faster, as we removed a useless data transfer
+- We should now correctly support loading transformers in offline mode if they were already in huggingface's cache
 
 ## Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 - Pyarrow dataset writing with multiprocessing should be faster, as we removed a useless data transfer
 - We should now correctly support loading transformers in offline mode if they were already in huggingface's cache
 - We now support `words[-10:10]` syntax in trainable span classifier `context_getter` parameter
+- :ambulance: Until now, `post_init` was applied **after** the instantiation of the optimizer : if the model discovered new labels, and therefore changed its parameter tensors to reflect that, these new tensors were not taken into account by the optimizer, which could likely lead to subpar performance. Now, `post_init` is applied **before** the optimizer is instantiated, so that the optimizer can correctly handle the new tensors.
 
 ## Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - Sub batch sizes for gradient accumulation can now be defined as simple "splits" of the original batch, e.g. `batch_size = 10000 tokens` and `sub_batch_size = 5 splits` to accumulate batches of 2000 tokens.
 - Parquet writer now has a `pyarrow_write_kwargs` to pass to [pyarrow.dataset.write_dataset](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html#pyarrow-dataset-write-dataset)
 - LinearSchedule (mostly used for LR scheduling) now allows a `end_value` parameter to configure if the learning rate should decay to zero or another value.
+- New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
 
 ## Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - LinearSchedule (mostly used for LR scheduling) now allows a `end_value` parameter to configure if the learning rate should decay to zero or another value.
 - New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
 - New `Training a span classifier` tutorial, and reorganized deep-learning docs
+- `ScheduledOptimizer` now warns when a parameter selector does not match any parameter.
 
 ## Fixed
 
@@ -24,6 +25,7 @@
 
 - Sections cues in `eds.history` are now section titles, and not the full section.
 - :boom: Validation metrics are now found under the root field `validation` in the training logs (e.g. `metrics['validation']['ner']['micro']['f']`)
+- It is now recommended to define optimizer groups of `ScheduledOptimizer` as a list of dicts of optim hyper-parameters, each containing a `selector` regex key, rather than as a single dict with a `selector` as keys and a dict of optim hyper-parameters as values. This allows for more flexibility in defining the optimizer groups, and is more consistent with the rest of the EDS-NLP API. This makes it easier to reference groups values from other places in config files, since their path doesn't contain a complex regex string anymore. See the updated training tutorials for more details.
 
 ## v0.17.2 (2025-06-25)
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Parquet writer now has a `pyarrow_write_kwargs` to pass to [pyarrow.dataset.write_dataset](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html#pyarrow-dataset-write-dataset)
 - LinearSchedule (mostly used for LR scheduling) now allows a `end_value` parameter to configure if the learning rate should decay to zero or another value.
 - New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
+- New `Training a span classifier` tutorial, and reorganized deep-learning docs
 
 ## Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 - Added clickable snippets in the documentation for more registered functions
 - Pyarrow dataset writing with multiprocessing should be faster, as we removed a useless data transfer
 - We should now correctly support loading transformers in offline mode if they were already in huggingface's cache
+- We now support `words[-10:10]` syntax in trainable span classifier `context_getter` parameter
 
 ## Changed
 

--- a/docs/assets/overrides/main.html
+++ b/docs/assets/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  Check out the new <a href="/tutorials/training">Model Training tutorial</a> !
+  Check out the new <a href="/tutorials/training-span-classifier">span classifier training tutorial</a> !
 {% endblock %}

--- a/docs/pipes/misc/explode.md
+++ b/docs/pipes/misc/explode.md
@@ -1,0 +1,9 @@
+# Explode {: #edsnlp.pipes.misc.explode.explode.Explode }
+
+::: edsnlp.pipes.misc.explode.explode.Explode
+    options:
+        heading_level: 2
+        show_bases: false
+        show_source: false
+        only_class_level: true
+        skip_parameters: ["nlp", "name"]

--- a/docs/pipes/misc/index.md
+++ b/docs/pipes/misc/index.md
@@ -8,14 +8,15 @@ For instance, the date detection and normalisation pipeline falls in this catego
 
 <!-- --8<-- [start:components] -->
 
-| Component                | Description                                 |
-|--------------------------|---------------------------------------------|
-| `eds.dates`              | Date extraction and normalisation           |
-| `eds.consultation_dates` | Identify consultation dates                 |
-| `eds.quantities`         | Quantity extraction and normalisation       |
-| `eds.sections`           | Section detection                           |
-| `eds.reason`             | Rule-based hospitalisation reason detection |
-| `eds.tables`             | Tables detection                            |
-| `eds.split`              | Doc splitting                               |
+| Component                | Description                                             |
+|--------------------------|---------------------------------------------------------|
+| `eds.dates`              | Date extraction and normalisation                       |
+| `eds.consultation_dates` | Identify consultation dates                             |
+| `eds.quantities`         | Quantity extraction and normalisation                   |
+| `eds.sections`           | Section detection                                       |
+| `eds.reason`             | Rule-based hospitalisation reason detection             |
+| `eds.tables`             | Tables detection                                        |
+| `eds.split`              | Doc splitting                                           |
+| `eds.explode`            | Explode entities between multiples copies of a document |
 
 <!-- --8<-- [end:components] -->

--- a/docs/training/training-api.md
+++ b/docs/training/training-api.md
@@ -1,0 +1,70 @@
+# Training API
+
+Under the hood, EDS-NLP uses PyTorch to train and run deep-learning models. EDS-NLP acts as a sidekick to PyTorch, providing a set of tools to perform preprocessing, composition and evaluation. The trainable [`TorchComponents`][edsnlp.core.torch_component.TorchComponent] are actually PyTorch modules with a few extra methods to handle the feature preprocessing and postprocessing. Therefore, EDS-NLP is fully compatible with the PyTorch ecosystem.
+
+To build and train a deep learning model, you can either build a training script from scratch (check out the [*Make a training script*](/tutorials/make-a-training-script) tutorial), or use the provided training API. The training API is designed to be flexible and can handle various types of models, including Named Entity Recognition (NER) models, span classifiers, and more. However, if you need more control over the training process, consider writing your own training script.
+
+EDS-NLP supports training models either from the command line or from a Python script or notebook, and switching between the two is relatively straightforward thanks to the use of [Confit](https://aphp.github.io/confit/).
+
+??? note "A word about Confit"
+
+    EDS-NLP makes heavy use of [Confit](https://aphp.github.io/confit/), a configuration library that allows you call functions from Python or the CLI, and validate and optionally cast their arguments.
+
+    The EDS-NLP function described on this page is the `train` function of the `edsnlp.train` module. When passing a dict to a type-hinted argument (either from a `config.yml` file, or by calling the function in Python), Confit will instantiate the correct class with the arguments provided in the dict. For instance, we pass a dict to the `train_data` parameter, which is actually type hinted as a `TrainingData`: this dict will actually be used as keyword arguments to instantiate this `TrainingData` object. You can also instantiate a `TrainingData` object directly and pass it to the function.
+
+    You can also tell Confit specifically which class you want to instantiate by using the `@register_name = "name_of_the_registered_class"` key and value in a dict or config section. We make a heavy use of this mechanism to build pipeline architectures.
+
+## How it works
+
+To train a model with EDS-NLP, you need the following ingredients:
+
+- **Pipeline**: a [pipeline][edsnlp.core.pipeline.Pipeline] with at least one trainable component. Components that share parameters or that must be updated together are trained in the same phase.
+
+- **Training streams**: one or more streams of documents wrapped in a TrainingData object. Each of these specifies how to shuffle the stream, how to batch it with a stat expression such as `2000 words` or `16 spans`, whether to split batches into sub batches for gradient accumulation, and which components it feeds.
+
+- **Validation streams**: optional streams of documents used for periodic evaluation.
+
+- **Scorer**: a [scorer][edsnlp.training.trainer.GenericScorer] that defines the metrics to compute on the validation set. By default, it reports speed and uses autocast during scoring unless disabled.
+
+- **Optimizer**: an [optimizer][edsnlp.training.optimizer.ScheduledOptimizer]. Defaults to AdamW with linear warmup and two groups of parameters, one for the transformer with lr 5•10^-5, and one for the rest of the model with lr 3•10^-4.
+
+- **A bunch of hyperparameters**: finally, the function expects various hyperparameters (most of them set to sensible defaults) to the function, such as `max_steps`, `seed`, `validation_interval`, `checkpoint_interval`, `grad_max_norm`, and more.
+
+The training then proceeds in several steps:
+
+**Setup**
+The function prepares the device with [Accelerate](https://huggingface.co/docs/accelerate/index), creates the output folders, materializes the validation set from the user-provided stream, and runs a post-initialization pass on the training data when requested. This `post_init` op let's the pipeline inspect the data before learning to adjust the number of heads depending on the labels encountered. Finally, the optimizer is instantiated.
+
+**Phases**
+Training runs **by phases**. A phase groups components that should be optimized together because they share parameters (think for instance of a BERT shared between multiple models). During a phase, losses are computed for each of these "active" components at each step, and only their parameters are updated.
+
+**Data preparation**
+Each TrainingData object turns its streams of documents into device ready batches. It optionally shuffles the stream, preprocess the documents for the active components, builds stat-aware batches (for instance, limiting the number of tokens per batch), optionally splits batches into sub batches for gradient accumulation, then converts everything into device-ready tensors. This can be done in parallel to the actual deep-learning work.
+
+**Optimization**
+For every training step the function draws one batch from each training stream (in case there are more than one) and synchronizes statistics across processes (in case we're doing multi-GPU training) to keep supports and losses consistent. It runs forward passes for the phase components. When several components reuse the same intermediate features a cache avoids recomputation. Gradients are accumulated over sub batches.
+
+**Gradient safety**
+Gradients are always clipped to `grad_max_norm`. Optionally the function tracks an exponential moving mean and variance of the gradient norm. If a spike is detected you can clip to the running mean or to a threshold or skip the update depending on `grad_dev_policy`. This protects training from rare extreme updates.
+
+**Validation and logging**
+At regular intervals the scorer evaluates the pipeline on the validation documents. It isolates each task by copying docs and disabling unrelated pipes to avoid leakage. It reports throughput and metrics for NER and span attribute classifiers plus any custom metrics.
+
+**Checkpoints and output**
+The model is saved on schedule and at the end in `output_dir/model-last` unless saving is disabled.
+
+## Tutorials and examples
+
+--8<-- "docs/tutorials/index.md:deep-learning-tutorials"
+
+## Parameters of `edsnlp.train` {: #edsnlp.training.trainer.train }
+
+Here are the parameters you can pass to the `train` function:
+
+::: edsnlp.training.trainer.train
+    options:
+        heading_level: 4
+        only_parameters: no-header
+        skip_parameters: []
+        show_source: false
+        show_toc: false

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,7 +2,9 @@
 
 We provide step-by-step guides to get you started. We cover the following use-cases:
 
-<!-- --8<-- [start:tutorials] -->
+### Base tutorials
+
+<!-- --8<-- [start:classic-tutorials] -->
 
 === card {: href=/tutorials/spacy101 }
 
@@ -83,21 +85,35 @@ We provide step-by-step guides to get you started. We cover the following use-ca
     ---
     Quickly visualize the results of your pipeline as annotations or tables.
 
+### Deep learning tutorials
+
+We also provide tutorials on how to train deep-learning models with EDS-NLP. These tutorials cover the training API, hyperparameter tuning, and more.
+
+<!-- --8<-- [start:deep-learning-tutorials] -->
+
 === card {: href=/tutorials/make-a-training-script }
 
     :fontawesome-solid-flask:
-    **Deep learning tutorial**
+    **Writing a training script**
 
     ---
-    Learn how EDS-NLP handles training deep-neural networks.
+    Learn how EDS-NLP handles training deep-neural networks, and how to write a training script on your own.
 
-=== card {: href=/tutorials/training }
+=== card {: href=/tutorials/training-ner }
 
-    :fontawesome-solid-brain:
-    **Training API**
+    :fontawesome-solid-highlighter:
+    **Training a NER model**
 
     ---
-    Learn how to quicky train a deep-learning model with `edsnlp.train`.
+    Learn how to quickly train a NER model with `edsnlp.train`.
+
+=== card {: href=/tutorials/training-span-classifier }
+
+    :fontawesome-solid-circle-check:
+    **Training a Span Classifier model**
+
+    ---
+    Learn how to quickly train a biopsy date classifier model model with `edsnlp.train`.
 
 === card {: href=/tutorials/tuning }
 
@@ -106,6 +122,9 @@ We provide step-by-step guides to get you started. We cover the following use-ca
 
     ---
     Learn how to tune hyperparameters of a model with `edsnlp.tune`.
+
+
+<!-- --8<-- [end:deep-learning-tutorials] -->
 
 
 <!-- --8<-- [end:tutorials] -->

--- a/docs/tutorials/make-a-training-script.md
+++ b/docs/tutorials/make-a-training-script.md
@@ -1,8 +1,8 @@
-# Deep-learning tutorial
+# Writing a training script
 
 In this tutorial, we'll see how we can write our own deep learning model training script with EDS-NLP. We will implement a script to train a named-entity recognition (NER) model.
 
-If you do not care about the details and just want to train a model, we suggest you to use the [training API](/tutorials/training) and move on to the next tutorial.
+If you do not care about the details and just want to train a model, we suggest that you use the [training API](/training/training-api) and move on to the [next tutorial](/tutorials/training-ner).
 
 !!! warning "Hardware requirements"
 
@@ -440,7 +440,7 @@ python train.py --config config.cfg --nlp.components.ner.embedding.embedding.tra
 
 ## Going further
 
-EDS-NLP also provides a generic training script that follows the same structure as the one we just wrote. You can learn more about in the [next Training API tutorial](/tutorials/training).
+EDS-NLP also provides a generic training script that follows the same structure as the one we just wrote. You can learn more about in the [next NER model training tutorial through EDS-NLP training API](/tutorials/training-ner).
 
 This tutorial gave you a glimpse of the training API of EDS-NLP. To build a custom trainable component, you can refer to the [TorchComponent][edsnlp.core.torch_component.TorchComponent] class or look up the implementation of [some of the trainable components on GitHub](https://github.com/aphp/edsnlp/tree/master/edsnlp/pipes/trainable).
 

--- a/docs/tutorials/training-ner.md
+++ b/docs/tutorials/training-ner.md
@@ -1,12 +1,12 @@
-# Training API {: #edsnlp.training.trainer.train }
+# Training a NER model
 
 In this tutorial, we'll see how we can quickly train a deep learning model with EDS-NLP using the `edsnlp.train` function.
 
 !!! warning "Hardware requirements"
 
-    Training a modern deep learning model requires a lot of computational resources. We recommend using a machine with a GPU, ideally with at least 16GB of VRAM. If you don't have access to a GPU, you can use a cloud service like [Google Colab](https://colab.research.google.com/), [Kaggle](https://www.kaggle.com/), [Paperspace](https://www.paperspace.com/) or [Vast.ai](https://vast.ai/).
+    Training modern deep-learning models is compute-intensive. A GPU with **≥ 16 GB VRAM** is recommended. Training on CPU is possible but much slower. On macOS, PyTorch’s MPS backend may not support all operations and you'll likely hit `NotImplementedError` messages : in this case, fall back to CPU using the `cpu=True` option.
 
-If you need a high level of control over the training procedure, we suggest you read the previous ["Deep learning tutorial"](./make-a-training-script.md) to understand how to build a training loop from scratch with EDS-NLP.
+This tutorial uses EDS-NLP’s command-line interface, `python -m edsnlp.train`. If you need fine-grained control over the loop, consider [**writing your own training script**](./make-a-training-script.md).
 
 ## Creating a project
 
@@ -66,13 +66,7 @@ uv pip install -e ".[dev]" -p $(uv python find)
 
 EDS-NLP supports training models either [from the command line](#from-the-command-line) or [from a Python script or notebook](#from-a-script-or-a-notebook), and switching between the two is straightforward thanks to the use of [Confit](https://aphp.github.io/confit/).
 
-??? note "A word about Confit"
-
-    EDS-NLP makes heavy use of [Confit](https://aphp.github.io/confit/), a configuration library that allows you call functions from Python or the CLI, and validate and optionally cast their arguments.
-
-    The EDS-NLP function used in this script is the `train` function of the `edsnlp.train` module. When passing a dict to a type-hinted argument (either from a `config.yml` file, or by calling the function in Python), Confit will instantiate the correct class with the arguments provided in the dict. For instance, we pass a dict to the `val_data` parameter, which is actually type hinted as a `SampleGenerator`: this dict will actually be used as keyword arguments to instantiate this `SampleGenerator` object. You can also instantiate a `SampleGenerator` object directly and pass it to the function.
-
-    You can also tell Confit specifically which class you want to instantiate by using the `@register_name = "name_of_the_registered_class"` key and value in a dict or config section. We make a heavy use of this mechanism to build pipeline architectures.
+Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a list of all the available options.
 
 === "From the command line"
 
@@ -170,7 +164,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         - '@factory': eds.standoff_dict2doc
           span_setter: 'gold_spans'
 
-    logger:
+    loggers:
         - '@loggers': csv
         - '@loggers': rich
           fields:
@@ -206,7 +200,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
       grad_max_norm: 1.0
       scorer: ${ scorer }
       optimizer: ${ optimizer }
-      logger: ${ logger }
+      logger: ${ loggers }
       # Do preprocessing in parallel on 1 worker
       num_workers: 1
       # Enable on Mac OS X or if you don't want to use available GPUs
@@ -297,7 +291,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
     )
 
     #
-    logger = [
+    loggers = [
         CSVLogger(),
         RichLogger(
             fields={
@@ -328,7 +322,7 @@ EDS-NLP supports training models either [from the command line](#from-the-comman
         optimizer=optimizer,
         grad_max_norm=1.0,
         output_dir="artifacts",
-        loggers
+        logger=loggers,
         # Do preprocessing in parallel on 1 worker
         num_workers=1,
         # Enable on Mac OS X or if you don't want to use available GPUs
@@ -348,16 +342,6 @@ cfg = confit.Config.from_disk(
 )
 nlp = train(**cfg["train"])
 ```
-
-Here are the parameters you can pass to the `train` function:
-
-::: edsnlp.training.trainer.train
-    options:
-        heading_level: 4
-        only_parameters: true
-        skip_parameters: []
-        show_source: false
-        show_toc: false
 
 ## Use the model
 

--- a/docs/tutorials/training-ner.md
+++ b/docs/tutorials/training-ner.md
@@ -120,14 +120,14 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
       groups:
         # Assign parameters starting with transformer (ie the parameters of the transformer component)
         # to a first group
-        "^transformer":
+        - selector: "ner[.]embedding[.]embedding"
           lr:
             '@schedules': linear
             "warmup_rate": 0.1
             "start_value": 0
             "max_value": 5e-5
         # And every other parameters to the second group
-        "":
+        - selector: ".*"
           lr:
             '@schedules': linear
             "warmup_rate": 0.1

--- a/docs/tutorials/training-span-classifier.md
+++ b/docs/tutorials/training-span-classifier.md
@@ -1,0 +1,353 @@
+# Training a span classifier
+
+In this tutorial, we’ll train a hybrid **biopsy date extraction** model with EDS-NLP using the `edsnlp.train` API. Our goal will be to distinguish **biopsy dates** from other dates. We’ll use a small, annotated dataset of dates to train the model, and then apply the model to the date candidates extracted by the rule-based `eds.dates` component.
+
+!!! warning "Hardware requirements"
+
+    Training modern deep-learning models is compute-intensive. A GPU with **≥ 16 GB VRAM** is recommended. Training on CPU is possible but much slower. On macOS, PyTorch’s MPS backend may not support all operations and you'll likely hit `NotImplementedError` messages : in this case, fall back to CPU using the `cpu=True` option.
+
+This tutorial uses EDS-NLP’s command-line interface, `python -m edsnlp.train`. If you need fine-grained control over the loop, consider [**writing your own training script**](./make-a-training-script.md).
+
+## Creating a project
+
+If you already have `edsnlp[ml]` installed, skip to the [next section](#creating-the-dataset)
+
+Create a new project:
+
+```bash { data-md-color-scheme="slate" }
+mkdir my_span_classification_project
+cd my_span_classification_project
+
+touch README.md pyproject.toml
+mkdir -p configs
+```
+
+Add a `pyproject.toml`:
+
+```toml { title="pyproject.toml" }
+[project]
+name = "my_span_classification_project"
+version = "0.1.0"
+description = ""
+authors = [
+    { name = "Firstname Lastname", email = "firstname.lastname@domain.com" }
+]
+readme = "README.md"
+requires-python = ">3.7.1,<4.0"
+
+dependencies = [
+    "edsnlp[ml]>=0.16.0",
+    "sentencepiece>=0.1.96"
+]
+
+[project.optional-dependencies]
+dev = [
+    "dvc>=2.37.0; python_version >= '3.8'",
+    "pandas>=1.4.0,<2.0.0; python_version >= '3.8'",
+    "pre-commit>=2.18.1",
+    "accelerate>=0.21.0; python_version >= '3.8'",
+    "rich-logger>=0.3.0"
+]
+```
+
+We recommend using a virtual environment and [uv](https://docs.astral.sh/uv/):
+
+```bash { data-md-color-scheme="slate" }
+pip install uv
+uv venv .venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+## Creating the dataset
+
+We'll use a small dataset of annotated biopsy dates. The dataset is in the [standoff format](https://brat.nlplab.org/standoff). You can use [Brat](https://brat.nlplab.org/) to visualize and edit the annotations.
+The dataset is available under [`tests/training/dataset_2`](https://github.com/aphp/edsnlp/tree/master/tests/training/dataset_2) directory of EDS-NLP's repository.
+
+To use it, download and copy it into a local `dataset` directory:
+
+- You can clone the repository and copy it yourself, or
+- Use this direct downloader [link](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Faphp%2Fedsnlp%2Ftree%2Fmaster%2Ftests%2Ftraining%2Fdataset) and unzip the downloaded archive.
+
+## Training the model
+
+You can train the model either from the command line or from a script or a notebook.
+Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a list of all the available options.
+
+=== "From the command line"
+
+    Create a config file:
+
+    ```yaml { title="configs/config.yml" }
+    vars:
+      train: './dataset/train'
+      dev: './dataset/dev'
+
+    # 🤖 PIPELINE DEFINITION
+    nlp:
+      '@core': pipeline
+      lang: eds
+
+      components:
+        normalizer:
+          '@factory': eds.normalizer
+
+        # When we encounter a new document, first we extract the dates from the text
+        dates:
+          '@factory': eds.dates
+          span_setter: 'ents'  # (1)!
+
+        # Then for each date, we classify it as a biopsy date or not
+        biopsy_classifier:
+          '@factory': eds.span_classifier
+          attributes: [ "is_biopsy_date" ]
+          span_getter: [ "ents", "gold_spans" ]
+          # ...using a context of 20 words before and after the date
+          context_getter: words[-20:20]
+          # ...embedded by pooling the embeddings
+          embedding:
+            '@factory': eds.span_pooler
+            # ...of a transformer model
+            embedding:
+              '@factory': eds.transformer
+              model: 'almanach/camembert-bio-base'
+              window: 128
+              stride: 96
+
+    # 📈 SCORER
+    scorer:
+      biopsy_date:
+        '@metrics': eds.span_attribute
+        span_getter: ${nlp.components.biopsy_classifier.span_getter}
+        qualifiers: ${nlp.components.biopsy_classifier.attributes}
+
+    # 🎛️ OPTIMIZER
+    optimizer:
+      "@core": optimizer !draft  # (2)!
+      optim: torch.optim.AdamW
+      groups:
+        'biopsy_classifier[.]embedding':
+          lr:
+            '@schedules': linear
+            warmup_rate: 0.1
+            start_value: 0.
+            max_value: 5e-5
+        '.*':
+          lr:
+            '@schedules': linear
+            warmup_rate: 0.1
+            start_value: 3e-4
+            max_value: 3e-4
+
+    # 📚 DATA
+    train_data:
+      - data:
+          # Load the training data from standoff (BRAT) files
+          '@readers': standoff
+          path: ${vars.train}
+          converter:
+            # Convert a standoff file to a Doc
+            - '@factory': eds.standoff_dict2doc
+              span_setter: 'gold_spans'
+              span_attributes: [ 'is_biopsy_date' ]
+              bool_attributes: [ 'is_biopsy_date' ]
+            # Split each doc into replicas, each with exactly one
+            # span from the `gold_spans` group to improve mixing
+            - '@factory': eds.explode
+              span_getter: 'gold_spans'
+        shuffle: dataset
+        batch_size: 8 spans
+        pipe_names: [ "biopsy_classifier" ]
+
+    val_data:
+      '@readers': standoff
+      path: ${vars.dev}
+      converter:
+        - '@factory': eds.standoff_dict2doc
+          span_setter: 'gold_spans'
+          span_attributes: [ 'is_biopsy_date' ]
+          bool_attributes: [ 'is_biopsy_date' ]
+
+    # 🚀 TRAIN SCRIPT OPTIONS
+    train:
+      nlp: ${nlp}
+      train_data: ${train_data}
+      val_data: ${val_data}
+      max_steps: 250
+      validation_interval: 50
+      max_grad_norm: 1.0
+      scorer: ${scorer}
+      num_workers: 1
+      output_dir: 'artifacts'
+    ```
+
+    1. Put entities extracted by `eds.dates` in `doc.ents`, instead of `doc.spans['dates']`.
+    2. Wait, what's does "draft" mean here ? The rationale is this: we don't want to
+    instantiate the optimizer now, because the nlp object hasn't been `post_init`'ed
+    yet : `post_init` is the operation that looks at some data, finds how many labels the model must learn,
+    and updates the model weights to have as many heads as there are labels. This function will
+    be called by `train`, so the optimizer should be defined *after*, when the model parameter tensors are
+    final. To do that, instead of instantiating the optimizer, we create a "Draft", which will be
+    instantiated inside the `train` function, once all the required parameters are set.
+
+    And train the model:
+
+    ```bash { data-md-color-scheme="slate" }
+    python -m edsnlp.train --config configs/config.yml --seed 42
+    ```
+
+=== "From a script or a notebook"
+
+    ```python { .no-check }
+    import edsnlp
+    from edsnlp.training import train, ScheduledOptimizer, TrainingData
+    from edsnlp.metrics.span_attribute import SpanAttributeMetric
+    import edsnlp.pipes as eds
+    import torch
+
+    # 🤖 PIPELINE DEFINITION
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(eds.normalizer())
+    # When we encounter a new document, first we extract the dates from the text
+    nlp.add_pipe(eds.dates(span_setter="ents"))  # (1)!
+    # Then for each data, we classify the dates as biopsy dates or not
+    nlp.add_pipe(
+        eds.span_classifier(
+            attributes=["is_biopsy_date"],
+            span_getter=[
+                "ents",  # used at inference time
+                "gold_spans",  # used at training time
+            ],
+            # ...using a context of 20 words before and after the date
+            context_getter="words[-20:20]",
+            # ...embedded by pooling the embeddings
+            embedding=eds.span_pooler(
+                # ...of a transformer model
+                embedding=eds.transformer(
+                    model="almanach/camembert-bio-base",
+                    window=128,
+                    stride=96,
+                ),
+            ),
+        ),
+        name="biopsy_classifier",
+    )
+
+    # 📈 SCORER
+    metric = SpanAttributeMetric(
+        span_getter=nlp.pipes.biopsy_classifier.span_getter,
+        qualifiers=nlp.pipes.biopsy_classifier.attributes,
+    )
+
+    # 📚 DATA
+    train_docs = (
+        edsnlp.data
+        # Load and convert standoff files to Doc objects
+        .read_standoff(
+            "./dataset/train",
+            span_setter="gold_spans",
+            span_attributes=["is_biopsy_date"],
+            bool_attributes=["is_biopsy_date"],
+        )
+        # Split each doc into replicas, each with exactly one
+        # span from the `gold_spans` group to improve mixing
+        .map(eds.explode(span_getter="gold_spans"))
+    )
+    val_docs = edsnlp.data.read_standoff(
+        "./dataset/dev",
+        span_setter="gold_spans",
+        span_attributes=["is_biopsy_date"],
+        bool_attributes=["is_biopsy_date"],
+    )
+
+    # 🎛️ OPTIMIZER (here it will be the same as thedefault one)
+    optimizer = ScheduledOptimizer.draft(  # (2)!
+        optim=torch.optim.AdamW,
+        groups={
+            "biopsy_classifier[.]embedding": {
+                "lr": {
+                    "@schedules": "linear",
+                    "warmup_rate": 0.1,
+                    "start_value": 0.,
+                    "max_value": 5e-5,
+                },
+            },
+            ".*": {
+                "lr": {
+                    "@schedules": "linear",
+                    "warmup_rate": 0.1,
+                    "start_value": 3e-4,
+                    "max_value": 3e-4,
+                },
+            },
+        }
+    )
+
+    # 🚀 TRAIN
+    train(
+        nlp=nlp,
+        train_data=TrainingData(
+            data=train_docs,
+            batch_size="8 spans",
+            pipe_names=["biopsy_classifier"],
+            shuffle="dataset",
+        ),
+        val_data=val_docs,
+        scorer={"biopsy_date": metric},
+        optimizer=optimizer,
+        max_steps=250,
+        validation_interval=50,
+        grad_max_norm=1.0,
+        num_workers=0,
+        output_dir="artifacts",
+        # cpu=True,  # (optional) use CPU instead of GPU/MPS
+    )
+    ```
+
+    1. Put entities extracted by `eds.dates` in `doc.ents`, instead of `doc.spans['dates']`.
+    2. Wait, what's does "draft" mean here ? The rationale is this: we don't want to
+    instantiate the optimizer now, because the nlp object hasn't been `post_init`'ed
+    yet : `post_init` is the operation that looks at some data, finds how many label the model must learn,
+    and updates the model weights to have as many heads as there are labels. This function will
+    be called by `train`, so the optimizer should be defined *after*, when the model parameter tensors are
+    final. To do that, instead of instantiating the optimizer, we create a "Draft", which will be
+    instantiated inside the `train` function, once all the required parameters are set.
+
+
+!!! note "Upstream annotations at training vs inference time"
+
+    In this example, the pipeline contains the `eds.dates` component
+    but this component is *not* applied to documents *during the training*.
+
+    Actually, this is not specific to this example: in EDS-NLP, the
+    documents used in a training are never modified by the
+    pipeline components, and are instead kept intact, as yielded by the
+    `training_data` parameter object of train(...).
+
+    This is intended: only the spans in `gold_spans` were
+    actually annotated with the `is_biopsy_date` attribute. If instead `eds.dates`
+    had modified the documents, the predicted dates would not necessarily had
+    contained the annotated attribute.
+
+    In general, there is no need to apply upstream pipe
+    to the documents when training a given trainable pipe.
+
+## Use the model
+
+You can now load the trained pipeline and extract the biopsy dates it predicts:
+
+```python { .no-check }
+import edsnlp
+
+nlp = edsnlp.load("artifacts/model-last")
+
+docs = edsnlp.data.from_iterable([
+    "Le 15/07/2023, un prélèvement a été réalisé."
+])
+docs = docs.map_pipeline(nlp)
+docs.to_pandas(
+    converter="ents",
+    # by default, will list doc.ents
+    span_attributes=["is_biopsy_date"],
+)
+```

--- a/docs/tutorials/training-span-classifier.md
+++ b/docs/tutorials/training-span-classifier.md
@@ -126,13 +126,15 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
       "@core": optimizer !draft  # (2)!
       optim: torch.optim.AdamW
       groups:
-        'biopsy_classifier[.]embedding':
+        # Small learning rate for the pretrained transformer model
+        - selector: 'biopsy_classifier[.]embedding[.]embedding'
           lr:
             '@schedules': linear
             warmup_rate: 0.1
             start_value: 0.
             max_value: 5e-5
-        '.*':
+        # Larger learning rate for the rest of the model
+        - selector: '.*'
           lr:
             '@schedules': linear
             warmup_rate: 0.1

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -793,11 +793,11 @@ class MarkupToDocConverter:
     PRESETS = {
         "md": {
             "opener": r"(?P<opener>\[)",
-            "closer": r"(?P<closer>\]\(\s*(?P<closer_label>[a-zA-Z0-9]+)\s*(?P<closer_attrs>.*?)\))",  # noqa: E501
+            "closer": r"(?P<closer>\]\(\s*(?P<closer_label>[a-zA-Z0-9_]+)\s*(?P<closer_attrs>.*?)\))",  # noqa: E501
         },
         "xml": {
-            "opener": r"(?P<opener><(?P<opener_label>[a-zA-Z0-9]+)(?P<opener_attrs>.*?)>)",  # noqa: E501
-            "closer": r"(?P<closer></(?P<closer_label>[a-zA-Z0-9]+)>)",
+            "opener": r"(?P<opener><(?P<opener_label>[a-zA-Z0-9_]+)(?P<opener_attrs>.*?)>)",  # noqa: E501
+            "closer": r"(?P<closer></(?P<closer_label>[a-zA-Z0-9_]+)>)",
         },
     }
 
@@ -855,7 +855,11 @@ class MarkupToDocConverter:
             attrs = groups.get("closer_attrs", groups.get("opener_attrs")) or ""
             attrs = {
                 k: self._as_python(v)
-                for k, v in (kv.split("=") for kv in attrs.split())
+                for k, v in (
+                    kv.split("=") if "=" in kv else (kv.strip(), "True")
+                    for kv in attrs.split()
+                    if kv.strip()
+                )
             }
             text += inline_text[last_inline_offset:inline_start]
             if is_opener:

--- a/edsnlp/metrics/span_attribute.py
+++ b/edsnlp/metrics/span_attribute.py
@@ -133,8 +133,6 @@ def span_attribute_metric(
             "predicted by another NER pipe in your model."
         )
 
-    for name, (pred, gold, pred_with_prob) in labels.items():
-        print("-", name, "pred/gold", pred, gold, "=>", prf(pred, gold))
     return {
         name: {
             **prf(pred, gold),

--- a/edsnlp/pipes/__init__.py
+++ b/edsnlp/pipes/__init__.py
@@ -83,3 +83,4 @@ if TYPE_CHECKING:
     from .trainable.embeddings.transformer.factory import create_component as transformer
     from .trainable.embeddings.text_cnn.factory import create_component as text_cnn
     from .misc.split import Split as split
+    from .misc.explode import Explode as explode

--- a/edsnlp/pipes/misc/explode/__init__.py
+++ b/edsnlp/pipes/misc/explode/__init__.py
@@ -1,0 +1,1 @@
+from .explode import Explode

--- a/edsnlp/pipes/misc/explode/explode.py
+++ b/edsnlp/pipes/misc/explode/explode.py
@@ -1,0 +1,116 @@
+from typing import Iterable, List, Optional, Tuple
+
+from spacy.tokens import Doc, Span
+
+import edsnlp
+from edsnlp import Pipeline
+from edsnlp.utils.span_getters import SpanGetterArg, get_spans_with_group
+
+
+@edsnlp.registry.factory.register("eds.explode", spacy_compatible=False)
+class Explode:
+    def __init__(
+        self,
+        nlp: Optional[Pipeline] = None,
+        name: str = "explode",
+        *,
+        span_getter: SpanGetterArg = {"ents": True},
+        filter_expr: Optional[str] = None,
+    ):
+        """
+        Explode a Doc into multiple distinct Doc objects, one per span retrieved through
+        the `span_getter` : each span becomes alone in its own Doc. Note that entities
+        that are not selected by the `span_getter` will be lost in the new docs.
+
+        !!! warning "Not for pipelines"
+
+            This component is not meant to be used in a pipeline, but rather
+            as a preprocessing step when dealing with a stream of documents
+            as in the example below.
+
+        !!! note "Difference with `eds.split`"
+
+            While `eds.split` breaks a document into smaller chunks based on length or
+            regex rules, `eds.explode` creates a separate document for each selected
+            span. This means `eds.split` is typically used for segmenting text for
+            context size or processing constraints, whereas `eds.explode` is designed
+            for span-level tasks that require span-level mixing, like training span
+            classifiers, ensuring that each span is isolated in its own document while
+            preserving the original context.
+
+        Examples
+        --------
+        ```python
+        import edsnlp.pipes as eds
+        from edsnlp.data.converters import MarkupToDocConverter
+
+        converter = MarkupToDocConverter(
+            preset="xml",
+            # Put xml annotated spans in distinct doc.spans[label] groups
+            span_setter={"*": True},
+        )
+        doc = converter(
+            "Le <person>patient</person> a mal au <body_part>bras</body_part>, à la "
+            "<body_part>jambe</body_part> et au <body_part>torse</body_part>"
+        )
+
+        exploder = eds.explode(span_getter=["body_part"])
+        print(doc.text, "->", doc.spans)
+        # Out: Le patient a mal au bras, à la jambe et au torse -> {'person': [patient], 'body_part': [bras, jambe, torse]}
+
+        for new_doc in exploder(doc):
+            print(new_doc.text, "->", new_doc.spans)
+        # Out: Le patient a mal au bras, à la jambe et au torse -> {'person': [], 'body_part': [bras]}
+        # Out: Le patient a mal au bras, à la jambe et au torse -> {'person': [], 'body_part': [jambe]}
+        # Out: Le patient a mal au bras, à la jambe et au torse -> {'person': [], 'body_part': [torse]}
+        ```
+
+        Parameters
+        ----------
+        nlp: Optional[Pipeline]
+            The pipeline object
+        name: str
+            Name of the pipe
+        span_getter: SpanGetterArg
+            The span getter to use to retrieve spans from the Doc.
+            Default is `{"ents": True}` which retrieves all entities in `doc.ents`.
+        filter_expr: Optional[str]
+            An optional filter expression to filter the produced documents. The callable
+            expects a single argument, the new Doc, and should return a boolean.
+        """  # noqa: E501
+        self.span_getter = span_getter
+        self.filter_fn = eval(f"lambda doc:{filter_expr}") if filter_expr else None
+
+    def __call__(self, doc: Doc) -> Iterable[Doc]:
+        for new_doc in self.explode_doc(doc):
+            if not self.filter_fn or self.filter_fn(new_doc):
+                yield new_doc
+
+    def explode_doc(self, doc: Doc) -> Iterable[Doc]:
+        """
+        Yield a sequence of docs, one per span returned by the getter.
+        """
+        base = doc.copy()
+        span_pairs: List[Tuple[Span, str]] = list(
+            get_spans_with_group(base, self.span_getter)
+        )
+        # Nothing to explode: return the original doc unchanged
+        if not span_pairs:
+            yield doc
+            return
+
+        for name in base.spans:
+            base.spans[name] = []
+        base.ents = []
+
+        for span, group in span_pairs:
+            if group == "ents":
+                base.ents = [span]
+                new_doc = base.copy()
+                base.ents = []
+            else:
+                base.spans[group] = [span]
+                new_doc = base.copy()
+                base.spans[group] = []
+
+            yield new_doc

--- a/edsnlp/pipes/misc/split/split.py
+++ b/edsnlp/pipes/misc/split/split.py
@@ -143,7 +143,10 @@ class Split:
         regex: Optional[str]
             The regex pattern to split the document on
         filter_expr: Optional[str]
-            An optional filter expression to filter the produced documents
+            An optional filter expression to filter the produced documents. The callable
+            expects a single `doc` argument, the new Doc, and should return a boolean.
+            For example, to filter out documents with less than 5 tokens,
+            you can use `filter_expr="len(doc) >= 5"`.
         randomize: float
             The randomization factor to split the documents, to avoid
             producing documents that are all `max_length` tokens long

--- a/edsnlp/pipes/trainable/biaffine_dep_parser/biaffine_dep_parser.py
+++ b/edsnlp/pipes/trainable/biaffine_dep_parser/biaffine_dep_parser.py
@@ -340,7 +340,8 @@ class TrainableBiaffineDependencyParser(
     which you can load using the [`edsnlp.data.read_conll`][edsnlp.data.read_conll]
     function.
 
-    To train the model, refer to the [Training tutorial](/tutorials/training).
+    To train the model, you can adapt the the
+    [Training NER tutorial](/tutorials/training-ner).
 
     Parameters
     ----------

--- a/edsnlp/pipes/trainable/ner_crf/ner_crf.py
+++ b/edsnlp/pipes/trainable/ner_crf/ner_crf.py
@@ -115,7 +115,7 @@ class TrainableNerCrf(TorchComponent[NERBatchOutput, NERBatchInput], BaseNERComp
     )
     ```
 
-    To train the model, refer to the [Training](/tutorials/training)
+    To train the model, refer to the [Training](/tutorials/training-ner)
     tutorial.
 
     Extensions

--- a/edsnlp/pipes/trainable/span_classifier/span_classifier.py
+++ b/edsnlp/pipes/trainable/span_classifier/span_classifier.py
@@ -34,7 +34,12 @@ from edsnlp.utils.bindings import (
     Attributes,
     AttributesArg,
 )
-from edsnlp.utils.span_getters import SpanFilter, SpanGetterArg, get_spans
+from edsnlp.utils.span_getters import (
+    ContextWindow,
+    SpanFilter,
+    SpanGetterArg,
+    get_spans,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +206,7 @@ class TrainableSpanClassifier(
         qualifiers: AttributesArg = None,
         label_weights: Dict[str, Dict[Any, float]] = None,
         span_getter: SpanGetterArg = None,
-        context_getter: Optional[SpanGetterArg] = None,
+        context_getter: Optional[Union[ContextWindow, SpanGetterArg]] = None,
         values: Optional[Dict[str, List[Any]]] = None,
         keep_none: bool = False,
     ):

--- a/edsnlp/pipes/trainable/span_classifier/span_classifier.py
+++ b/edsnlp/pipes/trainable/span_classifier/span_classifier.py
@@ -146,7 +146,8 @@ class TrainableSpanClassifier(
     nlp.post_init(gold_data)
     ```
 
-    To train the model, refer to the [Training](/tutorials/training) tutorial.
+    To train the model, refer to the [Training](/tutorials/training-span-classifier)
+    tutorial.
 
     You can inspect the bindings that will be used for training and prediction
     ```{ .python .no-check }

--- a/edsnlp/training/optimizer.py
+++ b/edsnlp/training/optimizer.py
@@ -1,4 +1,5 @@
 import importlib
+import warnings
 from collections import defaultdict
 from typing import (
     Any,
@@ -166,7 +167,9 @@ class ScheduledOptimizer(torch.optim.Optimizer):
         optim: Union[torch.optim.Optimizer, Type[torch.optim.Optimizer], str],
         module: Optional[Union[PipelineProtocol, torch.nn.Module]] = None,
         total_steps: Optional[int] = None,
-        groups: Optional[Dict[str, Union[Dict, Literal[False]]]] = None,
+        groups: Optional[
+            Union[List[Dict], Dict[str, Union[Dict, Literal[False]]]]
+        ] = None,
         init_schedules: bool = True,
         **kwargs,
     ):
@@ -183,13 +186,17 @@ class ScheduledOptimizer(torch.optim.Optimizer):
         optim = ScheduledOptimizer(
             cls="adamw",
             module=model,
-            groups={
+            groups=[
                 # Exclude all parameters matching 'bias' from optimization.
-                "bias": False,
-                # Parameters starting with 'transformer' receive this learning rate
+                {
+                    "selector": "bias",
+                    "exclude": True,
+                },
+                # Parameters of the NER module's embedding receive this learning rate
                 # schedule. If a parameter matches both 'transformer' and 'ner',
-                # the 'transformer' settings take precedence due to the order.
-                "^transformer": {
+                # the first group settings take precedence due to the order.
+                {
+                    "selector": "^ner[.]embedding"
                     "lr": {
                         "@schedules": "linear",
                         "start_value": 0.0,
@@ -199,7 +206,8 @@ class ScheduledOptimizer(torch.optim.Optimizer):
                 },
                 # Parameters starting with 'ner' receive this learning rate schedule,
                 # unless a 'lr' value has already been set by an earlier selector.
-                "^ner": {
+                {
+                    "selector": "^ner"
                     "lr": {
                         "@schedules": "linear",
                         "start_value": 0.0,
@@ -209,10 +217,11 @@ class ScheduledOptimizer(torch.optim.Optimizer):
                 },
                 # Apply a weight_decay of 0.01 to all parameters not excluded.
                 # This setting doesn't conflict with others and applies to all.
-                "": {
+                {
+                    "selector": "",
                     "weight_decay": 0.01,
                 },
-            },
+            ],
             total_steps=1000,
         )
         ```
@@ -221,24 +230,28 @@ class ScheduledOptimizer(torch.optim.Optimizer):
         ----------
         optim : Union[str, Type[torch.optim.Optimizer], torch.optim.Optimizer]
             The optimizer to use. If a string (like "adamw") or a type to instantiate,
-            the`module` and `groups` must be provided.
+            the `module` and `groups` must be provided.
         module : Optional[Union[PipelineProtocol, torch.nn.Module]]
             The module to optimize. Usually the `nlp` pipeline object.
         total_steps : Optional[int]
             The total number of steps, used for schedules.
-        groups : Optional[Dict[str, Group]]
-            The groups to optimize. The key is a regex selector to match parameters in
-            `module.named_parameters()` and the value is a dictionary with the keys
-            `params` and `schedules`.
+        groups : Optional[List[Group]]
+            The groups to optimize. Each group is a dictionary containing:
 
-            The matching is performed by running  `regex.search(selector, name)` so you
-            do not have to match the full name. Note that the order of dict keys
-            matter. If a parameter name matches multiple selectors, the
+            - a regex `selector` key to match the parameter of that group by their names
+              (as listed by `nlp.named_parameters()`)
+            - and several other keys that define the optimizer parameters for that
+              group, such as `lr`, `weight_decay` etc. The value for these keys can
+              be a `Schedule` instance or a simple value
+            - an `exclude` key that can be set to True to exclude parameters
+
+            The matching is performed by running `regex.search(selector, name)` so you
+            do not have to match the full name. Note that the order of the groups
+            matters. If a parameter name matches multiple selectors, the
             configurations of these selectors are combined in reverse order (from the
             last matched selector to the first), allowing later selectors to complete
-            options from earlier ones. If a selector maps to `False`, any parameters
-            matching it are excluded from optimization and not included in any parameter
-            group.
+            options from earlier ones. If a selector contains `exclude=True`, any
+            parameter matching it is excluded from optimization.
         """
         should_instantiate_optim = isinstance(optim, str) or isinstance(optim, type)
         if should_instantiate_optim and (groups is None or module is None):
@@ -257,6 +270,15 @@ class ScheduledOptimizer(torch.optim.Optimizer):
         if should_instantiate_optim:
             named_parameters = list(module.named_parameters())
             groups = Config.resolve(groups, registry=edsnlp.registry)
+
+            # New groups format
+            if isinstance(groups, list):
+                groups = [dict(g) for g in groups]
+                groups = {
+                    g.pop("selector"): g if not g.get("exclude") else False
+                    for g in groups
+                }
+
             groups = {
                 sel: dict(group) if group else False for sel, group in groups.items()
             }
@@ -268,8 +290,20 @@ class ScheduledOptimizer(torch.optim.Optimizer):
                     )
                 )
             groups_to_params = defaultdict(lambda: [])
+            empty_selectors = {sel for sel in groups}
             for params, group in param_to_groups.items():
                 groups_to_params[group].append(params)
+                for sel in group:
+                    empty_selectors.discard(sel)
+
+            if empty_selectors:
+                warnings.warn(
+                    f"Selectors {list(empty_selectors)} did not match any parameters."
+                )
+                warnings.warn(
+                    "For reference, here are the parameters of the module:\n"
+                    + "\n".join("- " + name for name, _ in named_parameters)
+                )
 
             cliques = []
             for selectors, params in groups_to_params.items():

--- a/edsnlp/training/optimizer.py
+++ b/edsnlp/training/optimizer.py
@@ -128,7 +128,13 @@ class LinearSchedule(Schedule):
     def step(self, group, closure=None):
         self.idx += 1
         if self.max_value is None:
-            self.max_value = get_deep_attr(group, self.paths[0])
+            if isinstance(get_deep_attr(group, self.paths[0]), (int, float)):
+                self.max_value = get_deep_attr(group, self.paths[0])
+            else:
+                raise Exception(
+                    "The max_value parameter of the linear schedule "
+                    "must be set to a valid number."
+                )
         warmup_steps = self.total_steps * self.warmup_rate
         if self.idx < warmup_steps:
             progress = self.idx / warmup_steps

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -87,12 +87,29 @@ def deep_set_unflat(x, stats):
 class GenericScorer:
     def __init__(
         self,
-        speed: bool = True,
         batch_size: Union[int, str] = 1,
         autocast: Union[bool, Any] = None,
-        **scorers,
+        speed: bool = True,
+        **metrics,
     ):
-        self.scorers = scorers
+        """
+        A scorer to evaluate the model performance on various tasks.
+
+        Parameters
+        ----------
+        batch_size: Union[int, str]
+            The batch size to use for scoring. Can be an int (number of documents)
+            or a string (batching expression like "2000 words").
+        speed: bool
+            Whether to compute the model speed (words/documents per second)
+        autocast: Union[bool, Any]
+            Whether to use autocasting for mixed precision during the evaluation,
+            defaults to True.
+        metrics: Dict[str, Any]
+            A keyword arguments mapping of metric names to metrics objects. See the
+            [metrics](/metrics) documentation for more info.
+        """
+        self.metrics = metrics
         self.speed = speed
         self.batch_size = batch_size
         self.autocast = autocast
@@ -100,7 +117,7 @@ class GenericScorer:
     def __call__(self, nlp: Pipeline, docs: Iterable[Any]):
         scores = {}
         docs = list(docs)
-        scorers = dict(self.scorers)
+        metrics = dict(self.metrics)
 
         # Speed
         if self.speed:
@@ -123,12 +140,12 @@ class GenericScorer:
         ner_pipes = [
             name for name, pipe in nlp.pipeline if isinstance(pipe, BaseNERComponent)
         ]
-        ner_scorers = {
-            name: scorers.pop(name)
-            for name in list(scorers)
-            if isinstance(scorers[name], NerMetric)
+        ner_metrics = {
+            name: metrics.pop(name)
+            for name in list(metrics)
+            if isinstance(metrics[name], NerMetric)
         }
-        if ner_pipes and ner_scorers:
+        if ner_pipes and ner_metrics:
             clean_ner_docs = [d.copy() for d in tqdm(docs, desc="Copying docs")]
             for d in clean_ner_docs:
                 d.ents = []
@@ -140,8 +157,8 @@ class GenericScorer:
                         autocast=self.autocast,
                     )
                 )
-            for name, scorer in ner_scorers.items():
-                scores[name] = scorer(docs, ner_preds)
+            for name, metric in ner_metrics.items():
+                scores[name] = metric(docs, ner_preds)
 
         # Qualification
         qlf_pipes = [
@@ -149,12 +166,12 @@ class GenericScorer:
             for name, pipe in nlp.pipeline
             if isinstance(pipe, BaseSpanAttributeClassifierComponent)
         ]
-        span_attr_scorers = {
-            name: scorers.pop(name)
-            for name in list(scorers)
-            if isinstance(scorers[name], SpanAttributeMetric)
+        span_attr_metrics = {
+            name: metrics.pop(name)
+            for name in list(metrics)
+            if isinstance(metrics[name], SpanAttributeMetric)
         }
-        if qlf_pipes and span_attr_scorers:
+        if qlf_pipes and span_attr_metrics:
             clean_qlf_docs = [d.copy() for d in tqdm(docs, desc="Copying docs")]
             for doc in clean_qlf_docs:
                 for name in qlf_pipes:
@@ -169,11 +186,11 @@ class GenericScorer:
                         autocast=self.autocast,
                     )
                 )
-            for name, scorer in span_attr_scorers.items():
-                scores[name] = scorer(docs, qlf_preds)
+            for name, metric in span_attr_metrics.items():
+                scores[name] = metric(docs, qlf_preds)
 
-        # Custom scorers
-        for name, scorer in scorers.items():
+        # Custom metrics
+        for name, metric in metrics.items():
             pred_docs = [d.copy() for d in tqdm(docs, desc="Copying docs")]
             preds = list(
                 nlp.pipe(tqdm(pred_docs, desc="Predicting")).set_processing(
@@ -181,7 +198,7 @@ class GenericScorer:
                     autocast=self.autocast,
                 )
             )
-            scores[name] = scorer(docs, preds)
+            scores[name] = metric(docs, preds)
 
         return scores
 
@@ -510,6 +527,15 @@ def train(
     scorer: GenericScorer
         How to score the model. Expects a `GenericScorer` object or a dict
         containing a mapping of metric names to metric objects.
+
+        ??? note "`GenericScorer` object/dictionary"
+            ::: edsnlp.training.trainer.GenericScorer
+                options:
+                    heading_level: 1
+                    only_parameters: "no-header"
+                    skip_parameters: []
+                    show_source: false
+                    show_toc: false
     num_workers: int
         The number of workers to use for preprocessing the data in parallel.
         Setting it to 0 means no parallelization : data is processed on the

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -23,8 +23,7 @@ import torch
 from accelerate import Accelerator, PartialState
 from accelerate.tracking import GeneralTracker
 from accelerate.utils import gather_object
-from confit import validate_arguments
-from confit.registry import Draft
+from confit import Draft, validate_arguments
 from confit.utils.random import set_seed
 from tqdm import tqdm, trange
 from typing_extensions import Literal
@@ -33,7 +32,7 @@ import edsnlp
 from edsnlp import Pipeline, registry
 from edsnlp.core.stream import Stream
 from edsnlp.metrics.ner import NerMetric
-from edsnlp.metrics.span_attributes import SpanAttributeMetric
+from edsnlp.metrics.span_attribute import SpanAttributeMetric
 from edsnlp.pipes.base import (
     BaseNERComponent,
     BaseSpanAttributeClassifierComponent,
@@ -418,7 +417,11 @@ def train(
     val_data: AsList[Stream] = [],
     seed: int = 42,
     max_steps: int = 1000,
-    optimizer: Union[ScheduledOptimizer, Draft[ScheduledOptimizer], torch.optim.Optimizer] = None,  # noqa: E501
+    optimizer: Union[
+        Draft[ScheduledOptimizer],
+        ScheduledOptimizer,
+        torch.optim.Optimizer,
+    ] = None,
     validation_interval: Optional[int] = None,
     checkpoint_interval: Optional[int] = None,
     grad_max_norm: float = 5.0,
@@ -615,9 +618,19 @@ def train(
         + "".join(f"\n - {i + 1}: {', '.join(n)}" for i, n in enumerate(phases))
     )
 
+    if kwargs:
+        raise ValueError(f"Unknown arguments: {', '.join(kwargs)}")
+
+    # Prepare validation docs
+    val_docs = list(chain.from_iterable(val_data))
+
+    # Initialize pipeline with training documents
+    nlp.post_init(chain_zip([td.data for td in train_data if td.post_init]))
+
     all_params = set(nlp.parameters())
     optim = optimizer
     del optimizer
+    optim = Draft.instantiate(optim, module=nlp, total_steps=max_steps)
     if optim is None:
         warnings.warn(
             "No optimizer provided, using default optimizer with default parameters"
@@ -636,15 +649,6 @@ def train(
         module=nlp,
         total_steps=max_steps,
     )
-
-    if kwargs:
-        raise ValueError(f"Unknown arguments: {', '.join(kwargs)}")
-
-    # Prepare validation docs
-    val_docs = list(chain.from_iterable(val_data))
-
-    # Initialize pipeline with training documents
-    nlp.post_init(chain_zip([td.data for td in train_data if td.post_init]))
 
     for phase_i, pipe_names in enumerate(phases):
         trained_pipes_local: Dict[str, TorchComponent] = {

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -346,7 +346,7 @@ class TrainingData:
         with nlp.select_pipes(enable=self.pipe_names):
             data = data.map(nlp.preprocess, kwargs=dict(supervision=True))
         batcher = stat_batchify(self.batch_size[1] or "docs")
-        if self.sub_batch_size[1] == "splits":
+        if self.sub_batch_size and self.sub_batch_size[1] == "splits":
             data = data.batchify(
                 batch_size=self.batch_size[0] // self.sub_batch_size[0],
                 batch_by=batcher,

--- a/edsnlp/utils/span_getters.py
+++ b/edsnlp/utils/span_getters.py
@@ -244,7 +244,7 @@ class SpanGetterArg(Validated):
 
     @classmethod
     def validate(cls, value, config=None) -> SpanSetter:
-        return validate_span_setter(value)
+        return validate_span_getter(value)
 
 
 if TYPE_CHECKING:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,8 @@ nav:
       - tutorials/multiple-texts.md
       - advanced-tutorials/fastapi.md
       - tutorials/make-a-training-script.md
-      - tutorials/training.md
+      - tutorials/training-ner.md
+      - tutorials/training-span-classifier.md
       - tutorials/tuning.md
   - Pipes:
       - Overview: pipes/index.md
@@ -81,6 +82,7 @@ nav:
           - pipes/misc/reason.md
           - pipes/misc/tables.md
           - pipes/misc/split.md
+          - pipes/misc/explode.md
       - Named Entity Recognition:
           - Overview: pipes/ner/index.md
           - Scores:
@@ -148,6 +150,8 @@ nav:
       - concepts/pipeline.md
       - concepts/torch-component.md
       - concepts/inference.md
+  - Training:
+      - training/training-api.md
   - Metrics:
       - metrics/index.md
       - metrics/ner.md
@@ -198,6 +202,7 @@ plugins:
   - redirects:
       redirect_maps:
         'pipes/trainable/span-qualifier.md': 'pipes/trainable/span-classifier.md'
+        'tutorials/training.md': 'training/training-api.md'
   - search
   - minify:
       minify_html: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ where = ["."]
 
 # Data
 "eds.split"                       = "edsnlp.pipes.misc.split.split:Split"
+"eds.explode"                     = "edsnlp.pipes.misc.explode.explode:Explode"
 "eds.standoff_dict2doc"           = "edsnlp.data.converters:StandoffDict2DocConverter"
 "eds.standoff_doc2dict"           = "edsnlp.data.converters:StandoffDoc2DictConverter"
 "eds.conll_dict2doc"              = "edsnlp.data.converters:ConllDict2DocConverter"

--- a/tests/pipelines/misc/test_explode.py
+++ b/tests/pipelines/misc/test_explode.py
@@ -1,0 +1,126 @@
+from edsnlp.data.converters import MarkupToDocConverter
+from edsnlp.pipes.misc.explode import Explode
+from edsnlp.utils.span_getters import get_spans_with_group
+
+
+def make_doc():
+    """
+    Build a single document with two entities (entity, date) in `doc.ents`
+    and one adjective span in the custom span-group `adj`.
+    """
+    converter = MarkupToDocConverter(
+        preset="xml",
+        span_setter={"ents": ["entity", "date"], "adj": ["adj"]},
+    )
+    return converter(
+        "Ceci est un <entity>texte</entity> très <adj>important</adj>, "
+        "écrit le <date is_recent>25 juil. 2025</date>"
+    )
+
+
+def groups_in(doc):
+    """
+    Return the set of non-empty span-group names contained in `doc`.
+    (`ents` is treated as a group of its own.)
+    """
+    groups = set()
+    if len(doc.ents):
+        groups.add("ents")
+    groups.update(name for name, spans in doc.spans.items() if len(spans))
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+def test_explode_multiple_groups():
+    """
+    • Exploding on both ``ents`` and ``adj`` must yield exactly three docs.
+    • Each exploded doc must keep the full text, but contain **one** and only
+      one non-empty span-group.
+    • The surviving span must be the right one.
+    """
+    doc = make_doc()
+    exploder = Explode(span_getter=["ents", "adj"])
+
+    exploded = list(exploder(doc))
+    assert len(exploded) == 3
+
+    # In any order, we expect the three following "profiles"
+    profiles = sorted(
+        [
+            (
+                tuple(e.text for e in d.ents),
+                [e.text for e in d.spans.get("adj", [])],
+            )
+            for d in exploded
+        ]
+    )
+
+    assert profiles == sorted(
+        [
+            (("texte",), []),
+            (("25 juil. 2025",), []),
+            ((), ["important"]),
+        ]
+    )
+
+    # Check that attributes are correctly preserved
+    assert exploded[1].ents[0]._.is_recent is True
+    assert not exploded[0].ents[0]._.is_recent
+
+    # Each sub-document must contain *exactly* one non-empty span-group
+    assert all(len(groups_in(sub)) == 1 for sub in exploded)
+
+    # Original doc remains unaltered
+    assert groups_in(doc) == {"ents", "adj"}
+
+
+def test_explode_single_group():
+    """
+    Exploding only on ``ents`` yields one doc per entity and leaves
+    the ``adj`` group untouched in the originals.
+    """
+    doc = make_doc()
+    exploder = Explode(span_getter="ents")
+
+    exploded = list(exploder(doc))
+    assert len(exploded) == 2
+    assert all(len(sub.ents) == 1 for sub in exploded)
+    assert sorted(e.text for sub in exploded for e in sub.ents) == [
+        "25 juil. 2025",
+        "texte",
+    ]
+
+
+def test_explode_filter_expr():
+    doc = make_doc()
+    exploder = Explode(
+        span_getter=["ents", "adj"],
+        filter_expr="any('t' in e.text for e in (*doc.ents, *doc.spans['adj']))",
+    )
+
+    exploded = list(exploder(doc))
+    assert len(exploded) == 2
+    ents = [
+        (e.text, g)
+        for sub in exploded
+        for e, g in get_spans_with_group(sub, exploder.span_getter)
+    ]
+    assert ents == [("texte", "ents"), ("important", "adj")]
+
+
+def test_explode_no_spans():
+    """
+    When the document has no spans selected by the getter, the original
+    doc must be yielded unchanged (identity check included).
+    """
+    import spacy
+
+    nlp = spacy.blank("fr")
+    doc = nlp("Pas d'entités ici.")
+    exploder = Explode(span_getter="ents")
+
+    result = list(exploder(doc))
+    assert result == [doc]  # same object
+    assert len(result[0].ents) == 0

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -106,7 +106,7 @@ def insert_assert_statements(code):
                     end = match.end()
                     stmt_str = ast.unparse(stmt)
                     if stmt_str.startswith("print("):
-                        stmt_str = stmt_str[len("print") :]
+                        stmt_str = stmt_str.replace("print", "print_to_string")
                     repl = f"""\
 val = {stmt_str}
 try:
@@ -168,8 +168,11 @@ def test_code_blocks(url, tmpdir, reset_imports):
     code_with_asserts = """
 import pytest
 
+def print_to_string(*args, sep=" ", end="\\n", file=None, flush=False):
+    return (sep.join(map(str, args)) + end).rstrip('\\n')
+
 def assert_print(*args, sep=" ", end="\\n", file=None, flush=False):
-    printed.append((sep.join(map(str, args)) + end).rstrip('\\n'))
+    printed.append(print_to_string(*args, sep=sep, end=end, file=file, flush=flush))
 
 """ + insert_assert_statements(code)
     assert "# Out:" not in code_with_asserts, (

--- a/tests/training/dataset_2/dev/doc-0.ann
+++ b/tests/training/dataset_2/dev/doc-0.ann
@@ -1,0 +1,4 @@
+T1	date 21 35	6 février 1995
+T2	date 55 70	12 juillet 2025
+T3	date 155 170	13 juillet 2025
+T4	date 196 211	15 juillet 2025

--- a/tests/training/dataset_2/dev/doc-0.txt
+++ b/tests/training/dataset_2/dev/doc-0.txt
@@ -1,0 +1,4 @@
+Le patient est né le 6 février 1995.
+Il a été admis le 12 juillet 2025 pour douleur abdominale aiguë.
+Une appendicectomie laparoscopique a été réalisée le 13 juillet 2025.
+La sortie est prévue le 15 juillet 2025.

--- a/tests/training/dataset_2/dev/doc-1.ann
+++ b/tests/training/dataset_2/dev/doc-1.ann
@@ -1,0 +1,7 @@
+T1	date 20 31	19 mai 1978
+T2	date 79 95	28 décembre 2024
+T3	date 148 162	3 janvier 2025
+A1	is_biopsy_date T3
+T4	date 215 227	10 mars 2025
+A2	is_biopsy_date T4
+T5	date 261 273	2 avril 2025

--- a/tests/training/dataset_2/dev/doc-1.txt
+++ b/tests/training/dataset_2/dev/doc-1.txt
@@ -1,0 +1,4 @@
+La patiente, née le 19 mai 1978, a présenté une hépatomégalie diagnostiquée le 28 décembre 2024.
+Une biopsie hépatique percutanée a été réalisée le 3 janvier 2025.
+Une seconde biopsie de contrôle a été effectuée le 10 mars 2025.
+Discussion en RCP programmée le 2 avril 2025.

--- a/tests/training/dataset_2/dev/doc-2.ann
+++ b/tests/training/dataset_2/dev/doc-2.ann
@@ -1,0 +1,5 @@
+T1	date 18 33	30 octobre 1949
+T2	date 75 90	12 février 2025
+T3	date 146 161	20 février 2025
+A1	is_biopsy_date T3
+T4	date 190 205	27 février 2025

--- a/tests/training/dataset_2/dev/doc-2.txt
+++ b/tests/training/dataset_2/dev/doc-2.txt
@@ -1,0 +1,3 @@
+Le patient, né le 30 octobre 1949, consulte pour lésion cutanée repérée le 12 février 2025.
+Une biopsie excisionnelle de la lésion a été faite le 20 février 2025.
+Résultats attendus pour le 27 février 2025.

--- a/tests/training/dataset_2/dev/doc-3.ann
+++ b/tests/training/dataset_2/dev/doc-3.ann
@@ -1,0 +1,7 @@
+T1	date 23 34	5 juin 1961
+T2	date 65 77	15 août 2024
+T3	date 120 136	12 novembre 2024
+A1	is_biopsy_date T3
+T4	date 186 197	14 mai 2025
+A2	is_biopsy_date T4
+T5	date 239 257	1ᵉʳ septembre 2025

--- a/tests/training/dataset_2/dev/doc-3.txt
+++ b/tests/training/dataset_2/dev/doc-3.txt
@@ -1,0 +1,5 @@
+La patiente est née le 5 juin 1961.
+Une anémie a été détectée le 15 août 2024.
+Une biopsie médullaire a été réalisée le 12 novembre 2024.
+Un deuxième prélèvement médullaire a eu lieu le 14 mai 2025.
+Prochain contrôle hématologique fixé au 1ᵉʳ septembre 2025.

--- a/tests/training/dataset_2/dev/doc-4.ann
+++ b/tests/training/dataset_2/dev/doc-4.ann
@@ -1,0 +1,5 @@
+T1	date 28 42	9 juillet 2025
+T2	date 85 100	10 juillet 2025
+T3	date 185 196	6 août 2025
+T4	date 240 256	juillet prochain
+A1	is_biopsy_date T4

--- a/tests/training/dataset_2/dev/doc-4.txt
+++ b/tests/training/dataset_2/dev/doc-4.txt
@@ -1,0 +1,5 @@
+Le nouveau-né est arrivé le 9 juillet 2025 à terme.
+Dépistage métabolique réalisé le 10 juillet 2025.
+Aucune biopsie n’a été nécessaire à ce jour.
+Consultation pédiatrique planifiée le 6 août 2025.
+On préconise un prélèvement de cellule en juillet prochain.

--- a/tests/training/dataset_2/train/doc-0.ann
+++ b/tests/training/dataset_2/train/doc-0.ann
@@ -1,0 +1,5 @@
+T1	date 22 34	14 mars 1950
+T2	date 73 83	2 mai 2025
+T3	date 152 162	4 mai 2025
+A1	is_biopsy_date T3
+T4	date 205 217	18 juin 2025

--- a/tests/training/dataset_2/train/doc-0.txt
+++ b/tests/training/dataset_2/train/doc-0.txt
@@ -1,0 +1,5 @@
+
+Le patient est né le 14 mars 1950.
+Il s’est présenté en consultation le 2 mai 2025 pour douleurs thoraciques.
+Une biopsie pulmonaire a été réalisée le 4 mai 2025.
+La consultation de contrôle est fixée au 18 juin 2025.

--- a/tests/training/dataset_2/train/doc-1.ann
+++ b/tests/training/dataset_2/train/doc-1.ann
@@ -1,0 +1,5 @@
+T1	date 20 37	29 septembre 1982
+T2	date 55 68	15 avril 2025
+T3	date 139 152	17 avril 2025
+A1	is_biopsy_date T3
+T4	date 190 203	30 avril 2025

--- a/tests/training/dataset_2/train/doc-1.txt
+++ b/tests/training/dataset_2/train/doc-1.txt
@@ -1,0 +1,3 @@
+La patiente, née le 29 septembre 1982, a été admise le 15 avril 2025 pour céphalées.
+Une biopsie cérébrale stéréotaxique a été réalisée le 17 avril 2025.
+Un scanner de contrôle est prévu le 30 avril 2025.

--- a/tests/training/dataset_2/train/doc-10.ann
+++ b/tests/training/dataset_2/train/doc-10.ann
@@ -1,0 +1,6 @@
+T1	date 36 48	14 mars 2025
+T2	date 139 155	20 décembre 2022
+T3	date 206 218	16 mars 2025
+A1	is_biopsy_date T3
+T4	date 301 318	30 septembre 2025
+A2	is_biopsy_date T4

--- a/tests/training/dataset_2/train/doc-10.txt
+++ b/tests/training/dataset_2/train/doc-10.txt
@@ -1,0 +1,4 @@
+Monsieur A., 58 ans, a été admis le 14 mars 2025 pour rectorragies persistantes.
+Une coloscopie de surveillance avait déjà été réalisée le 20 décembre 2022.
+Une biopsie colique extensive a été effectuée le 16 mars 2025, confirmant une dysplasie de haut grade.
+Un contrôle histologique est planifié le 30 septembre 2025.

--- a/tests/training/dataset_2/train/doc-11.ann
+++ b/tests/training/dataset_2/train/doc-11.ann
@@ -1,0 +1,7 @@
+T1	date 70 84	5 février 2024
+T2	date 123 134	28 mai 2024
+T3	date 239 253	2 janvier 2025
+A1	is_biopsy_date T3
+T4	date 290 303	10 avril 2025
+A2	is_biopsy_date T4
+T5	date 359 370	7 août 2025

--- a/tests/training/dataset_2/train/doc-11.txt
+++ b/tests/training/dataset_2/train/doc-11.txt
@@ -1,0 +1,4 @@
+La patiente B., 43 ans, est prise en charge en dermatologie depuis le 5 février 2024.
+Un premier curetage a été réalisé le 28 mai 2024 avec amélioration partielle.
+Devant la persistance de la lésion, une biopsie cutanée punch a eu lieu le 2 janvier 2025, suivie d’une biopsie d’excision le 10 avril 2025.
+Les résultats histologiques seront discutés en RCP le 7 août 2025.

--- a/tests/training/dataset_2/train/doc-12.ann
+++ b/tests/training/dataset_2/train/doc-12.ann
@@ -1,0 +1,4 @@
+T1	date 61 77	1ᵉʳ juillet 2025
+T2	date 117 131	2 juillet 2025
+T3	date 135 150	15 juillet 2025
+T4	date 205 216	3 août 2025

--- a/tests/training/dataset_2/train/doc-12.txt
+++ b/tests/training/dataset_2/train/doc-12.txt
@@ -1,0 +1,4 @@
+Le nouveau-né prématuré a été hospitalisé en néonatologie le 1ᵉʳ juillet 2025.
+Il a reçu une cure d’antibiotiques du 2 juillet 2025 au 15 juillet 2025.
+Une échographie transfontanellaire est programmée le 3 août 2025 pour surveillance neurologique.
+Aucune biopsie n’a été nécessaire jusqu’à présent.

--- a/tests/training/dataset_2/train/doc-13.ann
+++ b/tests/training/dataset_2/train/doc-13.ann
@@ -1,0 +1,6 @@
+T1	date 48 64	18 novembre 2018
+T2	date 125 138	22 avril 2025
+T3	date 217 230	25 avril 2025
+A1	is_biopsy_date T3
+T4	date 257 272	12 octobre 2025
+T5	date 315 331	18 novembre 2025

--- a/tests/training/dataset_2/train/doc-13.txt
+++ b/tests/training/dataset_2/train/doc-13.txt
@@ -1,0 +1,4 @@
+Monsieur C. a subi une thyroïdectomie totale le 18 novembre 2018.
+Devant l’apparition d’un nodule cervical, il a consulté le 22 avril 2025.
+Une biopsie à l’aiguille fine du ganglion sus-claviculaire a été réalisée le 25 avril 2025.
+Un PET-scan est prévu le 12 octobre 2025 et une éventuelle reprise chirurgicale le 18 novembre 2025.

--- a/tests/training/dataset_2/train/doc-14.ann
+++ b/tests/training/dataset_2/train/doc-14.ann
@@ -1,0 +1,9 @@
+T1	date 58 74	9 septembre 2021
+T2	date 133 150	10 septembre 2021
+A1	is_biopsy_date T2
+T3	date 208 222	4 février 2025
+T4	date 257 271	6 février 2025
+A2	is_biopsy_date T4
+T5	date 314 326	20 août 2025
+T6	date 380 392	27 août 2025
+T7	date 439 455	15 novembre 2025

--- a/tests/training/dataset_2/train/doc-14.txt
+++ b/tests/training/dataset_2/train/doc-14.txt
@@ -1,0 +1,5 @@
+La patiente D., 60 ans, est suivie pour myélome depuis le 9 septembre 2021.
+Une première biopsie ostéo-médullaire a été pratiquée le 10 septembre 2021, révélant 15 % de plasmocytes.
+Après rechute clinique le 4 février 2025, une seconde biopsie a eu lieu le 6 février 2025.
+Les bilans sanguins seront renouvelés le 20 août 2025 et le résultat sera présenté au staff hématologie le 27 août 2025.
+Une greffe autologue est envisagée autour du 15 novembre 2025.

--- a/tests/training/dataset_2/train/doc-15.ann
+++ b/tests/training/dataset_2/train/doc-15.ann
@@ -1,0 +1,4 @@
+T1	date 21 34	14 avril 1950
+T2	date 61 75	2 janvier 2025
+T3	date 135 149	4 janvier 2025
+A1	is_biopsy_date T3

--- a/tests/training/dataset_2/train/doc-15.txt
+++ b/tests/training/dataset_2/train/doc-15.txt
@@ -1,0 +1,3 @@
+Le patient est né le 14 avril 1950.
+Consultation initiale le 2 janvier 2025 pour douleurs thoraciques.
+Biopsie bronchique pratiquée le 4 janvier 2025, en salle d’endoscopie.

--- a/tests/training/dataset_2/train/doc-16.ann
+++ b/tests/training/dataset_2/train/doc-16.ann
@@ -1,0 +1,2 @@
+T1	date 26 37	8 mars 2025
+T2	date 86 97	9 mars 2025

--- a/tests/training/dataset_2/train/doc-16.txt
+++ b/tests/training/dataset_2/train/doc-16.txt
@@ -1,0 +1,3 @@
+La patiente a consulté le 8 mars 2025 pour asthénie.
+Un scanner thoracique réalisé le 9 mars 2025 a montré une masse pulmonaire.
+Aucune biopsie n’a été programmée à ce stade.

--- a/tests/training/dataset_2/train/doc-17.ann
+++ b/tests/training/dataset_2/train/doc-17.ann
@@ -1,0 +1,6 @@
+T1	date 52 63	2 juin 2019
+T2	date 101 114	15 avril 2023
+A1	is_biopsy_date T2
+T3	date 150 161	10 mai 2023
+T4	date 195 206	20 mai 2025
+A2	is_biopsy_date T4

--- a/tests/training/dataset_2/train/doc-17.txt
+++ b/tests/training/dataset_2/train/doc-17.txt
@@ -1,0 +1,4 @@
+Patient suivi pour hépatopathie chronique depuis le 2 juin 2019.
+Première biopsie hépatique faite le 15 avril 2023.
+Un traitement antiviral débuté le 10 mai 2023.
+Biopsie de contrôle réalisée le 20 mai 2025 montrant une régression de la fibrose.

--- a/tests/training/dataset_2/train/doc-18.ann
+++ b/tests/training/dataset_2/train/doc-18.ann
@@ -1,0 +1,4 @@
+T1	date 23 34	30 mai 1978
+T2	date 70 84	5 juillet 2025
+T3	date 139 143	hier
+A1	is_biopsy_date T3

--- a/tests/training/dataset_2/train/doc-18.txt
+++ b/tests/training/dataset_2/train/doc-18.txt
@@ -1,0 +1,3 @@
+La patiente est née le 30 mai 1978.
+Elle a été admise aux urgences le 5 juillet 2025 pour rectorragies.
+Une biopsie colique a été réalisée hier.

--- a/tests/training/dataset_2/train/doc-19.ann
+++ b/tests/training/dataset_2/train/doc-19.ann
@@ -1,0 +1,2 @@
+T1	date 30 42	12 juin 2025
+T2	date 79 91	22 juin 2025

--- a/tests/training/dataset_2/train/doc-19.txt
+++ b/tests/training/dataset_2/train/doc-19.txt
@@ -1,0 +1,3 @@
+Cette primipare a accouché le 12 juin 2025 sans complication.
+Elle consulte le 22 juin 2025 pour douleurs pelviennes persistantes.
+Aucun geste invasif n’a été indiqué.

--- a/tests/training/dataset_2/train/doc-2.ann
+++ b/tests/training/dataset_2/train/doc-2.ann
@@ -1,0 +1,5 @@
+T1	date 18 32	8 janvier 1967
+T2	date 68 80	janvier 2024
+T3	date 124 139	12 février 2024
+A1	is_biopsy_date T3
+T4	date 196 211	10 juillet 2025

--- a/tests/training/dataset_2/train/doc-2.txt
+++ b/tests/training/dataset_2/train/doc-2.txt
@@ -1,0 +1,3 @@
+Le patient, né le 8 janvier 1967, souffre de pancytopénie depuis le janvier 2024.
+Une biopsie médullaire a été effectuée le 12 février 2024, révélant une aplasie.
+La dernière consultation date du 10 juillet 2025.

--- a/tests/training/dataset_2/train/doc-20.ann
+++ b/tests/training/dataset_2/train/doc-20.ann
@@ -1,0 +1,4 @@
+T1	date 14 29	9 novembre 1943
+T2	date 68 80	31 août 2024
+T3	date 131 147	5 septembre 2024
+A1	is_biopsy_date T3

--- a/tests/training/dataset_2/train/doc-20.txt
+++ b/tests/training/dataset_2/train/doc-20.txt
@@ -1,0 +1,3 @@
+Patient né le 9 novembre 1943.
+Coloscopie de dépistage effectuée le 31 août 2024 révélant un polype.
+Biopsie du polype réalisée le 5 septembre 2024 avec résultat négatif.

--- a/tests/training/dataset_2/train/doc-21.ann
+++ b/tests/training/dataset_2/train/doc-21.ann
@@ -1,0 +1,4 @@
+T1	date 48 61	10 avril 2025
+T2	date 87 100	15 avril 2025
+T3	date 171 186	28 juillet 2025
+A1	is_biopsy_date T3

--- a/tests/training/dataset_2/train/doc-21.txt
+++ b/tests/training/dataset_2/train/doc-21.txt
@@ -1,0 +1,3 @@
+La patiente a découvert un nodule thyroïdien le 10 avril 2025.
+Échographie réalisée le 15 avril 2025 confirmant la lésion.
+Une biopsie à l’aiguille fine est programmée le 28 juillet 2025.

--- a/tests/training/dataset_2/train/doc-22.ann
+++ b/tests/training/dataset_2/train/doc-22.ann
@@ -1,0 +1,4 @@
+T1	date 45 58	1ᵉʳ juin 2025
+T2	date 106 117	3 juin 2025
+A1	is_biopsy_date T2
+T3	date 204 222	1ᵉʳ septembre 2025

--- a/tests/training/dataset_2/train/doc-22.txt
+++ b/tests/training/dataset_2/train/doc-22.txt
@@ -1,0 +1,3 @@
+Le patient a été vu pour une masse rénale le 1ᵉʳ juin 2025.
+Une biopsie percutanée avait été planifiée le 3 juin 2025 mais a été annulée en raison d’une amélioration clinique.
+Un contrôle IRM est fixé au 1ᵉʳ septembre 2025.

--- a/tests/training/dataset_2/train/doc-23.ann
+++ b/tests/training/dataset_2/train/doc-23.ann
@@ -1,0 +1,2 @@
+T1	date 43 58	14 février 2010
+T2	date 85 100	14 juillet 2025

--- a/tests/training/dataset_2/train/doc-23.txt
+++ b/tests/training/dataset_2/train/doc-23.txt
@@ -1,0 +1,3 @@
+Patient suivi pour diabète diagnostiqué le 14 février 2010.
+Consultation de suivi le 14 juillet 2025, HbA1c stable.
+Aucune biopsie n’est envisagée.

--- a/tests/training/dataset_2/train/doc-24.ann
+++ b/tests/training/dataset_2/train/doc-24.ann
@@ -1,0 +1,5 @@
+T1	date 17 32	20 juillet 2025
+T2	date 88 103	21 juillet 2025
+T3	date 137 152	22 juillet 2025
+A1	is_biopsy_date T3
+T4	date 224 239	24 juillet 2025

--- a/tests/training/dataset_2/train/doc-24.txt
+++ b/tests/training/dataset_2/train/doc-24.txt
@@ -1,0 +1,4 @@
+Patient admis le 20 juillet 2025 pour hémoptysie.
+Préparation pré-anesthésique faite le 21 juillet 2025.
+Biopsie pulmonaire effectuée le 22 juillet 2025 avec tolérance satisfaisante.
+Nouveau contrôle radiographique prévu le 24 juillet 2025.

--- a/tests/training/dataset_2/train/doc-3.ann
+++ b/tests/training/dataset_2/train/doc-3.ann
@@ -1,0 +1,5 @@
+T1	date 23 35	22 juin 1943
+T2	date 76 87	5 mars 2025
+T3	date 142 153	7 mars 2025
+A1	is_biopsy_date T3
+T4	date 186 200	1ᵉʳ avril 2025

--- a/tests/training/dataset_2/train/doc-3.txt
+++ b/tests/training/dataset_2/train/doc-3.txt
@@ -1,0 +1,4 @@
+La patiente est née le 22 juin 1943.
+Elle a consulté pour perte de poids le 5 mars 2025.
+Une biopsie gastrique endoscopique a été réalisée le 7 mars 2025.
+Une chimiothérapie a débuté le 1ᵉʳ avril 2025.

--- a/tests/training/dataset_2/train/doc-4.ann
+++ b/tests/training/dataset_2/train/doc-4.ann
@@ -1,0 +1,6 @@
+T1	date 18 34	11 novembre 2000
+T2	date 67 78	21 mai 2025
+T3	date 119 130	23 mai 2025
+A1	is_biopsy_date T3
+T4	date 191 202	25 mai 2025
+T5	date 217 229	10 juin 2025

--- a/tests/training/dataset_2/train/doc-4.txt
+++ b/tests/training/dataset_2/train/doc-4.txt
@@ -1,0 +1,3 @@
+Le patient, né le 11 novembre 2000, a été victime d’un accident le 21 mai 2025.
+Une biopsie cutanée a été effectuée le 23 mai 2025 pour suspicion d’infection.
+Une autre biopsie est prévue le 25 mai 2025 avec suivi le 10 juin 2025.

--- a/tests/training/dataset_2/train/doc-5.ann
+++ b/tests/training/dataset_2/train/doc-5.ann
@@ -1,0 +1,6 @@
+T1	date 17 32	14 juillet 1958
+T2	date 85 101	12 novembre 2023
+T3	date 142 156	2 janvier 2025
+T4	date 230 244	6 janvier 2025
+A1	is_biopsy_date T4
+T5	date 341 353	10 août 2025

--- a/tests/training/dataset_2/train/doc-5.txt
+++ b/tests/training/dataset_2/train/doc-5.txt
@@ -1,0 +1,4 @@
+Le patient né le 14 juillet 1958 est suivi pour une néphropathie chronique depuis le 12 novembre 2023.
+Il a été hospitalisé en néphrologie le 2 janvier 2025 pour aggravation de la créatinémie.
+Une biopsie rénale a été réalisée le 6 janvier 2025 et a confirmé la glomérulosclérose segmentaire.
+Le prochain contrôle biologique est planifié le 10 août 2025.

--- a/tests/training/dataset_2/train/doc-6.ann
+++ b/tests/training/dataset_2/train/doc-6.ann
@@ -1,0 +1,8 @@
+T1	date 28 39	9 mars 2010
+T2	date 91 106	18 février 2025
+T3	date 174 189	25 février 2025
+A1	is_biopsy_date T3
+T4	date 248 259	3 mars 2025
+A2	is_biopsy_date T4
+T5	date 329 341	17 mars 2025
+T6	date 376 388	24 mars 2025

--- a/tests/training/dataset_2/train/doc-6.txt
+++ b/tests/training/dataset_2/train/doc-6.txt
@@ -1,0 +1,4 @@
+M. L., diabétique depuis le 9 mars 2010, a consulté pour un nodule pulmonaire découvert le 18 février 2025.
+La biopsie transthoracique guidée par scanner a été programmée le 25 février 2025 mais a dû être reportée.
+Le geste a finalement eu lieu le 3 mars 2025 sans complication immédiate.
+Un contrôle radiographique est prévu le 17 mars 2025 et la consultation d’oncologie le 24 mars 2025.

--- a/tests/training/dataset_2/train/doc-7.ann
+++ b/tests/training/dataset_2/train/doc-7.ann
@@ -1,0 +1,4 @@
+T1	date 31 43	8 avril 2017
+T2	date 74 84	5 mai 2025
+T3	date 148 159	12 mai 2025
+T4	date 220 232	20 juin 2025

--- a/tests/training/dataset_2/train/doc-7.txt
+++ b/tests/training/dataset_2/train/doc-7.txt
@@ -1,0 +1,3 @@
+La patiente, greffée rénale le 8 avril 2017, a été vue en consultation le 5 mai 2025 pour bilan de suivi annuel.
+Le dosage de tacrolimus réalisé le 12 mai 2025 est dans la cible.
+L’échographie Doppler programmée pour le 20 juin 2025 surveillera la perméabilité vasculaire.

--- a/tests/training/dataset_2/train/doc-8.ann
+++ b/tests/training/dataset_2/train/doc-8.ann
@@ -1,0 +1,7 @@
+T1	date 6 23	30 septembre 1980
+T2	date 85 101	10 décembre 2024
+T3	date 151 166	15 janvier 2025
+A1	is_biopsy_date T3
+T4	date 279 293	5 juillet 2025
+A2	is_biopsy_date T4
+T5	date 348 363	29 juillet 2025

--- a/tests/training/dataset_2/train/doc-8.txt
+++ b/tests/training/dataset_2/train/doc-8.txt
@@ -1,0 +1,4 @@
+Né le 30 septembre 1980, ce patient présente des lésions cutanées évoluant depuis le 10 décembre 2024.
+Une première biopsie cutanée a été effectuée le 15 janvier 2025 et a montré une dermatite lichénienne.
+Devant la persistance des lésions, une seconde biopsie a été réalisée le 5 juillet 2025.
+Les résultats seront discutés en RCP dermatologie le 29 juillet 2025.

--- a/tests/training/dataset_2/train/doc-9.ann
+++ b/tests/training/dataset_2/train/doc-9.ann
@@ -1,0 +1,7 @@
+T1	date 39 54	19 février 2021
+T2	date 99 110	2 juin 2025
+T3	date 158 169	9 juin 2025
+A1	is_biopsy_date T3
+T4	date 248 264	1er juillet 2025
+T5	date 313 325	20 août 2025
+T6	date 360 377	15 septembre 2025

--- a/tests/training/dataset_2/train/doc-9.txt
+++ b/tests/training/dataset_2/train/doc-9.txt
@@ -1,0 +1,4 @@
+Madame V., opérée d’une mastectomie le 19 février 2021, a présenté une récidive locale détectée le 2 juin 2025.
+Une biopsie du lit tumoral a été pratiquée le 9 juin 2025 confirmant une récidive infiltrante.
+La patiente a débuté la radiothérapie le 1er juillet 2025 et recevra une chimiothérapie complémentaire le 20 août 2025.
+Un contrôle clinique est fixé au 15 septembre 2025.

--- a/tests/training/ner_qlf_diff_bert_config.yml
+++ b/tests/training/ner_qlf_diff_bert_config.yml
@@ -64,8 +64,10 @@ optimizer:
   optim: torch.optim.AdamW
   module: ${ nlp }
   groups:
-    "^transformer": false
-    ".*":
+    # Transformer
+    - selector: "ner[.]embedding[.]embedding"
+      exclude: true
+    - selector: ".*"
       lr:
           "@schedules": linear
           start_value: 1e-3

--- a/tests/training/ner_qlf_same_bert_config.yml
+++ b/tests/training/ner_qlf_same_bert_config.yml
@@ -60,8 +60,10 @@ optimizer:
   optim: AdamW
   module: ${ nlp }
   groups:
-    "^transformer": false
-    ".*":
+    # Transformer
+    - selector: "transformer"
+      exclude: true
+    - selector: ".*"
       lr: 1e-3
 
 # 📚 DATA


### PR DESCRIPTION
New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
The goal is mainly to allow more flexibility when designing the batch sizes for training span based components (eg. span classifier).
- at the moment, to allow the batch to "mix" well, the user must split the documents into smaller chunks, hoping to get at most a few entities per chunk. There is also the issue of context, as a span qualifier may want to train with a context of 30 words before/after, but if the chunks are smaller than that, the model will never see the context size that it will seing after its training (ie on non chunked docs)
- so splitting along the entities (assuming the prediction of the component on a given entity doesn't depend on the fact that another entity is annotated) allows 1/ to preserve context, 2/ mix batches correctly

**Change overview**

- Added:

  - New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
  - New `Training a span classifier` tutorial, and reorganized deep-learning docs
- `ScheduledOptimizer` now warns when a parameter selector does not match any parameter.

- Fixed:

  - We should now correctly support loading transformers in offline mode if they were already in huggingface's cache
  - We now support `words[-10:10]` syntax in trainable span classifier `context_getter` parameter
  - :ambulance: :warning: MAJOR FIX: Until now, `post_init` was applied **after** the instantiation of the optimizer : if the model discovered new labels, and therefore changed its parameter tensors to reflect that, these new tensors were not taken into account by the optimizer, which could likely lead to subpar performance. Now, `post_init` is applied **before** the optimizer is instantiated, so that the optimizer can correctly handle the new tensors.

- Changed:
  - It is now recommended to define optimizer groups of `ScheduledOptimizer` as a list of dicts of optim hyper-parameters, each containing a `selector` regex key, rather than as a single dict with a `selector` as keys and a dict of optim hyper-parameters as values. This allows for more flexibility in defining the optimizer groups, and is more consistent with the rest of the EDS-NLP API. This makes it easier to reference groups values from other places in config files, since their path doesn't contain a complex regex string anymore. See the updated training tutorials for more details.


## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
