### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -338,9 +338,9 @@ jobs:
           set -euo pipefail
           vercel deploy public/ --yes --token=$VERCEL_TOKEN --archive=tgz --prod 2>&1 | tee vercel-deploy.log
 
-          URL=$(sed -nE 's/^Aliased: (https:\/\/[^ ]+).*/\1/p' vercel-deploy.log | tail -n 1)
+          URL=$(sed -nE 's/^.*Aliased[[:space:]:]+(https:\/\/[^[:space:]]+).*/\1/p' vercel-deploy.log | tail -n 1)
           if [[ -z "$URL" ]]; then
-            URL=$(sed -nE 's/^Production: (https:\/\/[^ ]+).*/\1/p' vercel-deploy.log | tail -n 1)
+            URL=$(sed -nE 's/^.*Production[[:space:]:]+(https:\/\/[^[:space:]]+).*/\1/p' vercel-deploy.log | tail -n 1)
           fi
 
           if [[ -z "$URL" ]]; then

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Changed
+
+- CoNLL infered columns warning will be a custom warning from now on
+
 ## Fixed
 
 - Fix LLM Markup Extractor to always pass an api (dummy if unset) key to its LLM backend

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Fixed
+
+- Fix LLM Markup Extractor to always pass an api (dummy if unset) key to its LLM backend
+
 ## v0.21.0 (2026-03-26)
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,15 @@
 
 ## Unreleased
 
-## Changed
+### Added
+
+- `eds.biaffine_dep_parser` now support multiple root decoding, which is mostly useful when processing sequences that contain multiple sentences
+
+### Changed
 
 - CoNLL infered columns warning will be a custom warning from now on
 
-## Fixed
+### Fixed
 
 - Fix LLM Markup Extractor to always pass an api (dummy if unset) key to its LLM backend
 

--- a/edsnlp/data/conll.py
+++ b/edsnlp/data/conll.py
@@ -33,6 +33,13 @@ DEFAULT_COLUMNS = [
 ]
 
 
+class CoNLLWarning(UserWarning):
+    pass
+
+
+warnings.filterwarnings("once", category=CoNLLWarning)
+
+
 def parse_conll(
     path: str,
     cols: Optional[List[str]] = None,
@@ -82,8 +89,9 @@ def parse_conll(
         except StopIteration:
             cols = DEFAULT_COLUMNS
             warnings.warn(
-                f"No #global.columns comment found in the CoNLL file. "
-                f"Using default {cols}"
+                f"No #global.columns comment found in the CoNLL file {path}. "
+                f"Using default {cols}",
+                CoNLLWarning,
             )
 
     doc = {"words": []}

--- a/edsnlp/pipes/llm/llm_markup_extractor/llm_markup_extractor.py
+++ b/edsnlp/pipes/llm/llm_markup_extractor/llm_markup_extractor.py
@@ -299,8 +299,16 @@ class LlmMarkupExtractor(BaseNERComponent):
         # Double check just in case, but confit should have caught this
         assert api_url is not None, "api_url must be provided"
         api_key = os.getenv("OPENAI_API_KEY", "")
-        self.client = openai.OpenAI(base_url=self.api_url, api_key=api_key)
-        self.async_client = openai.AsyncOpenAI(base_url=self.api_url, api_key=api_key)
+        self.client = openai.OpenAI(
+            base_url=self.api_url,
+            api_key=api_key or None,
+            _enforce_credentials=bool(api_key),
+        )
+        self.async_client = openai.AsyncOpenAI(
+            base_url=self.api_url,
+            api_key=api_key or None,
+            _enforce_credentials=bool(api_key),
+        )
         self.prompt = prompt
         self.api_kwargs = api_kwargs or {}
         self.max_concurrent_requests = max_concurrent_requests

--- a/edsnlp/pipes/trainable/biaffine_dep_parser/biaffine_dep_parser.py
+++ b/edsnlp/pipes/trainable/biaffine_dep_parser/biaffine_dep_parser.py
@@ -18,9 +18,11 @@ from edsnlp.utils.span_getters import SpanGetterArg, get_spans
 logger = logging.getLogger(__name__)
 
 
-# ===============================================================
-def chuliu_edmonds_one_root(scores: np.ndarray) -> np.ndarray:
+def chuliu_edmonds(scores: np.ndarray) -> np.ndarray:
     """
+    Decode a maximum spanning dependency forest, allowing multiple tokens to attach
+    to the artificial root.
+
     Shamelessly copied from
     https://github.com/hopsparser/hopsparser/blob/main/hopsparser/mst.py#L63
     All credits, Loic Grobol at Université Paris Nanterre, France, the
@@ -48,187 +50,205 @@ def chuliu_edmonds_one_root(scores: np.ndarray) -> np.ndarray:
 
     ---
 
-    Repeatedly Use the Chu‑Liu/Edmonds algorithm to find a maximum spanning
+    Parameters
+    ----------
+    scores: np.ndarray
+        A 2d numeric array such that `scores[i][j]` is the weight
+        of the `$j→i$` edge in the graph and the 0-th node is the root.
+
+    Returns
+    -------
+    np.ndarray
+        tree: a 1d integer array such that `tree[i]` is the head of the `i`-th node
+    """
+    return chuliu_edmonds_inner_(scores.astype(np.float64, copy=True))
+
+
+def tarjan_find_cycles(tree: np.ndarray) -> List[np.ndarray]:
+    """
+    Use Tarjan's SCC algorithm to find cycles in a tree.
+
+    Parameters
+    ----------
+    tree: np.ndarray
+        A 1d integer array such that `tree[i]` is the head of
+       the `i`-th node
+
+    Returns
+    -------
+    np.ndarray
+        cycles: a list of 1d bool arrays such that `cycles[i][j]` is
+        true iff the `j`-th node of `tree` is in the `i`-th cycle
+    """
+    indices = -np.ones_like(tree)
+    lowlinks = -np.ones_like(tree)
+    onstack = np.zeros_like(tree, dtype=bool)
+    stack = list()
+    # I think this is in a list to be able to mutate it in the closure, even
+    # though `nonlocal` exists
+    _index = [0]
+    cycles = []
+
+    def strong_connect(i):
+        _index[0] += 1
+        index = _index[-1]  # `_index` is of length 1 so this is also `_index[0]`???
+        indices[i] = lowlinks[i] = index - 1
+        stack.append(i)
+        onstack[i] = True
+        dependents = np.where(np.equal(tree, i))[0]
+        for j in dependents:
+            if indices[j] == -1:
+                strong_connect(j)
+                lowlinks[i] = min(lowlinks[i], lowlinks[j])
+            elif onstack[j]:
+                lowlinks[i] = min(lowlinks[i], indices[j])
+
+        # There's a cycle!
+        if lowlinks[i] == indices[i]:
+            cycle = np.zeros_like(indices, dtype=bool)
+            while stack[-1] != i:
+                j = stack.pop()
+                onstack[j] = False
+                cycle[j] = True
+            stack.pop()
+            onstack[i] = False
+            cycle[i] = True
+            if cycle.sum() > 1:
+                cycles.append(cycle)
+        return
+
+    # -------------------------------------------------------------
+    for i in range(len(tree)):
+        if indices[i] == -1:
+            strong_connect(i)
+    return cycles
+
+
+def chuliu_edmonds_inner_(scores: np.ndarray) -> np.ndarray:
+    """
+    Use the Chu-Liu/Edmonds algorithm to find a maximum spanning
+    arborescence from the weight matrix of a rooted weighted directed
+    graph.
+
+    Parameters
+    ----------
+    scores: np.ndarray
+        A 2d numeric array such that `scores[i][j]` is the
+        weight of the `$j->i$` edge in the graph and the 0-th node is the root.
+
+    Returns
+    -------
+    np.ndarray
+        A 1d integer array such that `tree[i]` is the head of the `i`-th node
+    """
+    np.fill_diagonal(scores, -float("inf"))  # prevent self-loops
+    scores[0] = -float("inf")
+    scores[0, 0] = 0
+    tree = cast(np.ndarray, np.argmax(scores, axis=1))
+    cycles = tarjan_find_cycles(tree)
+    if not cycles:
+        return tree
+    else:
+        # t = len(tree); c = len(cycle); n = len(noncycle)
+        # locations of cycle; (t) in [0,1]
+        cycle = cycles.pop()
+        # indices of cycle in original tree; (c) in t
+        cycle_locs = np.where(cycle)[0]
+        # heads of cycle in original tree; (c) in t
+        cycle_subtree = tree[cycle]
+        # scores of cycle in original tree; (c) in R
+        cycle_scores = scores[cycle, cycle_subtree]
+        # total score of cycle; () in R
+        total_cycle_score = cycle_scores.sum()
+
+        # locations of noncycle; (t) in [0,1]
+        noncycle = np.logical_not(cycle)
+        # indices of noncycle in original tree; (n) in t
+        noncycle_locs = np.where(noncycle)[0]
+
+        # scores of cycle's potential heads; (c x n) - (c) + () -> (n x c) in R
+        metanode_head_scores = (
+            scores[cycle][:, noncycle] - cycle_scores[:, np.newaxis] + total_cycle_score
+        )
+        # scores of cycle's potential dependents; (n x c) in R
+        metanode_dep_scores = scores[noncycle][:, cycle]
+        # best noncycle head for each cycle dependent; (n) in c
+        metanode_heads = np.argmax(metanode_head_scores, axis=0)
+        # best cycle head for each noncycle dependent; (n) in c
+        metanode_deps = np.argmax(metanode_dep_scores, axis=1)
+
+        # scores of noncycle graph; (n x n) in R
+        subscores = scores[noncycle][:, noncycle]
+        # expand to make space for the metanode (n+1 x n+1) in R
+        subscores = np.pad(subscores, ((0, 1), (0, 1)), "constant")
+        # set the contracted graph scores of cycle's potential
+        # heads; (c x n)[:, (n) in n] in R -> (n) in R
+        subscores[-1, :-1] = metanode_head_scores[
+            metanode_heads, np.arange(len(noncycle_locs))
+        ]
+        # set the contracted graph scores of cycle's potential
+        # dependents; (n x c)[(n) in n] in R-> (n) in R
+        subscores[:-1, -1] = metanode_dep_scores[
+            np.arange(len(noncycle_locs)), metanode_deps
+        ]
+
+        # MST with contraction; (n+1) in n+1
+        contracted_tree = chuliu_edmonds_inner_(subscores)
+        # head of the cycle; () in n
+        cycle_head = contracted_tree[-1]
+        # fixed tree: (n) in n+1
+        contracted_tree = contracted_tree[:-1]
+        # initialize new tree; (t) in 0
+        new_tree = -np.ones_like(tree)
+        # fixed tree with no heads coming from the cycle: (n) in [0,1]
+        contracted_subtree = contracted_tree < len(contracted_tree)
+        # add the nodes to the new tree (t)[(n)[(n) in [0,1]] in t]
+        # in t = (n)[(n)[(n) in [0,1]] in n] in t
+        new_tree[noncycle_locs[contracted_subtree]] = noncycle_locs[
+            contracted_tree[contracted_subtree]
+        ]
+        # fixed tree with heads coming from the cycle: (n) in [0,1]
+        contracted_subtree = np.logical_not(contracted_subtree)
+        # add the nodes to the tree (t)[(n)[(n) in [0,1]] in t]
+        # in t = (c)[(n)[(n) in [0,1]] in c] in t
+        new_tree[noncycle_locs[contracted_subtree]] = cycle_locs[
+            metanode_deps[contracted_subtree]
+        ]
+        # add the old cycle to the tree; (t)[(c) in t] in t = (t)[(c) in t] in t
+        new_tree[cycle_locs] = tree[cycle_locs]
+        # root of the cycle; (n)[() in n] in c = () in c
+        cycle_root = metanode_heads[cycle_head]
+        # add the root of the cycle to the new
+        # tree; (t)[(c)[() in c] in t] = (c)[() in c]
+        new_tree[cycle_locs[cycle_root]] = noncycle_locs[cycle_head]
+        return new_tree
+
+
+def chuliu_edmonds_one_root(scores: np.ndarray) -> np.ndarray:
+    """
+    Repeatedly use the Chu‑Liu/Edmonds algorithm to find a maximum spanning
     dependency tree from the weight matrix of a rooted weighted directed graph.
 
-    **ATTENTION: this modifies `scores` in place.**
+    Parameters
+    ----------
 
-    ## Input
+    scores: np.ndarray
+        A 2d numeric array such that `scores[i][j]` is the weight
+        of the `$j→i$` edge in the graph and the 0-th node is the root.
 
-    - `scores`: A 2d numeric array such that `scores[i][j]` is the weight
-    of the `$j→i$` edge in the graph and the 0-th node is the root.
-
-    ## Output
-
-    - `tree`: A 1d integer array such that `tree[i]` is the head of the `i`-th node
+    Returns
+    -------
+    np.ndarray
+        A 1d integer array such that `tree[i]` is the head of the `i`-th node
     """
-
-    # FIXME: we don't actually need this in CLE: we only need one critical cycle
-    def tarjan(tree: np.ndarray) -> List[np.ndarray]:
-        """Use Tarjan's SCC algorithm to find cycles in a tree
-
-        ## Input
-
-        - `tree`: A 1d integer array such that `tree[i]` is the head of
-           the `i`-th node
-
-        ## Output
-
-        - `cycles`: A list of 1d bool arrays such that `cycles[i][j]` is
-           true iff the `j`-th node of
-          `tree` is in the `i`-th cycle
-        """
-        indices = -np.ones_like(tree)
-        lowlinks = -np.ones_like(tree)
-        onstack = np.zeros_like(tree, dtype=bool)
-        stack = list()
-        # I think this is in a list to be able to mutate it in the closure, even
-        # though `nonlocal` exists
-        _index = [0]
-        cycles = []
-
-        def strong_connect(i):
-            _index[0] += 1
-            index = _index[-1]  # `_index` is of length 1 so this is also `_index[0]`???
-            indices[i] = lowlinks[i] = index - 1
-            stack.append(i)
-            onstack[i] = True
-            dependents = np.where(np.equal(tree, i))[0]
-            for j in dependents:
-                if indices[j] == -1:
-                    strong_connect(j)
-                    lowlinks[i] = min(lowlinks[i], lowlinks[j])
-                elif onstack[j]:
-                    lowlinks[i] = min(lowlinks[i], indices[j])
-
-            # There's a cycle!
-            if lowlinks[i] == indices[i]:
-                cycle = np.zeros_like(indices, dtype=bool)
-                while stack[-1] != i:
-                    j = stack.pop()
-                    onstack[j] = False
-                    cycle[j] = True
-                stack.pop()
-                onstack[i] = False
-                cycle[i] = True
-                if cycle.sum() > 1:
-                    cycles.append(cycle)
-            return
-
-        # -------------------------------------------------------------
-        for i in range(len(tree)):
-            if indices[i] == -1:
-                strong_connect(i)
-        return cycles
-
-    # TODO: split out a `contraction` function to make this more readable
-    def chuliu_edmonds(scores: np.ndarray) -> np.ndarray:
-        """Use the Chu‑Liu/Edmonds algorithm to find a maximum spanning
-        arborescence from the weight matrix of a rooted weighted directed
-        graph
-
-        ## Input
-
-        - `scores`: A 2d numeric array such that `scores[i][j]` is the
-          weight of the `$j→i$` edge in the graph and the 0-th node is the root.
-
-        ## Output
-
-        - `tree`: A 1d integer array such that `tree[i]` is the head of the `i`-th node
-        """
-        np.fill_diagonal(scores, -float("inf"))  # prevent self-loops
-        scores[0] = -float("inf")
-        scores[0, 0] = 0
-        tree = cast(np.ndarray, np.argmax(scores, axis=1))
-        cycles = tarjan(tree)
-        if not cycles:
-            return tree
-        else:
-            # t = len(tree); c = len(cycle); n = len(noncycle)
-            # locations of cycle; (t) in [0,1]
-            cycle = cycles.pop()
-            # indices of cycle in original tree; (c) in t
-            cycle_locs = np.where(cycle)[0]
-            # heads of cycle in original tree; (c) in t
-            cycle_subtree = tree[cycle]
-            # scores of cycle in original tree; (c) in R
-            cycle_scores = scores[cycle, cycle_subtree]
-            # total score of cycle; () in R
-            total_cycle_score = cycle_scores.sum()
-
-            # locations of noncycle; (t) in [0,1]
-            noncycle = np.logical_not(cycle)
-            # indices of noncycle in original tree; (n) in t
-            noncycle_locs = np.where(noncycle)[0]
-
-            # scores of cycle's potential heads; (c x n) - (c) + () -> (n x c) in R
-            metanode_head_scores = (
-                scores[cycle][:, noncycle]
-                - cycle_scores[:, np.newaxis]
-                + total_cycle_score
-            )
-            # scores of cycle's potential dependents; (n x c) in R
-            metanode_dep_scores = scores[noncycle][:, cycle]
-            # best noncycle head for each cycle dependent; (n) in c
-            metanode_heads = np.argmax(metanode_head_scores, axis=0)
-            # best cycle head for each noncycle dependent; (n) in c
-            metanode_deps = np.argmax(metanode_dep_scores, axis=1)
-
-            # scores of noncycle graph; (n x n) in R
-            subscores = scores[noncycle][:, noncycle]
-            # expand to make space for the metanode (n+1 x n+1) in R
-            subscores = np.pad(subscores, ((0, 1), (0, 1)), "constant")
-            # set the contracted graph scores of cycle's potential
-            # heads; (c x n)[:, (n) in n] in R -> (n) in R
-            subscores[-1, :-1] = metanode_head_scores[
-                metanode_heads, np.arange(len(noncycle_locs))
-            ]
-            # set the contracted graph scores of cycle's potential
-            # dependents; (n x c)[(n) in n] in R-> (n) in R
-            subscores[:-1, -1] = metanode_dep_scores[
-                np.arange(len(noncycle_locs)), metanode_deps
-            ]
-
-            # MST with contraction; (n+1) in n+1
-            contracted_tree = chuliu_edmonds(subscores)
-            # head of the cycle; () in n
-            cycle_head = contracted_tree[-1]
-            # fixed tree: (n) in n+1
-            contracted_tree = contracted_tree[:-1]
-            # initialize new tree; (t) in 0
-            new_tree = -np.ones_like(tree)
-            # fixed tree with no heads coming from the cycle: (n) in [0,1]
-            contracted_subtree = contracted_tree < len(contracted_tree)
-            # add the nodes to the new tree (t)[(n)[(n) in [0,1]] in t]
-            # in t = (n)[(n)[(n) in [0,1]] in n] in t
-            new_tree[noncycle_locs[contracted_subtree]] = noncycle_locs[
-                contracted_tree[contracted_subtree]
-            ]
-            # fixed tree with heads coming from the cycle: (n) in [0,1]
-            contracted_subtree = np.logical_not(contracted_subtree)
-            # add the nodes to the tree (t)[(n)[(n) in [0,1]] in t]
-            # in t = (c)[(n)[(n) in [0,1]] in c] in t
-            new_tree[noncycle_locs[contracted_subtree]] = cycle_locs[
-                metanode_deps[contracted_subtree]
-            ]
-            # add the old cycle to the tree; (t)[(c) in t] in t = (t)[(c) in t] in t
-            new_tree[cycle_locs] = tree[cycle_locs]
-            # root of the cycle; (n)[() in n] in c = () in c
-            cycle_root = metanode_heads[cycle_head]
-            # add the root of the cycle to the new
-            # tree; (t)[(c)[() in c] in t] = (c)[() in c]
-            new_tree[cycle_locs[cycle_root]] = noncycle_locs[cycle_head]
-            return new_tree
-
-    scores = scores.astype(np.float64)
-    tree = chuliu_edmonds(scores)
+    scores = scores.astype(np.float64, copy=True)
+    tree = chuliu_edmonds_inner_(scores)
     roots_to_try = np.where(np.equal(tree[1:], 0))[0] + 1
 
     # PW: small change here (<= instead of ==) to avoid crashes in pathological cases
     if len(roots_to_try) <= 1:
         return tree
 
-    # -------------------------------------------------------------
     def set_root(scores: np.ndarray, root: int) -> Tuple[np.ndarray, np.ndarray]:
         """Force the `root`-th node to be the only node under the root by overwriting
         the weights of the other children of the root."""
@@ -243,7 +263,7 @@ def chuliu_edmonds_one_root(scores: np.ndarray) -> np.ndarray:
     best_score, best_tree = -np.inf, None  # This is what's causing it to crash
     for root in roots_to_try:
         _scores, root_score = set_root(scores, root)
-        _tree = chuliu_edmonds(_scores)
+        _tree = chuliu_edmonds_inner_(_scores)
         tree_probs = _scores[np.arange(len(_scores)), _tree]
         tree_score = (
             (tree_probs).sum() + (root_score)
@@ -371,9 +391,10 @@ class TrainableBiaffineDependencyParser(
     labels: List[str]
         The labels to predict. The labels can also be inferred from the data during
         `nlp.post_init(...)`.
-    decoding_mode: Literal["greedy", "mst"]
+    decoding_mode: Literal["greedy", "mst", "mst_one_root"]
         Whether to decode the dependencies greedily or using the Maximum Spanning Tree
-        algorithm.
+        algorithm. The `mst` mode allows multiple tokens to attach to the artificial
+        root, while `mst_one_root` constrains the decoded tree to a single root.
 
     Authors and citation
     --------------------
@@ -395,7 +416,7 @@ class TrainableBiaffineDependencyParser(
         hidden_size: int = 128,
         dropout_p: float = 0.0,
         labels: List[str] = ["root"],
-        decoding_mode: Literal["greedy", "mst"] = "mst",
+        decoding_mode: Literal["greedy", "mst", "mst_one_root"] = "mst",
     ):
         super().__init__(nlp=nlp, name=name)
         self.embedding = embedding
@@ -661,11 +682,24 @@ class TrainableBiaffineDependencyParser(
             results["arc_labels"].detach().cpu(),
         ):
             ctx: Span
+            num_tokens = len(ctx)
+            arc_logits = arc_logits[: num_tokens + 1, : num_tokens + 1]
+            arc_labels = arc_labels[: num_tokens + 1, : num_tokens + 1]
+
             if self.decoding_mode == "greedy":
-                tail_to_head_idx = arc_logits.argmax(-1)
-            else:
+                arc_logits = np.array(arc_logits, copy=True)
+                np.fill_diagonal(arc_logits, -float("inf"))
+                arc_logits[0] = -float("inf")
+                arc_logits[0, 0] = 0
+                tail_to_head_idx = torch.as_tensor(arc_logits.argmax(-1))
+            elif self.decoding_mode == "mst":
+                tail_to_head_idx = chuliu_edmonds(arc_logits)
+                tail_to_head_idx = torch.as_tensor(tail_to_head_idx)
+            elif self.decoding_mode == "mst_one_root":
                 tail_to_head_idx = chuliu_edmonds_one_root(arc_logits)
                 tail_to_head_idx = torch.as_tensor(tail_to_head_idx)
+            else:
+                raise ValueError(f"Unknown decoding mode: {self.decoding_mode}")
 
             # lab_logits: (tail=words+1, head=words+1, labels) -> prob
             # arc_logits: (tail=words+1) -> head_idx
@@ -675,10 +709,10 @@ class TrainableBiaffineDependencyParser(
             for tail_idx, (head_idx, label) in enumerate(
                 zip(tail_to_head_idx.tolist(), labels.tolist())
             ):
-                if head_idx == 0:
+                if tail_idx == 0:
                     continue
-                head = ctx[head_idx - 1]
                 tail = ctx[tail_idx - 1]
+                head = tail if head_idx == 0 else ctx[head_idx - 1]
                 tail.head = head
                 tail.dep_ = self.labels[label]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ docs = [
     "mkdocs-eds@git+https://github.com/aphp/mkdocs-eds.git@main#egg=mkdocs-eds",
     "mike",
     "markdown-grid-tables==0.4.0",
+    "huggingface-hub>=1.19.0",
+    "hf-xet>=1.5.0",
     "edsnlp[ml]",
 ]
 dev = [
@@ -55,6 +57,8 @@ dev = [
     "pyspark<4.0.0",  # TODO: uncap when we figure out the CI issue with pyspark 4.0.0
     "polars",
     "datasets",
+    "huggingface-hub>=1.19.0",
+    "hf-xet>=1.5.0",
     "scikit-learn",
     # Packaging
     "poetry",

--- a/tests/data/test_huggingface_dataset.py
+++ b/tests/data/test_huggingface_dataset.py
@@ -10,6 +10,7 @@ from edsnlp.data.huggingface_dataset import (
 )
 
 T = TypeVar("T")
+IMDB_DATASET = "stanfordnlp/imdb"
 
 
 def test_from_huggingface_dataset_conll2003_requires_split_when_omitted():
@@ -196,14 +197,14 @@ def test_from_huggingface_dataset_imdb_requires_split_when_omitted():
     with pytest.raises(ValueError, match=r"contains multiple splits"):
         # Use empty converter string to avoid triggering converter validation.
         from_huggingface_dataset(
-            "imdb",
+            IMDB_DATASET,
             converter="",
             load_kwargs={"streaming": True},
         )
 
 
 def test_from_huggingface_dataset_imdb_yields_records_without_converter():
-    ds_dict = datasets.load_dataset("imdb", streaming=True)
+    ds_dict = datasets.load_dataset(IMDB_DATASET, streaming=True)
     stream = from_huggingface_dataset(ds_dict, split="train", converter="")
     it: Iterator[dict] = iter(stream)
 
@@ -217,7 +218,7 @@ def test_from_huggingface_dataset_imdb_yields_records_without_converter():
 def test_from_huggingface_dataset_imdb_hf_ner_converter_validation_raises():
     with pytest.raises(ValueError, match=r"Cannot find these columns.*words_column"):
         from_huggingface_dataset(
-            "imdb",
+            IMDB_DATASET,
             split="train",
             converter="hf_ner",
             load_kwargs={"streaming": True},
@@ -229,7 +230,7 @@ def test_from_huggingface_dataset_imdb_hf_text_converter_produces_docs():
 
     nlp = edsnlp.blank("eds")
     stream = from_huggingface_dataset(
-        "imdb",
+        IMDB_DATASET,
         split="train",
         converter="hf_text",
         nlp=nlp,
@@ -254,7 +255,7 @@ def test_from_huggingface_dataset_imdb_hf_text_converter_shuffle_reproducibility
 
     nlp = edsnlp.blank("eds")
     stream1 = from_huggingface_dataset(
-        "imdb",
+        IMDB_DATASET,
         split="train",
         converter="hf_text",
         nlp=nlp,
@@ -264,7 +265,7 @@ def test_from_huggingface_dataset_imdb_hf_text_converter_shuffle_reproducibility
     )
 
     stream2 = from_huggingface_dataset(
-        "imdb",
+        IMDB_DATASET,
         split="train",
         converter="hf_text",
         nlp=nlp,
@@ -326,7 +327,7 @@ def test_huggingface_dataset_imdb_roundtrip():
 
     nlp = edsnlp.blank("eds")
     stream = from_huggingface_dataset(
-        "imdb",
+        IMDB_DATASET,
         split="train",
         converter="hf_text",
         nlp=nlp,

--- a/tests/data/test_huggingface_dataset.py
+++ b/tests/data/test_huggingface_dataset.py
@@ -13,14 +13,36 @@ T = TypeVar("T")
 IMDB_DATASET = "stanfordnlp/imdb"
 
 
-def test_from_huggingface_dataset_conll2003_requires_split_when_omitted():
+def test_from_huggingface_dataset_requires_split_when_omitted():
+    ds_dict = datasets.DatasetDict(
+        {
+            "train": datasets.Dataset.from_dict({"text": ["train"]}),
+            "test": datasets.Dataset.from_dict({"text": ["test"]}),
+        }
+    )
+
     with pytest.raises(ValueError, match=r"contains multiple splits"):
         # Use empty converter string to avoid triggering converter validation.
         from_huggingface_dataset(
-            "lhoestq/conll2003",
+            ds_dict,
             converter="",
-            load_kwargs={"streaming": True},
         )
+
+
+def test_from_huggingface_dataset_allows_omitted_split_for_single_dataset(
+    monkeypatch,
+):
+    hf_dataset = datasets.Dataset.from_dict({"text": ["hello"]})
+
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset",
+        lambda *args, **kwargs: hf_dataset,
+    )
+
+    stream = from_huggingface_dataset("single-split-dataset", converter="")
+
+    assert next(iter(stream)) == {"text": "hello"}
 
 
 def test_from_huggingface_dataset_conll2003_from_dataset_wrong_split_name():
@@ -191,16 +213,6 @@ def test_from_huggingface_dataset_conll2003_hf_ner_converter_shuffle_reproducibi
         assert isinstance(doc2, Doc)
         assert doc1.text == doc2.text
         assert [ent.label_ for ent in doc1.ents] == [ent.label_ for ent in doc2.ents]
-
-
-def test_from_huggingface_dataset_imdb_requires_split_when_omitted():
-    with pytest.raises(ValueError, match=r"contains multiple splits"):
-        # Use empty converter string to avoid triggering converter validation.
-        from_huggingface_dataset(
-            IMDB_DATASET,
-            converter="",
-            load_kwargs={"streaming": True},
-        )
 
 
 def test_from_huggingface_dataset_imdb_yields_records_without_converter():

--- a/tests/pipelines/trainable/test_biaffine_dep_parser.py
+++ b/tests/pipelines/trainable/test_biaffine_dep_parser.py
@@ -1,0 +1,54 @@
+# ruff:noqa:E402
+import numpy as np
+import pytest
+from spacy.tokens import Doc
+from spacy.vocab import Vocab
+
+pytestmark = pytest.mark.ml
+
+torch = pytest.importorskip("torch")
+
+from edsnlp.pipes.trainable.biaffine_dep_parser.biaffine_dep_parser import (
+    TrainableBiaffineDependencyParser,
+    chuliu_edmonds,
+    chuliu_edmonds_one_root,
+)
+
+
+def test_chuliu_edmonds_allows_multiple_roots():
+    scores = np.array(
+        [
+            [0.0, -10.0, -10.0],
+            [5.0, 0.0, 1.0],
+            [4.0, 1.0, 0.0],
+        ]
+    )
+
+    assert chuliu_edmonds(scores).tolist() == [0, 0, 0]
+    assert chuliu_edmonds_one_root(scores).tolist() == [0, 0, 1]
+    assert scores[1, 0] == 5.0
+
+
+def test_biaffine_dep_parser_postprocess_assigns_root_arcs():
+    doc = Doc(Vocab(), words=["a", "b"])
+    parser = TrainableBiaffineDependencyParser.__new__(
+        TrainableBiaffineDependencyParser
+    )
+    parser.decoding_mode = "mst"
+    parser.labels = ["root"]
+
+    arc_logits = torch.full((1, 3, 3), -10.0)
+    arc_logits[0, 0, 0] = 0.0
+    arc_logits[0, 1, 0] = 5.0
+    arc_logits[0, 2, 0] = 4.0
+    results = {
+        "arc_logits": arc_logits,
+        "arc_labels": torch.zeros((1, 3, 3), dtype=torch.long),
+    }
+
+    parser.postprocess([doc], results, [{"$contexts": [doc[:]]}])
+
+    assert doc[0].head == doc[0]
+    assert doc[0].dep_ == "root"
+    assert doc[1].head == doc[1]
+    assert doc[1].dep_ == "root"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- `eds.biaffine_dep_parser` now support multiple root decoding, which is mostly useful when processing sequences that contain multiple sentences

### Changed

- CoNLL infered columns warning will be a custom warning from now on

### Fixed

- Fix LLM Markup Extractor to always pass an api (dummy if unset) key to its LLM backend
## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
