### PR TITLE
Aditionnal parameters for the edsnlp.tune function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,7 +209,7 @@ jobs:
           PYTEST_MARKERS: ${{ matrix.pytest_markers }}
           TEST_DOCS: ${{ toJSON(matrix.test_docs) }}
         run: |
-          args=(-v)
+          args=(-v --inline-durations)
 
           if [[ -n "$PYTEST_MARKERS" ]]; then
             args+=(-m "$PYTEST_MARKERS")

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - Add support for `overwrite="append"` in `edsnlp.data.write_parquet`
 - Add confidence scores to spans predicted by `eds.extractive_qa`
 - Add DVC-backed tuning support with timeout and parallel trial handling
+- Expose Optuna pruner configuration in `edsnlp.tune` via `pruner={"type": "median"/"percentile", ...}`
 - Add `use_bullet_start` and `bullet_starters` options to `eds.sentences` to treat bullet points as sentence starters after a newline
 - New `span_from_group` parameter in `eds.matcher` and `eds.contextual_matcher` to use the first capturing group in the regex instead of the full match
 - `eds.sentences` can now split on double (or more newlines), with a `hard_newline_count` parameter (e.g. 2 for two newlines), disabled by default

--- a/docs/tutorials/tuning.md
+++ b/docs/tutorials/tuning.md
@@ -87,6 +87,10 @@ tuning:
   two_phase_tuning: True
   # Metric used to evaluate trials.
   metric: "ner.micro.f"
+  # Pruning strategy for unpromising trials
+  pruner:
+    type: "median"
+    n_warmup_steps: 5
   # Hyperparameters to tune.
   hyperparameters:
 ```
@@ -99,6 +103,7 @@ Let's detail the new parameters:
 - `n_trials`: Number of training trials for tuning. If provided, it will override `gpu_hours` and tune the model for exactly `n_trial` trials.
 - `two_phase_tuning`: If True, performs a two-phase tuning. In the first phase, all hyperparameters are tuned, and in the second phase, the top half (based on importance) are fine-tuned while freezing others. By default, `two_phase_tuning` is False.
 - `metric`: Metric used to evaluate trials. It corresponds to a path in the scorer results (depending on the scorer used in the config). By default `metric` is set to "ner.micro.f".
+- `pruner` : Optuna pruner configuration to stop unpromising trials early. You can pass a string or a dictionary (e.g., `{"type": "percentile", "percentile": 25.0}`). Supported types are `"median"`, `"percentile"`, `"threshold"`, `"successive_halving"`, `"hyperband"`, and `"nop"` (to disable). By default, it uses `"median"`. Visit the [Optuna docs](https://optuna.readthedocs.io/en/stable/reference/pruners.html) for more information on each pruner's parameters.
 - `hyperparameters`: The list of hyperparameters to tune and details about their tunings. We will discuss how it work in the following section.
 
 ### 2.2. Add hyperparameters to tune
@@ -259,6 +264,7 @@ tuning:
   gpu_hours: 40.0
   two_phase_tuning: True
   metric: "ner.micro.f"
+  pruner: "median"
   hyperparameters:
     "nlp.components.ner.embedding.embedding.hidden_dropout_prob":
       alias: "hidden_dropout"

--- a/edsnlp/tune.py
+++ b/edsnlp/tune.py
@@ -30,6 +30,15 @@ from confit import Cli, Config
 from confit.utils.collections import split_path
 from confit.utils.random import set_seed
 from optuna.importance import FanovaImportanceEvaluator, get_param_importances
+from optuna.pruners import (
+    BasePruner,
+    HyperbandPruner,
+    MedianPruner,
+    NopPruner,
+    PercentilePruner,
+    SuccessiveHalvingPruner,
+    ThresholdPruner,
+)
 from optuna.samplers import TPESampler
 from pydantic import BaseModel, confloat, conint
 from ruamel.yaml import YAML
@@ -75,6 +84,39 @@ class HyperparameterConfig(BaseModel, extra="forbid"):
             dict: A dictionary representation of the hyperparameter configuration.
         """
         return self.model_dump(exclude_unset=True, exclude_defaults=True)
+
+
+PRUNER_TYPES = {
+    "median": MedianPruner,
+    "nop": NopPruner,
+    "percentile": PercentilePruner,
+    "threshold": ThresholdPruner,
+    "successive_halving": SuccessiveHalvingPruner,
+    "hyperband": HyperbandPruner,
+}
+
+
+def _build_pruner(
+    pruner_config: Optional[Dict[str, object]],
+) -> BasePruner:
+    if pruner_config is None:
+        return NopPruner()
+    if isinstance(pruner_config, str):
+        pruner_config = {"type": pruner_config}
+    if not isinstance(pruner_config, dict):
+        raise TypeError("pruner must be a dict or None")
+    pruner_type = pruner_config.get("type")
+    if not isinstance(pruner_type, str):
+        raise ValueError("pruner must include a string 'type' field")
+    try:
+        pruner_cls = PRUNER_TYPES[pruner_type]
+    except KeyError as exc:  # pragma: no cover
+        available = ", ".join(sorted(PRUNER_TYPES))
+        raise ValueError(
+            f"Unsupported pruner type {pruner_type!r}. Available types: {available}."
+        ) from exc
+    kwargs = {key: value for key, value in pruner_config.items() if key != "type"}
+    return pruner_cls(**kwargs)
 
 
 def _setup_logging():
@@ -636,16 +678,15 @@ def _monitor_metrics_file(
                     )
                 except Exception:
                     continue
-                print("Reporting", score, "at", step)
                 trial.report(score, step)
-                # if trial.should_prune():
-                #     pruned_event.set()
-                #     try:
-                #         queue.kill([entry.stash_rev])
-                #     except Exception as exc:  # pragma: no cover - best effort
-                #         logger.warning("Failed to kill pruned trial: %s", exc)
-                #     stop_event.set()
-                #     return
+                if trial.should_prune():
+                    pruned_event.set()
+                    try:
+                        queue.kill([entry.stash_rev])
+                    except Exception as exc:  # pragma: no cover - best effort
+                        logger.warning("Failed to kill pruned trial: %s", exc)
+                    stop_event.set()
+                    return
             last_len = len(entries)
         stop_event.wait(poll_interval)
 
@@ -848,6 +889,7 @@ def _optimize(
     checkpoint_dir,
     study=None,
     *,
+    pruner: Optional[Union[str, Dict[str, object]]] = "median",
     execution: Literal["inprocess", "dvc"] = "inprocess",
     phase: int = 1,
     seed: int = 42,
@@ -856,14 +898,16 @@ def _optimize(
     num_parallel_trials: int = 1,
     timeout: Optional[float] = None,
 ):
+    study_pruner = _build_pruner(pruner)
     if not study:
-        # pruner = PercentilePruner(n_startup_trials=5, n_warmup_steps=2)
         study = optuna.create_study(
             direction="maximize",
-            # pruner=pruner,
+            pruner=study_pruner,
             sampler=TPESampler(seed=random.randint(0, 2**32 - 1)),
             study_name=f"optuna-{uuid.uuid4().hex[:8]}",
         )
+    else:
+        study.pruner = study_pruner
     study_name = study.study_name
 
     def objective(trial):
@@ -1064,6 +1108,7 @@ def tune_two_phase(
     study: Optional[optuna.study.Study] = None,
     skip_phase_1: bool = False,
     timeout: Optional[float] = None,
+    pruner: Optional[Union[str, Dict[str, object]]] = "median",
     execution: Literal["inprocess", "dvc"] = "inprocess",
     seed: int = 42,
     seed_path: str = DEFAULT_TRAIN_SEED_PATH,
@@ -1110,6 +1155,18 @@ def tune_two_phase(
         Default is False.
     timeout : float, optional
         Timeout in seconds for each phase. If provided, it is applied to each phase.
+    pruner : dict, optional
+        Optuna pruner configuration. Pass None to disable pruning. The default uses
+        Optuna's MedianPruner. Visit Optuna docs for more information:
+        https://optuna.readthedocs.io/en/stable/reference/pruners.html.
+        Allowed pruner types (in `{"type": TYPE, "some_arg": ...}`) are:
+
+        - "median": MedianPruner
+        - "nop": NopPruner
+        - "percentile": PercentilePruner
+        - "threshold": ThresholdPruner
+        - "successive_halving": SuccessiveHalvingPruner
+        - "hyperband": HyperbandPruner
     execution : {"inprocess", "dvc"}, optional
         Execution backend for trials. Default is "inprocess".
     seed : int, optional
@@ -1161,6 +1218,7 @@ def tune_two_phase(
             metric_paths,
             checkpoint_dir,
             study,
+            pruner=pruner,
             execution=execution,
             phase=1,
             seed=seed,
@@ -1232,6 +1290,7 @@ def tune_two_phase(
         metric_paths,
         checkpoint_dir,
         study,
+        pruner=pruner,
         execution=execution,
         phase=2,
         seed=seed,
@@ -1269,6 +1328,7 @@ def tune(
     seed: int = 42,
     metric: Union[str, List[str]] = "ner.micro.f",
     keep_checkpoint: bool = False,
+    pruner: Optional[Union[str, Dict[str, object]]] = "median",
     execution: Literal["inprocess", "dvc"] = "inprocess",
     seed_path: str = DEFAULT_TRAIN_SEED_PATH,
     training_seeds: Optional[List[int]] = None,
@@ -1322,6 +1382,10 @@ def tune(
         Default is "ner.micro.f".
     keep_checkpoint : bool, optional
         If True, keeps the checkpoint file after tuning. Default is False.
+    pruner : dict, optional
+        Optuna pruner configuration. Pass None to disable pruning. Supported types
+        are "median", "nop", "percentile", "threshold", "successive_halving" and
+        "hyperband". The default uses Optuna's MedianPruner.
     execution : {"inprocess", "dvc"}, optional
         Execution backend for trials. Default is "inprocess".
     seed_path : str, optional
@@ -1414,6 +1478,7 @@ def tune(
                 study=study,
                 skip_phase_1=skip_phase_1,
                 timeout=phase_timeout,
+                pruner=pruner,
                 execution=execution,
                 seed=seed,
                 seed_path=seed_path,
@@ -1434,6 +1499,7 @@ def tune(
                 metric_paths,
                 checkpoint_dir,
                 study,
+                pruner=pruner,
                 execution=execution,
                 phase=1,
                 seed=seed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,15 @@ except ImportError:
     torch = None
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--inline-durations",
+        action="store_true",
+        default=False,
+        help="Append test call durations to verbose test status lines.",
+    )
+
+
 def pytest_collection_modifyitems(items):
     """Run test_docs* at the end"""
     first_tests = []
@@ -36,6 +45,40 @@ def pytest_collection_modifyitems(items):
         else:
             first_tests.append(item)
     items[:] = first_tests + last_tests
+
+
+def format_test_duration(duration):
+    if duration >= 60:
+        minutes, seconds = divmod(duration, 60)
+        return f"{int(minutes)}m{seconds:05.2f}s"
+    if duration >= 1:
+        return f"{duration:.2f}s"
+    if duration >= 0.01:
+        return f"{duration:.3f}s"
+    return f"{duration * 1000:.1f}ms"
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_report_teststatus(report, config):
+    result = yield
+
+    if (
+        not config.getoption("--inline-durations")
+        or report.when != "call"
+        or result is None
+    ):
+        return result
+
+    category, letter, word = result
+    duration_suffix = f" ({format_test_duration(report.duration)})"
+
+    if isinstance(word, tuple):
+        text, markup = word
+        word = (f"{text}{duration_suffix}", markup)
+    else:
+        word = f"{word}{duration_suffix}"
+
+    return category, letter, word
 
 
 @fixture(scope="session", params=["eds", "fr"])

--- a/tests/tuning/test_end_to_end.py
+++ b/tests/tuning/test_end_to_end.py
@@ -1,6 +1,9 @@
 import os
 import shutil
+from pathlib import Path
 
+import joblib
+import optuna
 import pytest
 
 from edsnlp.tune import tune
@@ -105,6 +108,69 @@ def test_tune(tmpdir, two_phase_tuning, n_trials, start_from_checkpoint):
             assert_results(phase_2_dir)
         else:
             assert_results(output_dir)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        shutil.rmtree(checkpoint_dir, ignore_errors=True)
+        shutil.rmtree("./artifacts", ignore_errors=True)
+
+
+def test_tune_updates_pruner_on_resume_end_to_end():
+    config_meta = {"config_path": ["tests/tuning/config.yml"]}
+    hyperparameters = {
+        "optimizer.groups.'.*'.lr.start_value": {
+            "alias": "start_value",
+            "type": "float",
+            "low": 1e-4,
+            "high": 1e-3,
+            "log": True,
+        },
+        "optimizer.groups.'.*'.lr.warmup_rate": {
+            "alias": "warmup_rate",
+            "type": "float",
+            "low": 0.0,
+            "high": 0.3,
+            "step": 0.05,
+        },
+    }
+    output_dir = "./results"
+    checkpoint_dir = "./tests/tuning/test_checkpoints"
+    checkpoint_file = os.path.join(checkpoint_dir, "study.pkl")
+    try:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+
+        tune(
+            config_meta=config_meta,
+            hyperparameters=hyperparameters,
+            output_dir=output_dir,
+            checkpoint_dir=checkpoint_dir,
+            n_trials=1,
+            seed=42,
+            metric="ner.micro.f",
+            keep_checkpoint=True,
+            pruner={"type": "median", "n_min_trials": 3},
+        )
+
+        study = joblib.load(checkpoint_file)
+        assert isinstance(study.pruner, optuna.pruners.MedianPruner)
+        assert study.pruner._n_min_trials == 3
+
+        tune(
+            config_meta=config_meta,
+            hyperparameters=hyperparameters,
+            output_dir=output_dir,
+            checkpoint_dir=checkpoint_dir,
+            n_trials=2,
+            seed=42,
+            metric="ner.micro.f",
+            pruner=None,
+        )
+
+        archived = sorted(Path(checkpoint_dir).glob("study-*.pkl"))
+        assert archived, "Expected an archived study checkpoint after tuning"
+
+        resumed_study = joblib.load(archived[-1])
+        assert isinstance(resumed_study.pruner, optuna.pruners.NopPruner)
+        assert_results(output_dir)
     finally:
         shutil.rmtree(output_dir, ignore_errors=True)
         shutil.rmtree(checkpoint_dir, ignore_errors=True)

--- a/tests/tuning/test_tuning.py
+++ b/tests/tuning/test_tuning.py
@@ -9,6 +9,7 @@ import pytest
 
 from edsnlp.tune import (
     _build_overrides,
+    _build_pruner,
     _build_worker_argv,
     _build_xp_name,
     _collect_dvc_result,
@@ -384,6 +385,7 @@ def test_monitor_metrics_file_resets_and_skips_invalid_entries():
             self.calls += 1
 
     trial = Mock()
+    trial.should_prune.return_value = False
     stop_event = FakeStopEvent()
 
     with patch(
@@ -408,6 +410,42 @@ def test_monitor_metrics_file_resets_and_skips_invalid_entries():
         )
 
     assert trial.report.call_args_list == [((0.1, 1),), ((0.2, 2),)]
+
+
+def test_monitor_metrics_file_prunes_and_kills_entry():
+    # mock test with two steps: no pruning at first, then pruning (should prune True)
+    trial = Mock()
+    trial.should_prune.side_effect = [False, True]
+    stop_event = Mock()
+    stop_event.is_set.side_effect = [False, False]
+    pruned_event = Mock()
+    queue = Mock()
+    entry = SimpleNamespace(stash_rev="rev-1")
+
+    # a bit dangerous here, if all goes well the test will stop
+    # because of pruning, other wise if an infinite loop
+    with patch(
+        "edsnlp.tune._load_metrics_entries",
+        return_value=[
+            {"step": 1, "validation": {"ner": {"micro": {"f": 0.1}}}},
+            {"step": 2, "validation": {"ner": {"micro": {"f": 0.2}}}},
+        ],
+    ):
+        _monitor_metrics_file(
+            trial=trial,
+            metric_paths=[("ner", "micro", "f")],
+            metrics_path="unused.json",
+            stop_event=stop_event,
+            pruned_event=pruned_event,
+            queue=queue,
+            entry=entry,
+            poll_interval=0.5,
+        )
+
+    assert trial.report.call_args_list == [((0.1, 1),), ((0.2, 2),)]
+    pruned_event.set.assert_called_once()
+    queue.kill.assert_called_once_with(["rev-1"])
+    stop_event.set.assert_called_once()
 
 
 def test_stop_worker_pool_handles_none_list_and_pool():
@@ -560,6 +598,25 @@ def test_handle_pruned_dvc_runs_kills_other_entries():
         _handle_pruned_dvc_runs(queue, entries, entries[1])
 
     queue.kill.assert_called_once_with(["rev-1", "rev-3"])
+
+
+# mostly for coverage
+def test_build_pruner_supports_dict_config():
+    pruner = _build_pruner(
+        {
+            "type": "median",
+            "n_startup_trials": 7,
+            "n_warmup_steps": 3,
+            "interval_steps": 2,
+            "n_min_trials": 4,
+        }
+    )
+
+    assert isinstance(pruner, optuna.pruners.MedianPruner)
+    assert pruner._n_startup_trials == 7
+    assert pruner._n_warmup_steps == 3
+    assert pruner._interval_steps == 2
+    assert pruner._n_min_trials == 4
 
 
 def test_worker_process_skips_spawn_when_worker_is_already_running(monkeypatch):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Following [issue 457](https://github.com/aphp/edsnlp/issues/457)

`edsnlp.tune` now have a new parameter `pruner`:
Optuna pruner configuration. Pass None to disable pruning. The default uses Optuna's MedianPruner. Visit [Optuna docs](https://optuna.readthedocs.io/en/stable/reference/pruners.html) for more information. Allowed pruner types (in `{"type": TYPE, "some_arg": ...}`) are:
- "median": MedianPruner
- "nop": NopPruner
- "percentile": PercentilePruner
- "threshold": ThresholdPruner
- "successive_halving": SuccessiveHalvingPruner
- "hyperband": HyperbandPruner


The default uses Optuna's MedianPruner

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
