### PR TITLE
fix: Attribute Error when tuning hyperparameters

### DIFF
--- a/edsnlp/tune.py
+++ b/edsnlp/tune.py
@@ -292,7 +292,11 @@ def objective_with_param(config, tuned_parameters, trial, metric):
         raise
     scorer = GenericScorer(**kwargs["scorer"])
     val_data = kwargs["val_data"]
-    score = scorer(nlp, val_data)
+    print(val_data)
+    # val_docs = list(chain.from_iterable(val_data))
+    val_docs = list(val_data)
+    print(val_docs)
+    score = scorer(nlp, val_docs)
     for key in metric:
         score = score[key]
     return score

--- a/tests/tuning/config.yml
+++ b/tests/tuning/config.yml
@@ -113,6 +113,14 @@ val_data:
       span_setter : 'gold_spans'
       span_attributes : ['sosy', 'unit', 'negation']
       bool_attributes : ['negation']  # default standoff to doc converter
+  '@readers': standoff
+  path: tests/training/dataset/
+  converter:
+    - '@factory': eds.standoff_dict2doc
+      span_setter : 'gold_spans'
+      span_attributes : ['sosy', 'unit', 'negation']
+      bool_attributes : ['negation']  # default standoff to doc converter
+
 
 # 🚀 TRAIN SCRIPT OPTIONS
 train:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

When performing hyperparmeter tuning with a list as val_data (for example to monitor the metrics on the training set as well as the val set during training), get an attribute error ("copy").

## Checklist


- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
