### PR TITLE
fix: make minute_pattern and second_pattern match 00 consistently (Fixes #516)

### DIFF
--- a/edsnlp/pipes/misc/dates/patterns/atomic/time.py
+++ b/edsnlp/pipes/misc/dates/patterns/atomic/time.py
@@ -1,10 +1,10 @@
 hour_pattern = r"(?<!\d)(?P<hour>0?[0-9]|1\d|2[0-3])(?!\d)"
 lz_hour_pattern = r"(?<!\d)(?P<hour>0[1-9]|[12]\d|3[01])(?!\d)"
 
-minute_pattern = r"(?<!\d)(?P<minute>0?[1-9]|[1-5]\d)(?!\d)"
+minute_pattern = r"(?<!\d)(?P<minute>0?[0-9]|[1-5]\d)(?!\d)"
 lz_minute_pattern = r"(?<!\d)(?P<minute>0[0-9]|[1-5]\d)(?!\d)"
 
-second_pattern = r"(?<!\d)(?P<second>0?[1-9]|[1-5]\d)(?!\d)"
+second_pattern = r"(?<!\d)(?P<second>0?[0-9]|[1-5]\d)(?!\d)"
 lz_second_pattern = r"(?<!\d)(?P<second>0[0-9]|[1-5]\d)(?!\d)"
 
 # The time pattern is always optional


### PR DESCRIPTION
Fixes #516

## Problem
`minute_pattern` and `second_pattern` in `edsnlp/pipes/misc/dates/patterns/atomic/time.py` don't match `00`, unlike their `lz_` counterparts:
- `minute_pattern`: `0?[1-9]` → `00` excluded
- `lz_minute_pattern`: `0[0-9]` → `00` included
- `second_pattern`: `0?[1-9]` → `00` excluded
- `lz_second_pattern`: `0[0-9]` → `00` included

While `minute_pattern` and `second_pattern` are currently unused in the main codebase, they're public module-level constants that could be imported and used. Their inconsistency with the `lz_` variants is a latent source of bugs.

## Solution
Change `0?[1-9]` to `0?[0-9]` in both `minute_pattern` and `second_pattern` to be consistent with `lz_minute_pattern` and `lz_second_pattern`.

## Verification
- Verified syntax with `ast.parse()`
- Manual regex testing confirms `minute_pattern` now matches `00`:
  ```python
  >>> re.match(minute_pattern, "00")
  <re.Match object>
  >>> re.match(second_pattern, "00")
  <re.Match object>
  ```

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-07-02 | Fixed minute_pattern and second_pattern to match 00 consistently | rtmalikian |

### Files Changed
- `edsnlp/pipes/misc/dates/patterns/atomic/time.py` — Changed `0?[1-9]` to `0?[0-9]` in `minute_pattern` and `second_pattern`

### Verification
- Syntax check passes
- Regex patterns now consistently match `00` across all minute/second variants

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **deepseek-v4-pro** (DeepSeek) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
