### PR TITLE
chore: bump version to 0.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.20.0
+pip install edsnlp==0.21.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.20.0"
+pip install "edsnlp[ml]==0.21.0"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.21.0 (2026-03-26)
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.20.0
+pip install edsnlp==0.21.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.20.0"
+pip install "edsnlp[ml]==0.21.0"
 ```
 
 ### A first pipeline

--- a/edsnlp/_version.py
+++ b/edsnlp/_version.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 
 def get_version(base_version: str = __version__) -> str:


### PR DESCRIPTION
<!-- Edit the release message between the markers before merging this PR. -->
<!-- release-message:start -->
## Changelog

### Added

- Add `split_by_values` to span attribute metrics to report per-value scores for multiclass attributes.
- New `edsnlp.data.from_huggingface_dataset()` and `edsnlp.data.to_huggingface_dataset()` data connectors, with corresponding `hf_ner` and `hf_text` connectors adapted respectively for NER datasets and simple text datasets.
- Add `edsnlp.load_pipe` to load a specific component or nested subcomponent from a saved pipeline
- Add support for `overwrite="append"` in `edsnlp.data.write_parquet`
- Add confidence scores to spans predicted by `eds.extractive_qa`
- Add DVC-backed tuning support with timeout and parallel trial handling
- Expose Optuna pruner configuration in `edsnlp.tune` via `pruner={"type": "median"/"percentile", ...}`
- Add `use_bullet_start` and `bullet_starters` options to `eds.sentences` to treat bullet points as sentence starters after a newline
- New `span_from_group` parameter in `eds.matcher` and `eds.contextual_matcher` to use the first capturing group in the regex instead of the full match
- `eds.sentences` can now split on double (or more newlines), with a `hard_newline_count` parameter (e.g. 2 for two newlines), disabled by default
- We now detect quantities and their unit in cases like "Poids / IMC: 58 / 22"
- `eds.quantities` now supports prefixed inequalities such as `< 5 mg/L`
- `eds.quantities` now supports `valueless_patterns` for synthetic quantities such as `positif` / `negatif`
- `eds.quantities` table integration is more robust, including mixed value/unit layouts and units inferred from table headers

### Fixed

- Use protocol-provided filesystem when writing parquet files, ie now only telling the program to write parquets to "hdfs:///users/x/y" should suffice.
- Optimized CRF implementation (up to twice as fast end to end NER :rocket:)
- Fix average precision computation to account for the first recall step.
- In docs and test, we now use `hf-internal-testing/tiny-random-bert` instead of the outdated `prajjwal1/bert-tiny`
- Infer `LinearSchedule.max_value` from the current parameter value when omitted
- Warning messages about max tokenizer size are now suppressed, as we already handle windowing in such cases
- `eds.diabetes` now checks for surrounding negation when checking insulin dependancy
- `eds.sentences` no longer delays sentence splitting after `.{DIGIT}` patterns, preventing false splits in inputs such as `10.10.2010 : RCP`
- Fixed average precision computation:
  - base computation : the initial recall gain from 0 to the first true positive was ignored, but is now accounted for
  - and instead of being computed from the highest-probability label in `span._.prob`, which could make AP disagree with p/r/f and drop below 1 even on perfect gold to gold comparisons, we now use the actually assigned span attribute value.
- Expand the capitalized shape patterns used by `eds.sentences` to better detect sentence starts after newline tokens, including CRLF-separated lines
- Qualifier pipes now correctly take `span_getter` into account when it is passed, including when `on_ents_only=False`, instead of silently falling back to `doc.ents`
- Disorder components (e.g. `eds.peripheral_vascular_disease`) no longer raise an error in case of ill-assigned statuses
- Fixed a pattern in `eds.peripheral_vascular_disease`
- Unpickling quantities should not cause recursion error anymore

## Pull Requests
* fix: take protocol into account when writing data to parquet by @percevalw in https://github.com/aphp/edsnlp/pull/474
* Extern API fixes (torch & pandas) by @percevalw in https://github.com/aphp/edsnlp/pull/479
* Fix TensorBoard crash when logging non-scalar hyperparameters by @MukeshK17 in https://github.com/aphp/edsnlp/pull/476
* Metric qlf split by values by @percevalw in https://github.com/aphp/edsnlp/pull/485
* HF dataset integration by @marconaguib in https://github.com/aphp/edsnlp/pull/470
* Iac patch by @percevalw in https://github.com/aphp/edsnlp/pull/487
* fix: suppress long doc tokenization max size warning by @percevalw in https://github.com/aphp/edsnlp/pull/488
* fix: light negation detection for 'insulino-dependance' patterns by @percevalw in https://github.com/aphp/edsnlp/pull/489
* docs: better explanation of training vs inference pipeline by @percevalw in https://github.com/aphp/edsnlp/pull/490
* fix: correct ap computation by @percevalw in https://github.com/aphp/edsnlp/pull/491
* ci: added custom workflows to allow trusted PR to run the full PR checks by @percevalw in https://github.com/aphp/edsnlp/pull/492
* fix: support new spacy checking system by @percevalw in https://github.com/aphp/edsnlp/pull/493
* Sentencizer use better capitalization and bullet shape enhancement by @paul-bssr in https://github.com/aphp/edsnlp/pull/477
* 358 span getter argument by @percevalw in https://github.com/aphp/edsnlp/pull/494
* feat: new span_from_group param in eds.matcher and eds.contextual_matcher by @percevalw in https://github.com/aphp/edsnlp/pull/497
* feat: add hard_newline_count to eds.sentences by @percevalw in https://github.com/aphp/edsnlp/pull/496
* fix: no more delayed sentence split after a period + digit pattern by @percevalw in https://github.com/aphp/edsnlp/pull/498
* feat: basic support for key_a / key_b : val_a / val_b cases by @percevalw in https://github.com/aphp/edsnlp/pull/499
* Prevent status caused errors in disorder components and fix a pattern by @percevalw in https://github.com/aphp/edsnlp/pull/500
* Add operators, valueless quantities and better table parsing in eds.quantities by @percevalw in https://github.com/aphp/edsnlp/pull/501
* fix: support unpickling quantities by @percevalw in https://github.com/aphp/edsnlp/pull/503
* perf: don't try to torch compile crf reduce functions by @percevalw in https://github.com/aphp/edsnlp/pull/504
* Repo ci cleanup by @percevalw in https://github.com/aphp/edsnlp/pull/505
* chore(deps): bump pypa/gh-action-pypi-publish from 1.5.0 to 1.13.0 in /.github/workflows in the github_actions group across 1 directory by @dependabot[bot] in https://github.com/aphp/edsnlp/pull/444
* Aditionnal parameters for the edsnlp.tune function by @LucasDedieu in https://github.com/aphp/edsnlp/pull/458
* Release automation by @percevalw in https://github.com/aphp/edsnlp/pull/506

## New Contributors
* @MukeshK17 made their first contribution in https://github.com/aphp/edsnlp/pull/476
* @marconaguib made their first contribution in https://github.com/aphp/edsnlp/pull/470

**Full Changelog**: https://github.com/aphp/edsnlp/compare/v0.20.0...v0.21.0
<!-- release-message:end -->
