### PR TITLE
chore: bump version to 0.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.17.2
+pip install edsnlp==0.18.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.17.2"
+pip install "edsnlp[ml]==0.18.0"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## Unreleased
+## v0.18.0 (2025-07-02)
 
-## Added
+### Added
 
 - Added support for multiple loggers (`tensorboard`, `wandb`, `comet_ml`, `aim`, `mlflow`, `clearml`, `dvclive`, `csv`, `json`, `rich`) in `edsnlp.train` via the `logger` parameter. Default is [`json` and `rich`] for backward compatibility.
 - Sub batch sizes for gradient accumulation can now be defined as simple "splits" of the original batch, e.g. `batch_size = 10000 tokens` and `sub_batch_size = 5 splits` to accumulate batches of 2000 tokens.
@@ -12,7 +12,7 @@
 - New `Training a span classifier` tutorial, and reorganized deep-learning docs
 - `ScheduledOptimizer` now warns when a parameter selector does not match any parameter.
 
-## Fixed
+### Fixed
 
 - `use_section` in `eds.history` should now correctly handle cases when there are other sections following history sections.
 - Added clickable snippets in the documentation for more registered functions
@@ -22,7 +22,7 @@
 - :ambulance: Until now, `post_init` was applied **after** the instantiation of the optimizer : if the model discovered new labels, and therefore changed its parameter tensors to reflect that, these new tensors were not taken into account by the optimizer, which could likely lead to subpar performance. Now, `post_init` is applied **before** the optimizer is instantiated, so that the optimizer can correctly handle the new tensors.
 - Added missing entry points for readers and writers in the registry, including `write_parquet` and support for `polars` in `pyproject.toml`. Now all implemented readers and writers are correctly registered as entry points.
 
-## Changed
+### Changed
 
 - Sections cues in `eds.history` are now section titles, and not the full section.
 - :boom: Validation metrics are now found under the root field `validation` in the training logs (e.g. `metrics['validation']['ner']['micro']['f']`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.17.2
+pip install edsnlp==0.18.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.17.2"
+pip install "edsnlp[ml]==0.18.0"
 ```
 
 ### A first pipeline

--- a/docs/tutorials/training-ner.md
+++ b/docs/tutorials/training-ner.md
@@ -233,7 +233,7 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
     import edsnlp
     from edsnlp.training import train, ScheduledOptimizer, TrainingData
     from edsnlp.metrics.ner import NerExactMetric
-    from edsnlp.training.loggers import CSVLogger, RichLogger, WandbLogger
+    from edsnlp.training.loggers import CSVLogger, RichLogger, WandBLogger
     import edsnlp.pipes as eds
     import torch
 
@@ -242,6 +242,7 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
     nlp.add_pipe(
         # The NER pipe will be a CRF model
         eds.ner_crf(
+            name="ner",
             mode="joint",
             target_span_getter="gold_spans",
             # Set spans as both to ents and in separate `ent.label` groups
@@ -280,19 +281,21 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
         optim=torch.optim.Adam,
         module=nlp,
         total_steps=max_steps,
-        groups={
-            "^transformer": {
-                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0 "max_value": 5e-5,},
+        groups=[
+            {
+                "selector": "transformer",
+                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 0, "max_value": 5e-5,},
             },
-            "": {
-                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4 "max_value": 3e-4,},
+            {
+                "selector": ".*",
+                "lr": {"@schedules": "linear", "warmup_rate": 0.1, "start_value": 3e-4, "max_value": 3e-4,},
             },
-        },
+        ],
     )
 
     #
     loggers = [
-        CSVLogger(),
+        CSVLogger.draft(), # draft as we will let the train function specify the logging_dir
         RichLogger(
             fields={
                 "step": {},

--- a/docs/tutorials/training-span-classifier.md
+++ b/docs/tutorials/training-span-classifier.md
@@ -265,8 +265,9 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
     # 🎛️ OPTIMIZER (here it will be the same as thedefault one)
     optimizer = ScheduledOptimizer.draft(  # (2)!
         optim=torch.optim.AdamW,
-        groups={
-            "biopsy_classifier[.]embedding": {
+        groups=[
+            {
+                "selector": "biopsy_classifier[.]embedding",
                 "lr": {
                     "@schedules": "linear",
                     "warmup_rate": 0.1,
@@ -274,7 +275,8 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
                     "max_value": 5e-5,
                 },
             },
-            ".*": {
+            {
+                "selector": ".*",
                 "lr": {
                     "@schedules": "linear",
                     "warmup_rate": 0.1,
@@ -282,7 +284,7 @@ Visit the [`edsnlp.train` documentation][edsnlp.training.trainer.train] for a li
                     "max_value": 3e-4,
                 },
             },
-        }
+        ]
     )
 
     # 🚀 TRAIN

--- a/edsnlp/__init__.py
+++ b/edsnlp/__init__.py
@@ -15,7 +15,7 @@ import edsnlp.data  # noqa: F401
 import edsnlp.pipes
 from . import reducers
 
-__version__ = "0.17.2"
+__version__ = "0.18.0"
 
 BASE_DIR = Path(__file__).parent
 

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -25,8 +25,6 @@ def test_entrypoints():
 
 
 def test_readers_and_writers_entrypoints():
-    import importlib.metadata
-
     # Map of expected entry points for readers and writers
     expected_readers = {
         "spark": "from_spark",
@@ -47,9 +45,16 @@ def test_readers_and_writers_entrypoints():
         "polars": "to_polars",
         "parquet": "write_parquet",
     }
-    eps = importlib.metadata.entry_points()
-    readers = {ep.name for ep in eps.select(group="edsnlp_readers")}
-    writers = {ep.name for ep in eps.select(group="edsnlp_writers")}
+    eps = entry_points()
+    if hasattr(eps, "select"):
+        readers_eps = eps.select(group="edsnlp_readers")
+        writers_eps = eps.select(group="edsnlp_writers")
+    else:
+        readers_eps = eps.get("edsnlp_readers", [])
+        writers_eps = eps.get("edsnlp_writers", [])
+
+    readers = {ep.name for ep in readers_eps}
+    writers = {ep.name for ep in writers_eps}
     for name in expected_readers:
         assert name in readers, f"Reader entry point '{name}' is missing"
     for name in expected_writers:


### PR DESCRIPTION
## Changelog

- Added support for multiple loggers (`tensorboard`, `wandb`, `comet_ml`, `aim`, `mlflow`, `clearml`, `dvclive`, `csv`, `json`, `rich`) in `edsnlp.train` via the `logger` parameter. Default is [`json` and `rich`] for backward compatibility.
- Sub batch sizes for gradient accumulation can now be defined as simple "splits" of the original batch, e.g. `batch_size = 10000 tokens` and `sub_batch_size = 5 splits` to accumulate batches of 2000 tokens.
- Parquet writer now has a `pyarrow_write_kwargs` to pass to [pyarrow.dataset.write_dataset](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html#pyarrow-dataset-write-dataset)
- LinearSchedule (mostly used for LR scheduling) now allows a `end_value` parameter to configure if the learning rate should decay to zero or another value.
- New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
- New `Training a span classifier` tutorial, and reorganized deep-learning docs
- `ScheduledOptimizer` now warns when a parameter selector does not match any parameter.

### Fixed

- `use_section` in `eds.history` should now correctly handle cases when there are other sections following history sections.
- Added clickable snippets in the documentation for more registered functions
- Pyarrow dataset writing with multiprocessing should be faster, as we removed a useless data transfer
- We should now correctly support loading transformers in offline mode if they were already in huggingface's cache
- We now support `words[-10:10]` syntax in trainable span classifier `context_getter` parameter
- :ambulance: Until now, `post_init` was applied **after** the instantiation of the optimizer : if the model discovered new labels, and therefore changed its parameter tensors to reflect that, these new tensors were not taken into account by the optimizer, which could likely lead to subpar performance. Now, `post_init` is applied **before** the optimizer is instantiated, so that the optimizer can correctly handle the new tensors.
- Added missing entry points for readers and writers in the registry, including `write_parquet` and support for `polars` in `pyproject.toml`. Now all implemented readers and writers are correctly registered as entry points.

### Changed

- Sections cues in `eds.history` are now section titles, and not the full section.
- :boom: Validation metrics are now found under the root field `validation` in the training logs (e.g. `metrics['validation']['ner']['micro']['f']`)
- It is now recommended to define optimizer groups of `ScheduledOptimizer` as a list of dicts of optim hyper-parameters, each containing a `selector` regex key, rather than as a single dict with a `selector` as keys and a dict of optim hyper-parameters as values. This allows for more flexibility in defining the optimizer groups, and is more consistent with the rest of the EDS-NLP API. This makes it easier to reference groups values from other places in config files, since their path doesn't contain a complex regex string anymore. See the updated training tutorials for more details.

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
