### PR TITLE
chore: bump version to 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```shell
-pip install edsnlp==0.21.0
+pip install edsnlp==0.22.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```shell
-pip install "edsnlp[ml]==0.21.0"
+pip install "edsnlp[ml]==0.22.0"
 ```
 
 ### A first pipeline

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.22.0 (2026-06-17)
 
 ### Added
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@ Check out our interactive [demo](https://aphp.github.io/edsnlp/demo/) !
 You can install EDS-NLP via `pip`. We recommend pinning the library version in your projects, or use a strict package manager like [Poetry](https://python-poetry.org/).
 
 ```{: data-md-color-scheme="slate" }
-pip install edsnlp==0.21.0
+pip install edsnlp==0.22.0
 ```
 
 or if you want to use the trainable components (using pytorch)
 
 ```{: data-md-color-scheme="slate" }
-pip install "edsnlp[ml]==0.21.0"
+pip install "edsnlp[ml]==0.22.0"
 ```
 
 ### A first pipeline

--- a/edsnlp/_version.py
+++ b/edsnlp/_version.py
@@ -4,7 +4,7 @@ import subprocess
 from importlib import metadata
 from pathlib import Path
 
-_BASE_VERSION = "0.21.0"
+_BASE_VERSION = "0.22.0"
 
 
 def get_version(base_version: str = _BASE_VERSION) -> str:

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -72,7 +72,7 @@ def run(
 def normalize_version(version: str) -> str:
     if not re.fullmatch(r"\d+\.\d+\.\d+", version):
         raise ReleaseError(
-            f"Invalid version '{version}'. Expected a semantic version like 0.21.0."
+            f"Invalid version '{version}'. Expected a semantic version like 0.22.0."
         )
     return version
 
@@ -385,7 +385,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "version",
         nargs="?",
-        help="Target version, for example 0.21.0",
+        help="Target version, for example 0.22.0",
     )
     parser.add_argument(
         "--bump",


### PR DESCRIPTION
<!-- Edit the release message between the markers before merging this PR. -->
<!-- release-message:start -->
## Changelog

### Added

- `eds.biaffine_dep_parser` now support multiple root decoding, which is mostly useful when processing sequences that contain multiple sentences

### Changed

- CoNLL infered columns warning will be a custom warning from now on

### Fixed

- Fix LLM Markup Extractor to always pass an api (dummy if unset) key to its LLM backend
- Installing EDS-NLP from a repo clone will now automatically add a `dev.<hash>` suffix to the installed package version

## Pull Requests
* Various fixes by @percevalw in https://github.com/aphp/edsnlp/pull/508
* fix: add suffix to dev version and open new release PR if existing is closed by @percevalw in https://github.com/aphp/edsnlp/pull/510


**Full Changelog**: https://github.com/aphp/edsnlp/compare/v0.21.0...v0.22.0
<!-- release-message:end -->
