### PR TITLE
fix: take protocol into account when writing data to parquet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Use protocol-provided filesystem when writing parquet files, ie now only telling the program to write parquets to "hdfs:///users/x/y" should suffice.
+
 ## v0.20.0 (2025-12-12)
 
 ### Added

--- a/edsnlp/data/parquet.py
+++ b/edsnlp/data/parquet.py
@@ -148,7 +148,6 @@ class ParquetWriter(BatchWriter):
                 )
             for file in dataset.files:
                 self.fs.rm_file(file)
-        self.fs = filesystem
         batch_size, batch_by = Stream.validate_batching(batch_size, batch_by)
         if batch_by in ("docs", "doc", None, batchify) and batch_size is None:
             warnings.warn(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Use protocol-provided filesystem when writing parquet files, ie now only telling the program to write parquets to "hdfs:///users/x/y" should suffice.
## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
