### PR TITLE
Attention pooling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- New `attention` pooling mode in `eds.span_pooler`
+- New `word_pooling_mode=False` in `eds.transformer` to allow returning the worpiece embeddings directly, instead of the mean-pooled word embeddings. At the moment, this only works with `eds.span_pooler` which can pool over wordpieces or words seamlessly.
+
 ## v0.18.0 (2025-09-02)
 
 📢 EDS-NLP will drop support for Python 3.7, 3.8 and 3.9 support in the next major release (v0.19.0), in October 2025. Please upgrade to Python 3.10 or later.
@@ -13,6 +20,7 @@
 - New `eds.explode` pipe that splits one document into multiple documents, one per span yielded by its `span_getter` parameter, each new document containing exactly that single span.
 - New `Training a span classifier` tutorial, and reorganized deep-learning docs
 - `ScheduledOptimizer` now warns when a parameter selector does not match any parameter.
+- New `attention` pooling mode in `eds.span_pooler`
 
 ### Fixed
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -4,6 +4,7 @@ We provide step-by-step guides to get you started. We cover the following use-ca
 
 ### Base tutorials
 
+<!-- --8<-- [start:tutorials] -->
 <!-- --8<-- [start:classic-tutorials] -->
 
 === card {: href=/tutorials/spacy101 }
@@ -85,6 +86,8 @@ We provide step-by-step guides to get you started. We cover the following use-ca
     ---
     Quickly visualize the results of your pipeline as annotations or tables.
 
+<!-- --8<-- [end:classic-tutorials] -->
+
 ### Deep learning tutorials
 
 We also provide tutorials on how to train deep-learning models with EDS-NLP. These tutorials cover the training API, hyperparameter tuning, and more.
@@ -123,8 +126,5 @@ We also provide tutorials on how to train deep-learning models with EDS-NLP. The
     ---
     Learn how to tune hyperparameters of a model with `edsnlp.tune`.
 
-
 <!-- --8<-- [end:deep-learning-tutorials] -->
-
-
 <!-- --8<-- [end:tutorials] -->

--- a/edsnlp/pipes/trainable/embeddings/text_cnn/text_cnn.py
+++ b/edsnlp/pipes/trainable/embeddings/text_cnn/text_cnn.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 import torch
 from typing_extensions import Literal, TypedDict
@@ -86,6 +86,10 @@ class TextCnnEncoder(WordContextualizerComponent):
             residual=residual,
             normalize=normalize,
         )
+
+    def collate(self, batch: Dict[str, Any]) -> BatchInput:
+        emb = self.embedding.collate(batch["embedding"])
+        return {"embedding": emb, "out_structure": emb["out_structure"]}
 
     def forward(self, batch: BatchInput) -> WordEmbeddingBatchOutput:
         """

--- a/edsnlp/training/trainer.py
+++ b/edsnlp/training/trainer.py
@@ -849,9 +849,7 @@ def train(
                 for idx, (batch, batch_pipe_names) in enumerate(
                     zip(batches, batches_pipe_names)
                 ):
-                    cache_ctx = (
-                        nlp.cache() if len(batch_pipe_names) > 1 else nullcontext()
-                    )
+                    cache_ctx = nlp.cache()
                     no_sync_ctx = (
                         accelerator.no_sync(trained_pipes)
                         if idx < len(batches) - 1

--- a/edsnlp/tune.py
+++ b/edsnlp/tune.py
@@ -595,7 +595,7 @@ def compute_remaining_n_trials_possible(
             remaining_gpu_time, compute_time_per_trial(study, ema=True)
         )
         return n_trials
-    except ValueError:
+    except ValueError:  # pragma: no cover
         return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ docs-no-ml = [
 ml = [
     "rich-logger>=0.3.1",
     "torch>=1.13.0; python_version>='3.9'",
-    "foldedtensor>=0.4.0",
+    "foldedtensor @ git+https://github.com/aphp/foldedtensor.git@indice-mapping#egg=foldedtensor",
     "safetensors>=0.3.0; python_version>='3.8'",
     "safetensors>=0.3.0,<0.5.0; python_version<'3.8'",
     "transformers>=4.0.0",

--- a/tests/pipelines/trainable/dummy_embeddings.py
+++ b/tests/pipelines/trainable/dummy_embeddings.py
@@ -1,0 +1,123 @@
+from typing import List, Optional
+
+import pytest
+
+pytest.importorskip("torch")
+
+import foldedtensor as ft
+import torch
+from typing_extensions import Literal
+
+from edsnlp import Pipeline
+from edsnlp.pipes.trainable.embeddings.typing import WordEmbeddingComponent
+
+
+class DummyEmbeddings(WordEmbeddingComponent[dict]):
+    """
+    For each word, embedding = (word idx in sent) * [1, 1, ..., 1] (size = dim)
+    """
+
+    def __init__(
+        self,
+        nlp: Optional[Pipeline] = None,
+        name: str = "fixed_embeddings",
+        word_pooling_mode: Literal["mean", False] = "mean",
+        *,
+        dim: int,
+    ):
+        super().__init__(nlp, name)
+        self.output_size = int(dim)
+        self.word_pooling_mode = word_pooling_mode
+
+    def preprocess(self, doc, *, contexts=None, prompts=()):
+        if contexts is None:
+            contexts = [doc[:]]
+
+        inputs: List[List[List[int]]] = []
+        total = 0
+
+        for ctx in contexts:
+            words = []
+            for word in ctx:
+                subwords = []
+                for subword in word.text[::4]:
+                    subwords.append(total)
+                    total += 1
+                words.append(subwords)
+            inputs.append(words)
+
+        return {
+            "inputs": inputs,  # List[Context][Word] -> int
+        }
+
+    def collate(self, batch):
+        # Flatten indices and keep per-(sample,context) lengths to refold later
+        inputs = ft.as_folded_tensor(
+            batch["inputs"],
+            data_dims=("sample", "token"),
+            full_names=("sample", "context", "word", "token"),
+            dtype=torch.long,
+        )
+        item_indices = span_offsets = span_indices = None
+        if self.word_pooling_mode == "mean":
+            samples = torch.arange(max(inputs.lengths["sample"]))
+            words = torch.arange(max(inputs.lengths["word"]))
+            n_words = len(words)
+            n_samples = len(samples)
+            words = words[None, :].expand(n_samples, -1)
+            samples = samples[:, None].expand(-1, n_words)
+            words = words.masked_fill(
+                ~inputs.refold("sample", "word", "token").mask.any(-1), 0
+            )
+            item_indices, span_offsets, span_indices = (
+                inputs.lengths.make_indices_ranges(
+                    begins=(samples, words),
+                    ends=(samples, words + 1),
+                    indice_dims=(
+                        "sample",
+                        "word",
+                    ),
+                    return_tensors="pt",
+                )
+            )
+            span_offsets = ft.as_folded_tensor(
+                span_offsets,
+                data_dims=(
+                    "sample",
+                    "word",
+                ),
+                full_names=("sample", "context", "word"),
+                lengths=list(inputs.lengths)[0:-1],
+            )
+
+        return {
+            "out_structure": span_offsets.lengths
+            if self.word_pooling_mode == "mean"
+            else inputs.lengths,
+            "inputs": inputs,
+            "item_indices": item_indices,
+            "span_offsets": span_offsets,
+            "span_indices": span_indices,
+        }
+
+    def forward(self, batch):
+        embeddings = (
+            batch["inputs"]
+            .unsqueeze(-1)
+            .expand(-1, -1, self.output_size)
+            .to(torch.float32)
+        )
+        print("shape before pool", embeddings.shape)
+        if self.word_pooling_mode == "mean":
+            embeddings = torch.nn.functional.embedding_bag(
+                embeddings.view(-1, self.output_size),
+                batch["item_indices"],
+                offsets=batch["span_offsets"].view(-1),
+                mode="max",
+            )
+            embeddings = batch["span_offsets"].with_data(
+                embeddings.view(*batch["span_offsets"].shape, self.output_size)
+            )
+        return {
+            "embeddings": embeddings,
+        }

--- a/tests/pipelines/trainable/test_span_pooler.py
+++ b/tests/pipelines/trainable/test_span_pooler.py
@@ -1,0 +1,277 @@
+import confit.utils.random
+import pytest
+from dummy_embeddings import DummyEmbeddings
+
+import edsnlp
+import edsnlp.pipes as eds
+from edsnlp.data.converters import MarkupToDocConverter
+from edsnlp.pipes.trainable.embeddings.span_pooler.span_pooler import SpanPooler
+from edsnlp.utils.collections import batch_compress_dict, decompress_dict
+
+pytest.importorskip("torch.nn")
+
+import torch
+
+
+@pytest.mark.parametrize(
+    "word_pooling_mode,shape",
+    [
+        ("mean", (2, 5, 2)),
+        (False, (2, 6, 2)),
+    ],
+)
+def test_dummy_embeddings(word_pooling_mode, shape):
+    confit.utils.random.set_seed(42)
+    converter = MarkupToDocConverter()
+    doc1 = converter("This is a sentence.")
+    doc2 = converter("A shorter one.")
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(
+        DummyEmbeddings(dim=2, word_pooling_mode=word_pooling_mode), name="embeddings"
+    )
+    embedder: DummyEmbeddings = nlp.pipes.embeddings
+
+    prep1 = embedder.preprocess(doc1)
+    prep2 = embedder.preprocess(doc2)
+    pivoted_prep = decompress_dict(list(batch_compress_dict([prep1, prep2])))
+    batch = embedder.collate(pivoted_prep)
+    out = embedder.forward(batch)["embeddings"]
+
+    assert out.shape == shape
+
+
+@pytest.mark.parametrize("span_pooling_mode", ["max", "mean", "attention"])
+def test_span_pooler_on_words(span_pooling_mode):
+    confit.utils.random.set_seed(42)
+    converter = MarkupToDocConverter()
+    doc1 = converter("[This](ent) is [a sentence](ent). This is [small one](ent).")
+    doc2 = converter("An [even shorter one](ent) !")
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(
+        eds.span_pooler(
+            embedding=DummyEmbeddings(dim=2),
+            pooling_mode=span_pooling_mode,
+        )
+    )
+    pooler: SpanPooler = nlp.pipes.span_pooler
+
+    prep1 = pooler.preprocess(doc1, spans=doc1.ents)
+    prep2 = pooler.preprocess(doc2, spans=doc2.ents)
+    pivoted_prep = decompress_dict(list(batch_compress_dict([prep1, prep2])))
+    batch = pooler.collate(pivoted_prep)
+    out = pooler.forward(batch)["embeddings"]
+
+    assert out.shape == (4, 2)
+    out = out.refold("sample", "span")
+
+    assert out.shape == (2, 3, 2)
+    if span_pooling_mode == "attention":
+        expected = [
+            [[0.0000, 0.0000], [3.8102, 3.8102], [9.7554, 9.7554]],
+            [[3.6865, 3.6865], [0.0000, 0.0000], [0.0000, 0.0000]],
+        ]
+    elif span_pooling_mode == "mean":
+        expected = [
+            [[0.0000, 0.0000], [3.0000, 3.0000], [9.5000, 9.5000]],
+            [[2.6667, 2.6667], [0.0000, 0.0000], [0.0000, 0.0000]],
+        ]
+    elif span_pooling_mode == "max":
+        expected = [
+            [[0.0000, 0.0000], [4.0000, 4.0000], [10.0000, 10.0000]],
+            [[4.0000, 4.0000], [0.0000, 0.0000], [0.0000, 0.0000]],
+        ]
+    else:
+        raise ValueError(f"Unknown pooling mode: {span_pooling_mode}")
+    assert torch.allclose(out, torch.tensor(expected), atol=1e-4)
+
+
+@pytest.mark.parametrize("span_pooling_mode", ["max", "mean", "attention"])
+def test_span_pooler_on_tokens(span_pooling_mode):
+    confit.utils.random.set_seed(42)
+    converter = MarkupToDocConverter()
+    doc1 = converter("[This](ent) is [a sentence](ent). This is [small one](ent).")
+    doc2 = converter("An [even shorter one](ent) !")
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(
+        eds.span_pooler(
+            embedding=DummyEmbeddings(dim=2, word_pooling_mode=False),
+            pooling_mode=span_pooling_mode,
+        )
+    )
+    pooler: SpanPooler = nlp.pipes.span_pooler
+
+    prep1 = pooler.preprocess(doc1, spans=doc1.ents)
+    prep2 = pooler.preprocess(doc2, spans=doc2.ents)
+    pivoted_prep = decompress_dict(list(batch_compress_dict([prep1, prep2])))
+    batch = pooler.collate(pivoted_prep)
+    out = pooler.forward(batch)["embeddings"]
+
+    assert out.shape == (4, 2)
+    out = out.refold("sample", "span")
+
+    assert out.shape == (2, 3, 2)
+    if span_pooling_mode == "attention":
+        expected = [
+            [[0.0000, 0.0000], [3.6265, 3.6265], [9.6265, 9.6265]],
+            [[3.5655, 3.5655], [0.0000, 0.0000], [0.0000, 0.0000]],
+        ]
+    elif span_pooling_mode == "mean":
+        expected = [
+            [[0.0000, 0.0000], [3.0000, 3.0000], [9.0000, 9.0000]],
+            [[2.5000, 2.5000], [0.0000, 0.0000], [0.0000, 0.0000]],
+        ]
+    elif span_pooling_mode == "max":
+        expected = [
+            [[0.0000, 0.0000], [4.0000, 4.0000], [10.0000, 10.0000]],
+            [[4.0000, 4.0000], [0.0000, 0.0000], [0.0000, 0.0000]],
+        ]
+    else:
+        raise ValueError(f"Unknown pooling mode: {span_pooling_mode}")
+    assert torch.allclose(out, torch.tensor(expected), atol=1e-4)
+
+
+def test_span_pooler_on_flat_hf_tokens():
+    confit.utils.random.set_seed(42)
+    converter = MarkupToDocConverter()
+    doc1 = converter("[This](ent) is [a sentence](ent). This is [small one](ent).")
+    doc2 = converter("An [even](ent) [shorter one](ent) !")
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(
+        eds.span_pooler(
+            embedding=eds.transformer(
+                model="almanach/camembert-base",
+                word_pooling_mode=False,
+            ),
+            pooling_mode="mean",
+        )
+    )
+    pooler: SpanPooler = nlp.pipes.span_pooler
+
+    prep1 = pooler.preprocess(doc1, spans=doc1.ents)
+    prep2 = pooler.preprocess(doc2, spans=doc2.ents)
+    pivoted_prep = decompress_dict(list(batch_compress_dict([prep1, prep2])))
+    print(
+        nlp.pipes.span_pooler.embedding.tokenizer.convert_ids_to_tokens(
+            prep2["embedding"]["input_ids"][0]
+        )
+    )
+    # fmt: off
+    assert prep1["embedding"]["input_ids"] == [
+        [
+            17526,  # ▁This: 0  -> span 0
+            2856,  #  ▁is: 1
+            33,  #    ▁a: 2 -> span 1
+            22625,  # ▁sentence: 3 -> span 1
+            9,  #     .: 4
+            17526,  # ▁This: 5
+            2856,  #  ▁is: 6
+            52,  #    ▁s: 7 -> span 2
+            215,  #   m: 8 -> span 2
+            3645,  #  all: 9 -> span 2
+            91,  #    ▁on: 10 -> span 2
+            35,  #    e: 11 -> span 2
+            9,  #     .: 12
+        ],
+    ]
+    # '▁An', '▁', 'even', '▁short', 'er', '▁on', 'e', '▁!'
+    assert prep2["embedding"]["input_ids"] == [
+        [
+            2764,  #  ▁An: 13
+            21,  #    ▁: 14
+            15999,  # even: 15 -> span 3
+            9161,  #  short: 16 -> span 4
+            108,  #   er: 17 -> span 4
+            91,  #    ▁on: 18 -> span 4
+            35,  #    e: 19 -> span 4
+            83,  #    ▁!: 20
+        ]
+    ]
+    # fmt: on
+    batch = pooler.collate(pivoted_prep)
+    out = pooler.forward(batch)["embeddings"]
+
+    word_embeddings = pooler.embedding(batch["embedding"])["embeddings"]
+    assert word_embeddings.shape == (21, 768)
+
+    assert out.shape == (5, 768)
+
+    # item_indices: [0, 2, 3, 7, 8, 9, 10, 11, 14, 15, 16, 17, 18, 19]
+    #                -  ----  ---------------  ------  --------------
+    # span_offsets: [0, 1,    3,               8,      10]
+    # span_indices: [0, 1, 1, 2, 2, 2, 2,  2,  3,  3,  4,  4,  4,  4]
+
+    assert torch.allclose(out[0], word_embeddings[0])
+    assert torch.allclose(out[1], word_embeddings[2:4].mean(0))
+    assert torch.allclose(out[2], word_embeddings[7:12].mean(0))
+    assert torch.allclose(out[3], word_embeddings[14:16].mean(0))
+    assert torch.allclose(out[4], word_embeddings[16:20].mean(0))
+
+
+def test_span_pooler_on_pooled_hf_tokens():
+    confit.utils.random.set_seed(42)
+    converter = MarkupToDocConverter()
+    doc1 = converter("[This](ent) is [a sentence](ent). This is [small one](ent).")
+    doc2 = converter("An [even](ent) [shorter one](ent) !")
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(
+        eds.span_pooler(
+            embedding=eds.transformer(
+                model="almanach/camembert-base",
+                word_pooling_mode="mean",
+            ),
+            pooling_mode="mean",
+        )
+    )
+    pooler: SpanPooler = nlp.pipes.span_pooler
+
+    prep1 = pooler.preprocess(doc1, spans=doc1.ents)
+    prep2 = pooler.preprocess(doc2, spans=doc2.ents)
+    pivoted_prep = decompress_dict(list(batch_compress_dict([prep1, prep2])))
+    print(
+        nlp.pipes.span_pooler.embedding.tokenizer.convert_ids_to_tokens(
+            prep2["embedding"]["input_ids"][0]
+        )
+    )
+    # fmt: off
+    assert prep1["embedding"]["input_ids"] == [
+        [
+            17526,  #          ▁This: 0  -> span 0
+            2856,  #           ▁is: 1
+            33,  #             ▁a: 2 -> span 1
+            22625,  #          ▁sentence: 3 -> span 1
+            9,  #              .: 4
+            17526,  #          ▁This: 5
+            2856,  #           ▁is: 6
+            52, 215, 3645,  #  ▁s m all: 7 -> span 2
+            91, 35,  #         ▁on e: 8 -> span 2
+            9,  #              .: 9
+        ],
+    ]
+    # '▁An', '▁', 'even', '▁short', 'er', '▁on', 'e', '▁!'
+    assert prep2["embedding"]["input_ids"] == [
+        [
+            2764,  #  ▁An: 10
+            21, 15999,  #    ▁, even: 11 -> span 3
+            9161, 108, #  short er: 12 -> span 4
+            91, 35,  #    ▁on e: 13 -> span 4
+            83,  #    ▁!: 14
+        ]
+    ]
+    # fmt: on
+    batch = pooler.collate(pivoted_prep)
+    out = pooler.forward(batch)["embeddings"]
+
+    word_embeddings = pooler.embedding(batch["embedding"])["embeddings"]
+    assert word_embeddings.shape == (15, 768)
+
+    assert out.shape == (5, 768)
+
+    # item_indices: [0, 2, 3, 7, 8, 11, 12, 13]
+    #                -  ----  ----  --  ------
+    # span_offsets: [0, 1,    3,    5,  6     ]
+
+    assert torch.allclose(out[0], word_embeddings[0])
+    assert torch.allclose(out[1], word_embeddings[2:4].mean(0))
+    assert torch.allclose(out[2], word_embeddings[7:9].mean(0))
+    assert torch.allclose(out[3], word_embeddings[11])
+    assert torch.allclose(out[4], word_embeddings[12:14].mean(0))

--- a/tests/pipelines/trainable/test_span_qualifier.py
+++ b/tests/pipelines/trainable/test_span_qualifier.py
@@ -49,7 +49,10 @@ def gold():
 
 
 @pytest.mark.parametrize("with_constraints_and_not_none", [True, False])
-def test_span_qualifier(gold, with_constraints_and_not_none, tmp_path):
+@pytest.mark.parametrize("word_pooling_mode", ["mean", False])
+def test_span_qualifier(
+    gold, with_constraints_and_not_none, word_pooling_mode, tmp_path
+):
     import torch
 
     nlp = edsnlp.blank("eds")
@@ -60,6 +63,7 @@ def test_span_qualifier(gold, with_constraints_and_not_none, tmp_path):
             model="prajjwal1/bert-tiny",
             window=128,
             stride=96,
+            word_pooling_mode=word_pooling_mode,
         ),
     )
     nlp.add_pipe(
@@ -69,6 +73,8 @@ def test_span_qualifier(gold, with_constraints_and_not_none, tmp_path):
             "embedding": {
                 "@factory": "eds.span_pooler",
                 "embedding": nlp.get_pipe("transformer"),
+                "norm": "layernorm",
+                "activation": "relu",
             },
             "span_getter": ["ents", "sc"],
             "qualifiers": {"_.test_negated": True, "_.event_type": ("event",)}

--- a/tests/training/ner_qlf_same_bert_config.yml
+++ b/tests/training/ner_qlf_same_bert_config.yml
@@ -36,6 +36,7 @@ nlp:
 
       embedding:
         '@factory': eds.span_pooler
+        pooling_mode: attention
 
         embedding: # ${ nlp.components.ner.embedding }
           '@factory': eds.text_cnn


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- New `attention` pooling mode in `eds.span_pooler`
- New `word_pooling_mode=False` in `eds.transformer` to allow returning the worpiece embeddings directly, instead of the mean-pooled word embeddings. At the moment, this only works with `eds.span_pooler` which can pool over wordpieces or words seamlessly.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
