### PR TITLE
fix: load()/load_from_huggingface() auto_update=False

### DIFF
--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -1284,7 +1284,7 @@ def load_from_huggingface(
     try:
         path = snapshot_download(
             repo_id,
-            local_files_only=True, 
+            local_files_only=True,
             token=token,
             revision=revision,
         )


### PR DESCRIPTION
## Description

BUG: With option `auto_update=False`, the `load()`/`load_from_huggingface()` functions (silently) update the model.

This is due to the 1st `snapshot_download(..., local_files_only=auto_update, ...)` call inside `load_from_huggingface()` that updates the local copy of the model (as `local_files_only` is `False`).

FIX: set `local_files_only=True` for the 1st `snapshot_download()`call.
 &rArr; it returns the current copy path (if any) or raise a `FileNotFoundError`.
So, when `auto_update=False`, if we have yet a copy of the model, it is not updated by the1st `snapshot_download()`, and the `snapshot_download()` is not called (as `path` is set).
And when `auto_update=True`, the 2nd `snapshot_download(..., local_files_only=False, ...)` is always called, so the model is updated as expected.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
