### PR TITLE
Split packaging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `edsnlp.package` now supports `code="dependency"` and `code="none"` to build model packages without embedding project code, which is better for model finetuning with custom code, since finetuned models only require the custom code and not the original model weights. Dependency mode infers the project package requirement from `pyproject.toml` and can check the selected uv index for unreleased local code changes.
+
 ### Changed
 
 - Rewrite the `eds.tnm` regex, which now covers more staging notations and rejects most lookalike abbreviations. Qualified against annotations from two physicians: precision 98.64% ± 1% (95% CI), entity-level recall 79.40% ± 1% (99% CI), document-level recall 95.53% ± 1% (99% CI)

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - **Breaking**: rename and extend the `TNM` model fields (`prefix` → `tumour_prefix`, `resection_completeness` → `resection`, one `_prefix`/`_specification`/`_suffix` set per component), which are now plain strings instead of enums. The renamed fields keep a deprecated alias — see the migration guide on the `eds.tnm` documentation page
 - Add a `banned_words` parameter to `eds.tnm` to configure the post-filter that drops lookalike abbreviations (`MTX`, `atom`, ...)
 - `TNM.norm()` no longer concatenates free-text suffixes verbatim, so `span.kb_id_` stays usable for grouping: only suffixes that read as a TNM qualifier are kept (`pT1(m)` → `pT1m`, whereas `pT1(grade 2)N1M0` used to normalise to `pT1grade 2N1M0`). The `o` → `0` coercion is likewise restricted to the numeric stage fields, so a suffix such as `(foie)` is no longer stored as `f0ie`
+- `edsnlp.package` now only supports PEP 621 projects, old style poetry packaging support has been removed.
 
 ### Fixed
 

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -157,7 +157,7 @@ nlp = edsnlp.load("path/to/your/model")
 
 ## Sharing a pipeline
 
-To share the pipeline and turn it into a pip installable package, you can use the `package` method, which will use or create a pyproject.toml file, fill it accordingly, and create a wheel file. At the moment, we only support the poetry package manager.
+To share the pipeline and turn it into a pip installable package, you can use the `package` method, which will use or create a PEP 621 pyproject.toml file, fill it accordingly, and create a wheel file.
 
 ```{ .python .no-check }
 nlp.package(

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -157,19 +157,96 @@ nlp = edsnlp.load("path/to/your/model")
 
 ## Sharing a pipeline
 
-To share the pipeline and turn it into a pip installable package, you can use the `package` method, which will use or create a PEP 621 pyproject.toml file, fill it accordingly, and create a wheel file.
+To share a pipeline, save the model artifacts and turn them into a pip installable
+model package.
 
-```{ .python .no-check }
-nlp.package(
-    name="your-package-name",  # leave None to reuse name in pyproject.toml
-    version="0.0.1",
-    root_dir="path/to/project/root",  # optional, to retrieve an existing pyproject.toml file
-    # if you don't have a pyproject.toml, you can provide the metadata here instead
-    metadata=dict(
-        authors="Firstname Lastname <your.email@domain.fr>",
-        description="A short description of your package",
-    ),
-)
+=== "Python"
+
+    ```{ .python .no-check }
+    nlp.package(
+        name="your-package-name",  # leave None to reuse name in pyproject.toml
+        version="0.0.1",
+        root_dir="path/to/project/root",  # optional, to retrieve an existing pyproject.toml file
+        # if you don't have a pyproject.toml, you can provide the metadata here instead
+        metadata=dict(
+            authors="Firstname Lastname <your.email@domain.fr>",
+            description="A short description of your package",
+        ),
+    )
+    ```
+
+=== "CLI"
+
+    ```{ .bash data-md-color-scheme="slate" }
+    python -m edsnlp.package path/to/your/model \
+      --name your-package-name \
+      --version 0.0.1
+    ```
+
+This creates a wheel file in the `dist` folder.
+
+### Models with custom code
+
+If your model uses custom project code, for instance a new torch component, the
+recommended release layout is to keep project code and model weights in separate
+packages.
+
+- the project package contains custom pipes and factories
+- the model package contains the saved artifacts and a generated `load` function
+- the model package depends on the project package
+
+Release the code package through your normal project release process before
+publishing the model package. Then package the model with dependency mode.
+
+=== "Python"
+
+    ```{ .python .no-check }
+    nlp.package(
+        name="eds-coding-aphp",
+        version="2026.7.4",
+        root_dir="path/to/project/root",
+        code="dependency",
+        code_check="error",
+        publish_index="gitlab",
+    )
+    ```
+
+=== "CLI"
+
+    ```{ .bash data-md-color-scheme="slate" }
+    python -m edsnlp.package artifacts/model-last \
+      --name eds-coding-aphp \
+      --version 2026.7.4 \
+      --code dependency \
+      --code-check error \
+      --publish-index gitlab
+    ```
+
+EDS-NLP infers the project dependency from `pyproject.toml`, for example
+`eds-coding>=1.4,<1.5` for `eds-coding` version `1.4.0`. You can override this
+with `code_dependency` if needed. With uv, a private index can be declared in
+`pyproject.toml`.
+
+
+```toml
+[[tool.uv.index]]
+name = "gitlab"
+url = "https://gitlab.example/api/v4/projects/123/packages/pypi/simple"
+publish-url = "https://gitlab.example/api/v4/projects/123/packages/pypi"
+explicit = true
 ```
 
-This will create a wheel file in the root_dir/dist folder, which you can share and install with pip.
+```{ .bash data-md-color-scheme="slate" }
+uv publish --index gitlab dist/eds_coding_aphp-2026.7.4-py3-none-any.whl
+```
+
+When `--publish-index` is set, `--code-check warn` or `--code-check error`
+checks that the inferred code dependency is available on that index. It also
+compares the registry wheel with the local project package files, so unreleased
+local code changes are reported before the model package is built.
+
+Use `code="embed"` for a self contained model package that bundles custom code
+with the weights. Avoid it for models that will be fine tuned and redistributed,
+because downstream packages can end up depending on obsolete base model weights.
+Use `code="none"` only when the runtime environment already provides every
+custom factory needed by the model.

--- a/docs/tutorials/training-ner.md
+++ b/docs/tutorials/training-ner.md
@@ -378,7 +378,7 @@ for ent in doc.ents:
 To package the model and share it with friends or family (if the model does not contain sensitive data), you can use the following command:
 
 ```{ .bash data-md-color-scheme="slate" }
-python -m edsnlp.package --pipeline artifacts/model-last/ --name my_ner_model --distributions sdist
+python -m edsnlp.package --pipeline artifacts/model-last/ --name my_ner_model
 ```
 
 *Parametrize either via the CLI or in `config.yml` under `[package]`.*
@@ -386,5 +386,12 @@ python -m edsnlp.package --pipeline artifacts/model-last/ --name my_ner_model --
 The model saved at the train script output path (`artifacts/model-last`) will be named `my_ner_model` and will be saved in the `dist` folder. You can upload it to a package registry or install it directly with
 
 ```{ .bash data-md-color-scheme="slate" }
-pip install dist/my_ner_model-0.1.0.tar.gz
+pip install dist/my_ner_model-0.1.0-py3-none-any.whl
 ```
+
+!!! note "Custom code"
+
+    If your model uses custom project code, for instance a new torch component,
+    release that project code first and package the model with `--code dependency`.
+    See [Sharing a pipeline](../concepts/pipeline.md#sharing-a-pipeline) for the
+    recommended release layout.

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -999,7 +999,7 @@ class Pipeline(Validated):
         dist_dir: Union[str, Path] = "dist",
         artifacts_name: str = "artifacts",
         check_dependencies: bool = False,
-        project_type: Optional[Literal["poetry", "setuptools"]] = None,
+        project_type: Optional[Literal["setuptools"]] = None,
         version: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = {},
         distributions: Optional[AsList[Literal["wheel", "sdist"]]] = ["wheel"],

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -1007,6 +1007,10 @@ class Pipeline(Validated):
         isolation: bool = True,
         skip_build_dependency_check: bool = False,
         readme_replacements: Dict[str, str] = {},
+        code: Literal["embed", "dependency", "none"] = "embed",
+        code_dependency: Optional[str] = None,
+        code_check: Literal["off", "warn", "error"] = "warn",
+        publish_index: Optional[str] = None,
     ):
         from edsnlp.package import package
 
@@ -1026,6 +1030,10 @@ class Pipeline(Validated):
             isolation=isolation,
             skip_build_dependency_check=skip_build_dependency_check,
             readme_replacements=readme_replacements,
+            code=code,
+            code_dependency=code_dependency,
+            code_check=code_check,
+            publish_index=publish_index,
         )
 
     if TYPE_CHECKING:

--- a/edsnlp/package.py
+++ b/edsnlp/package.py
@@ -1,11 +1,16 @@
+import json
 import os
 import re
 import shutil
 import sys
 import tempfile
 import warnings
+import zipfile
+from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, Union
+from urllib.parse import unquote, urljoin, urlparse
+from urllib.request import urlopen
 
 import build
 import confit
@@ -14,6 +19,8 @@ import toml
 from build.__main__ import build_package, build_package_via_sdist
 from confit import Cli
 from loguru import logger
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name, parse_wheel_filename
 from typing_extensions import Literal
 
 import edsnlp
@@ -80,6 +87,7 @@ def load(
 """
 
 AUTHOR_REGEX = re.compile(r"(?P<name>.*) <(?P<email>.*)>")
+HREF_REGEX = re.compile(r"""href=["']([^"']+)["']""", flags=re.IGNORECASE)
 
 
 def parse_authors(authors):
@@ -100,6 +108,129 @@ def replace_with_dict(content: str, replacements: dict):
     return content
 
 
+def build_minor_range_dependency(name: str, version: str):
+    """
+    Build the default project code dependency used by dependency mode.
+    The returned requirement is written to the model package metadata.
+    """
+    release = version.split("+", 1)[0].split("-", 1)[0].split(".")
+    try:
+        major = int(release[0])
+        minor = int(release[1])
+    except (IndexError, ValueError) as e:  # pragma: no cover
+        raise ValueError(
+            f"Cannot infer a minor dependency range from version {version!r}."
+        ) from e
+    return f"{name}>={major}.{minor},<{major}.{minor + 1}"
+
+
+def resolve_simple_index_wheel(index_url: str, requirement: Requirement):
+    """
+    Find the newest wheel from a simple index that satisfies the code dependency.
+    The package command uses the returned URL to compare registry and local code.
+    """
+    if requirement.url:  # pragma: no cover
+        return requirement.url
+    package_url = urljoin(
+        index_url.rstrip("/") + "/",
+        canonicalize_name(requirement.name) + "/",
+    )
+    try:
+        parsed = urlparse(package_url)
+        if parsed.scheme == "file":
+            path = Path(unquote(parsed.path))
+            content = (
+                (path / "index.html").read_text() if path.is_dir() else path.read_text()
+            )
+        else:  # pragma: no cover
+            with urlopen(package_url) as response:
+                content = response.read().decode()
+    except Exception:  # pragma: no cover
+        return None
+    candidates = []
+    for href in HREF_REGEX.findall(content):
+        filename = Path(unquote(urlparse(href).path)).name
+        try:
+            wheel_name, wheel_version, _, _ = parse_wheel_filename(filename)
+        except Exception:
+            continue
+        if wheel_name != canonicalize_name(requirement.name):
+            continue
+        if requirement.specifier and wheel_version not in requirement.specifier:
+            continue
+        candidates.append((wheel_version, urljoin(package_url, href)))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def compare_registry_wheel_with_local_code(
+    wheel_url: str,
+    root_dir: Path,
+    pyproject: Dict[str, Any],
+):
+    """
+    Compare project package files from the registry wheel and local checkout.
+    The package command uses returned differences to warn about unreleased code.
+    """
+    parsed = urlparse(wheel_url)
+    if parsed.scheme == "file":
+        data = Path(unquote(parsed.path)).read_bytes()
+    else:  # pragma: no cover
+        with urlopen(wheel_url) as response:
+            data = response.read()
+
+    find = dict(
+        pyproject.get("tool", {})
+        .get("setuptools", {})
+        .get("packages", {})
+        .get("find", {})
+    )
+    where = find.pop("where", ["."])
+    where = [where] if not isinstance(where, list) else where
+    package_roots = {}
+    for w in where:
+        source_root = root_dir / w
+        for package in setuptools.find_packages(source_root, **find):
+            package_roots[package] = source_root / Path(package.replace(".", "/"))
+
+    local_files = {}
+    for package, package_dir in package_roots.items():
+        for path in package_dir.rglob("*"):
+            if (
+                "__pycache__" in path.parts
+                or ".ipynb_checkpoints" in path.parts
+                or path.is_dir()
+                or path.suffix in {".pyc", ".pyo"}
+            ):
+                continue
+            wheel_path = Path(package.replace(".", "/")) / path.relative_to(package_dir)
+            local_files[str(wheel_path)] = path.read_bytes()
+
+    differences = []
+    with zipfile.ZipFile(BytesIO(data)) as zf:
+        names = set(zf.namelist())
+        for path, content in sorted(local_files.items()):
+            if path not in names:
+                differences.append(f"{path} is missing from the registry wheel")
+                continue
+            if zf.read(path) != content:
+                differences.append(f"{path} differs from the registry wheel")
+    return differences
+
+
+def handle_code_check(message: str, code_check: str):
+    """
+    Apply the selected code check policy to a packaging problem.
+    The package command uses this to turn checks into warnings or errors.
+    """
+    if code_check == "off":  # pragma: no cover
+        return
+    if code_check == "error":
+        raise RuntimeError(message)
+    warnings.warn(message, UserWarning)
+
+
 class Packager:
     def __init__(
         self,
@@ -115,6 +246,11 @@ class Packager:
         exclude: AsList[str],
         readme_replacements: Dict[str, str] = {},
         file_paths: Sequence[Path],
+        code: Literal["embed", "dependency", "none"],
+        code_dependency: Optional[str] = None,
+        code_check: Literal["off", "warn", "error"] = "warn",
+        publish_index: Optional[str] = None,
+        code_metadata: Optional[Dict[str, Any]] = None,
     ):
         self.name = name
         self.version = version
@@ -131,6 +267,11 @@ class Packager:
         self.exclude = exclude
         self.file_paths = file_paths
         self.pyproject = pyproject
+        self.code = code
+        self.code_dependency = code_dependency
+        self.code_check = code_check
+        self.publish_index = publish_index
+        self.code_metadata = code_metadata or {}
 
         logger.info(f"root_dir: {root_dir}")
         logger.info(f"artifacts_name: {artifacts_name}")
@@ -193,6 +334,12 @@ class Packager:
         else:
             self.pipeline.to_disk(build_artifacts_dir, exclude=set())
 
+        if self.code_metadata:
+            meta_path = build_artifacts_dir / "meta.json"
+            meta = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+            meta.setdefault("packaging", {})["code"] = self.code_metadata
+            meta_path.write_text(json.dumps(meta, indent=2))
+
         # After building wheel, artifacts will be placed inside the
         # package dir, not next to it as in source distribution so
         # we let the load script test both locations
@@ -231,12 +378,31 @@ class SetuptoolsPackager(Packager):
         metadata: Optional[Dict[str, Any]] = {},
         exclude: AsList[str],
         readme_replacements: Dict[str, str] = {},
+        code: Literal["embed", "dependency", "none"] = "embed",
+        code_dependency: Optional[str] = None,
+        code_check: Literal["off", "warn", "error"] = "warn",
+        publish_index: Optional[str] = None,
     ):
         try:
             version = version or pyproject["project"]["version"]
         except (KeyError, TypeError):
             version = "0.1.0"
         name = name or pyproject["project"]["name"]
+        code_project_name = (
+            pyproject["project"]["name"] if pyproject is not None else None
+        )
+        code_project_version = (
+            pyproject["project"].get("version") if pyproject is not None else None
+        )
+        if (
+            code != "embed"
+            and code_project_name is not None
+            and canonicalize_name(name) == canonicalize_name(code_project_name)
+        ):
+            raise ValueError(
+                "The model package name must differ from the project code package "
+                "name when code is not embedded."
+            )
         if pyproject is not None:
             main_package = snake_case(pyproject["project"]["name"].lower())
         else:
@@ -272,29 +438,38 @@ class SetuptoolsPackager(Packager):
             }
         )
 
-        try:
-            find = dict(pyproject["tool"].pop("setuptools", {})["packages"]["find"])
-        except Exception:
-            find = {}
-        where = find.pop("where", ["."])
-        where = [where] if not isinstance(where, list) else where
         packages = {main_package, model_package}
-        for w in where:
-            # TODO Should we handle namespaces ?
-            # if find.pop("namespace", None) is not None:
-            #     packages.extend(setuptools.find_namespace_packages(**find))
-            packages.update(setuptools.find_packages(w, **find))
+        if code != "embed":
+            packages = {model_package}
+        else:
+            try:
+                find = dict(
+                    pyproject.get("tool", {})
+                    .get("setuptools", {})
+                    .get("packages", {})
+                    .get("find", {})
+                )
+            except Exception:
+                find = {}
+            where = find.pop("where", ["."])
+            where = [where] if not isinstance(where, list) else where
+            for w in where:
+                # TODO Should we handle namespaces ?
+                # if find.pop("namespace", None) is not None:
+                #     packages.extend(setuptools.find_namespace_packages(**find))
+                packages.update(setuptools.find_packages(w, **find))
         packages = sorted([p for p in packages if p])
         file_paths = []
-        for package in packages:
-            for path in (root_dir / package).rglob("*"):
-                if (
-                    "__pycache__" in path.parts
-                    or ".ipynb_checkpoints" in path.parts
-                    or path.is_dir()
-                ):
-                    continue
-                file_paths.append(path)
+        if code == "embed":
+            for package in packages:
+                for path in (root_dir / package).rglob("*"):
+                    if (
+                        "__pycache__" in path.parts
+                        or ".ipynb_checkpoints" in path.parts
+                        or path.is_dir()
+                    ):
+                        continue
+                    file_paths.append(path)
 
         new_pyproject["tool"]["hatch"]["build"] = {
             "packages": [*packages, artifacts_name],
@@ -314,6 +489,46 @@ class SetuptoolsPackager(Packager):
         metadata["name"] = model_package
         metadata["version"] = version
 
+        code_metadata = {}
+        if code == "dependency":
+            if code_dependency is None:
+                if code_project_name is None:
+                    raise ValueError(
+                        "Could not infer a code dependency from pyproject.toml."
+                    )
+                if code_project_version is None:  # pragma: no cover
+                    try:
+                        import importlib.metadata as importlib_metadata
+
+                        code_project_version = importlib_metadata.version(
+                            code_project_name
+                        )
+                    except Exception as e:
+                        raise ValueError(
+                            "Could not infer a code dependency version from "
+                            "pyproject.toml or installed package metadata."
+                        ) from e
+                code_dependency = build_minor_range_dependency(
+                    code_project_name,
+                    code_project_version,
+                )
+            dependencies = list(new_pyproject["project"].get("dependencies", []))
+            dep_req = Requirement(code_dependency)
+            dependencies = [
+                dep
+                for dep in dependencies
+                if canonicalize_name(Requirement(dep).name)
+                != canonicalize_name(dep_req.name)
+            ]
+            dependencies.append(code_dependency)
+            new_pyproject["project"]["dependencies"] = dependencies
+            code_metadata = {
+                "mode": "dependency",
+                "dependency": code_dependency,
+                "project": code_project_name,
+                "version": code_project_version,
+            }
+
         new_pyproject = new_pyproject.merge({"project": metadata})
 
         super().__init__(
@@ -328,6 +543,11 @@ class SetuptoolsPackager(Packager):
             exclude=exclude,
             readme_replacements=readme_replacements,
             file_paths=file_paths,
+            code=code,
+            code_dependency=code_dependency,
+            code_check=code_check,
+            publish_index=publish_index,
+            code_metadata=code_metadata,
         )
 
 
@@ -350,8 +570,11 @@ def package(
     skip_build_dependency_check: bool = False,
     exclude: Optional[AsList[str]] = None,
     readme_replacements: Dict[str, str] = {},
+    code: Literal["embed", "dependency", "none"] = "embed",
+    code_dependency: Optional[str] = None,
+    code_check: Literal["off", "warn", "error"] = "warn",
+    publish_index: Optional[str] = None,
 ):
-    # root_dir = Path(".").resolve()
     exclude = exclude or ["artifacts/vocab/*"]
     pyproject_path = root_dir / "pyproject.toml"
 
@@ -361,6 +584,10 @@ def package(
             raise ValueError(
                 f"No pyproject.toml could be found in the root directory {root_dir}, "
                 f"you need to create one, or fill the name parameter."
+            )
+        if code == "dependency" and code_dependency is None:
+            raise ValueError(
+                "A pyproject.toml file is required to infer the code dependency."
             )
 
     if check_dependencies:
@@ -376,7 +603,6 @@ def package(
         if project_type is None:
             project_type = "setuptools"
         packager_cls = {
-            # for backward compatibility
             "standard": SetuptoolsPackager,
             "setuptools": SetuptoolsPackager,
         }[project_type]
@@ -397,7 +623,98 @@ def package(
         metadata=metadata,
         exclude=exclude,
         readme_replacements=readme_replacements,
+        code=code,
+        code_dependency=code_dependency,
+        code_check=code_check,
+        publish_index=publish_index,
     )
+
+    selected_index = None
+    selected_index_url = None
+    if pyproject is not None:
+        indexes = pyproject.get("tool", {}).get("uv", {}).get("index", [])
+        indexes = [indexes] if isinstance(indexes, dict) else indexes
+        publishable = [idx for idx in indexes if idx.get("publish-url")]
+        if publish_index is not None:
+            if publish_index == "pypi":  # pragma: no cover
+                selected_index = "pypi"
+                selected_index_url = "https://pypi.org/simple"
+            else:
+                for idx in indexes:
+                    if idx.get("name") == publish_index:
+                        selected_index = publish_index
+                        selected_index_url = idx.get("url")
+                        break
+                if selected_index_url is None:
+                    handle_code_check(
+                        f"Could not find uv index {publish_index!r} in pyproject.toml.",
+                        code_check,
+                    )
+        elif len(publishable) == 1:
+            selected_index = publishable[0].get("name")
+            selected_index_url = publishable[0].get("url")
+        elif len(publishable) > 1 and code != "embed" and code_check != "off":
+            warnings.warn(
+                "Multiple publishable uv indexes were found, pass publish_index to "
+                "select one for registry checks.",
+                UserWarning,
+            )
+
+    if code == "dependency":
+        req = Requirement(packager.code_dependency)
+        registry_wheel_url = None
+        if selected_index_url is not None:
+            registry_wheel_url = resolve_simple_index_wheel(selected_index_url, req)
+            if registry_wheel_url is None:
+                handle_code_check(
+                    f"Code dependency {packager.code_dependency!r} was not found in "
+                    f"uv index {selected_index!r}.",
+                    code_check,
+                )
+            else:
+                differences = compare_registry_wheel_with_local_code(
+                    registry_wheel_url,
+                    root_dir,
+                    pyproject,
+                )
+                if differences:
+                    handle_code_check(
+                        "Local project code differs from the registry package "
+                        f"selected for {packager.code_dependency!r}:\n"
+                        + "\n".join(f"- {diff}" for diff in differences[:10]),
+                        code_check,
+                    )
+        elif code_check != "off":  # pragma: no cover
+            warnings.warn(
+                f"No publish index was selected for {packager.code_dependency!r}, "
+                "registry installability and code contents were not verified.",
+                UserWarning,
+            )
+        try:  # pragma: no cover
+            import importlib.metadata as importlib_metadata
+
+            dist = importlib_metadata.distribution(req.name)
+            direct_url = dist.read_text("direct_url.json")
+            direct_url = json.loads(direct_url) if direct_url else {}
+            is_editable = direct_url.get("dir_info", {}).get("editable", False)
+        except Exception:  # pragma: no cover
+            is_editable = False
+        if is_editable and code_check != "off":  # pragma: no cover
+            message = (
+                f"Code dependency {req.name!r} is installed in editable mode, the "
+                "local source may differ from the released package."
+            )
+            if registry_wheel_url is not None:
+                warnings.warn(message, UserWarning)
+            else:
+                handle_code_check(message, code_check)
+    elif code == "none" and code_check != "off":
+        warnings.warn(
+            "Packaging with code='none' does not include project code or add a code "
+            "dependency, custom factories must already be importable.",
+            UserWarning,
+        )
+
     packager.make_src_dir()
     packager.build(
         distributions=distributions,

--- a/edsnlp/package.py
+++ b/edsnlp/package.py
@@ -1,7 +1,6 @@
 import os
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import warnings
@@ -15,26 +14,10 @@ import toml
 from build.__main__ import build_package, build_package_via_sdist
 from confit import Cli
 from loguru import logger
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal
 
 import edsnlp
 from edsnlp.utils.typing import AsList, Validated
-
-PoetryConstraint = TypedDict(
-    "PoetryConstraint",
-    {
-        "version": str,
-        "extras": Optional[Sequence[str]],
-        "markers": Optional[str],
-        "url": Optional[str],
-        "path": Optional[str],
-        "git": Optional[str],
-        "ref": Optional[str],
-        "branch": Optional[str],
-        "tag": Optional[str],
-    },
-    total=False,
-)
 
 logger.remove()
 logger.add(
@@ -74,42 +57,6 @@ class ModuleName(str, Validated):
 
 if TYPE_CHECKING:
     ModuleName = str  # noqa F811
-
-POETRY_SNIPPET = """\
-from poetry.core.masonry.builders.sdist import SdistBuilder
-from poetry.factory import Factory
-try:
-    from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
-except ImportError:
-    from poetry.core.masonry.utils.module import ModuleOrPackageNotFoundError as ModuleOrPackageNotFound
-import sys
-# Initialize the Poetry object for the current project
-poetry = Factory().create_poetry("__root_dir__")
-
-# Initialize the builder
-try:
-    builder = SdistBuilder(poetry)
-    # Get the list of files to include
-    files = builder.find_files_to_add()
-except ModuleOrPackageNotFound:
-    if not poetry.package.packages:
-        print([])
-        sys.exit(0)
-
-print([
-    {k: v for k, v in {
-    "include": getattr(include, '_include'),
-    "from": getattr(include, 'source', None),
-    "formats": getattr(include, 'formats', None),
-    }.items() if v}
-    for include in builder._module.includes
-])
-
-
-# Print the list of files
-for file in files:
-    print(file.path)
-"""  # noqa E501
 
 INIT_PY = """
 # -----------------------------------------
@@ -212,15 +159,6 @@ class Packager:
             skip_dependency_check=skip_dependency_check,
         )
 
-    # def update_pyproject(self):
-    #     # Adding artifacts to include in pyproject.toml
-    #     snake_name = snake_case(self.name.lower())
-    #     included = self.pyproject["tool"]["poetry"].setdefault("include", [])
-    #     included.append(f"{snake_name}/{self.artifacts_name}/**")
-    #     packages = list(self.packages)
-    #     packages.append({"include": snake_name})
-    #     self.pyproject["tool"]["poetry"]["packages"] = packages
-
     def make_src_dir(self):
         snake_name = snake_case(self.name.lower())
         package_dir = self.build_dir / snake_name
@@ -238,8 +176,6 @@ class Packager:
                 )
             os.makedirs(dest_path.parent, exist_ok=True)
             shutil.copy(file_path, dest_path)
-
-        # self.update_pyproject()
 
         # Write pyproject.toml
         (self.build_dir / "pyproject.toml").write_text(toml.dumps(self.pyproject))
@@ -280,181 +216,7 @@ class Packager:
                     logger.info(f"SKIP {rel}")
 
 
-class OldStylePoetryPackager(Packager):
-    def __init__(
-        self,
-        *,
-        name: ModuleName,
-        pyproject: Optional[Dict[str, Any]],
-        pipeline: Union[Path, "edsnlp.Pipeline"],
-        version: Optional[str],
-        root_dir: Path = ".",
-        build_dir: Optional[Path] = None,
-        dist_dir: Path,
-        artifacts_name: ModuleName,
-        metadata: Optional[Dict[str, Any]] = {},
-        exclude: AsList[str],
-        readme_replacements: Dict[str, str] = {},
-    ):
-        try:
-            version = version or pyproject["tool"]["poetry"]["version"]
-        except (KeyError, TypeError):  # pragma: no cover
-            version = "0.1.0"
-        name = name or pyproject["tool"]["poetry"]["name"]
-        main_package = (
-            snake_case(pyproject["tool"]["poetry"]["name"].lower())
-            if pyproject is not None
-            else None
-        )
-        model_package = snake_case(name.lower())
-
-        root_dir = root_dir.resolve()
-        dist_dir = dist_dir if Path(dist_dir).is_absolute() else root_dir / dist_dir
-
-        build_dir = Path(tempfile.mkdtemp()) if build_dir is None else build_dir
-
-        new_pyproject: Dict[str, Any] = {
-            "build-system": {
-                "requires": ["hatchling"],
-                "build-backend": "hatchling.build",
-            },
-            "tool": {
-                "hatch": {
-                    "build": {},
-                    # in case the user provides a git dependency for example
-                    "metadata": {"allow-direct-references": True},
-                }
-            },
-            "project": {
-                "name": model_package,
-                "version": version,
-                "requires-python": ">=3.10",
-            },
-        }
-        file_paths = []
-
-        if pyproject is not None:
-            poetry = pyproject["tool"]["poetry"]
-
-            # Extract packages
-            poetry_bin_path = shutil.which("poetry")
-            if poetry_bin_path is None:
-                raise RuntimeError("Poetry is not installed or not found in PATH.")
-            python_executable = Path(poetry_bin_path).read_text().split("\n")[0][2:]
-            result = subprocess.run(
-                [
-                    *python_executable.split(),
-                    "-c",
-                    POETRY_SNIPPET.replace("__root_dir__", str(root_dir)),
-                ],
-                stdout=subprocess.PIPE,
-                cwd=root_dir,
-            )
-            if result.returncode != 0:
-                raise Exception()
-            out = result.stdout.decode().strip().split("\n")
-            file_paths = [root_dir / file_path for file_path in out[1:]]
-            packages = {
-                main_package,
-                model_package,
-                *(package["include"] for package in eval(out[0])),
-            }
-            packages = sorted([p for p in packages if p])
-            new_pyproject["tool"]["hatch"]["build"] = {
-                "packages": [*packages, artifacts_name],
-                "exclude": ["__pycache__/", "*.pyc", "*.pyo", ".ipynb_checkpoints"],
-                "artifacts": [artifacts_name],
-                "targets": {
-                    "wheel": {
-                        "sources": {
-                            f"{artifacts_name}": f"{model_package}/{artifacts_name}"
-                        },
-                    },
-                },
-            }
-            if "description" in poetry:  # pragma: no cover
-                new_pyproject["project"]["description"] = poetry["description"]
-            if "classifiers" in poetry:  # pragma: no cover
-                new_pyproject["project"]["classifiers"] = poetry["classifiers"]
-            if "keywords" in poetry:  # pragma: no cover
-                new_pyproject["project"]["keywords"] = poetry["keywords"]
-            if "license" in poetry:  # pragma: no cover
-                new_pyproject["project"]["license"] = {"text": poetry["license"]}
-            if "readme" in poetry:  # pragma: no cover
-                new_pyproject["project"]["readme"] = poetry["readme"]
-            if "authors" in poetry:  # pragma: no cover
-                new_pyproject["project"]["authors"] = parse_authors(poetry["authors"])
-            if "plugins" in poetry:  # pragma: no cover
-                new_pyproject["project"]["entry-points"] = poetry["plugins"]
-            if "scripts" in poetry:  # pragma: no cover
-                new_pyproject["project"]["scripts"] = poetry["scripts"]
-
-            # Dependencies
-            deps = []
-            poetry_deps = poetry["dependencies"]
-            for dep_name, constraint in poetry_deps.items():
-                dep = dep_name
-                constraint: PoetryConstraint = (
-                    dict(constraint)
-                    if isinstance(constraint, dict)
-                    else {"version": constraint}
-                )
-                try:
-                    dep += f"[{','.join(constraint.pop('extras'))}]"
-                except KeyError:
-                    pass
-                if "version" in constraint:
-                    dep_version = constraint.pop("version")
-                    assert not dep_version.startswith("^"), (
-                        "Packaging models with ^ dependencies is not supported"
-                    )
-                    dep += (
-                        ""
-                        if dep_version == "*"
-                        else dep_version
-                        if not dep_version[0].isdigit()
-                        else f"=={dep_version}"
-                    )
-                try:
-                    dep += f"; {constraint.pop('markers')}"
-                except KeyError:
-                    pass
-                assert not constraint, (
-                    f"Unsupported constraints for dependency {dep_name}: {constraint}"
-                )
-                if dep_name == "python":
-                    new_pyproject["project"]["requires-python"] = dep.replace(
-                        "python", ""
-                    )
-                    continue
-                deps.append(dep)
-
-            new_pyproject["project"]["dependencies"] = deps
-
-        if "authors" in metadata:
-            metadata["authors"] = parse_authors(metadata["authors"])
-        metadata["name"] = model_package
-        metadata["version"] = version
-
-        new_pyproject = confit.Config(new_pyproject).merge({"project": metadata})
-
-        # Use hatch
-        super().__init__(
-            name=model_package,
-            pyproject=new_pyproject,
-            pipeline=pipeline,
-            version=version,
-            root_dir=root_dir,
-            build_dir=build_dir,
-            dist_dir=dist_dir,
-            artifacts_name=artifacts_name,
-            exclude=exclude,
-            readme_replacements=readme_replacements,
-            file_paths=file_paths,
-        )
-
-
-class StandardPackager(Packager):
+class SetuptoolsPackager(Packager):
     def __init__(
         self,
         *,
@@ -579,7 +341,7 @@ def package(
     dist_dir: Path = Path("dist"),
     artifacts_name: ModuleName = "artifacts",
     check_dependencies: bool = False,
-    project_type: Optional[str] = None,
+    project_type: Optional[Literal["setuptools"]] = None,
     version: Optional[str] = None,
     metadata: Optional[Dict[str, Any]] = {},
     distributions: Optional[AsList[Literal["wheel", "sdist"]]] = ["wheel"],
@@ -611,25 +373,17 @@ def package(
         pyproject = toml.loads((root_dir / "pyproject.toml").read_text())
 
     try:
-        _ = pyproject["tool"]["poetry"]["name"]
-        inferred_project_type = "old-style-poetry"
-    except (KeyError, TypeError):
-        inferred_project_type = "standard"
-
-    try:
         if project_type is None:
-            project_type = inferred_project_type
+            project_type = "setuptools"
         packager_cls = {
-            "old-style-poetry": OldStylePoetryPackager,
-            "standard": StandardPackager,
             # for backward compatibility
-            "poetry": OldStylePoetryPackager,
-            "setuptools": StandardPackager,
+            "standard": SetuptoolsPackager,
+            "setuptools": SetuptoolsPackager,
         }[project_type]
     except Exception:  # pragma: no cover
         raise ValueError(
-            f"Could not process project type {project_type!r} only old-style poetry "
-            f"and PEP 621 pyproject.toml formats are supported for now."
+            f"Could not process project type {project_type!r} only PEP 621 "
+            f"pyproject.toml formats are supported."
         )
     packager = packager_cls(
         pyproject=pyproject,

--- a/tests/utils/test_package.py
+++ b/tests/utils/test_package.py
@@ -187,3 +187,193 @@ def load(
         )
     module.load()
     edsnlp.load(module_name)
+
+
+def test_package_dependency_mode_with_code_wheel_and_local_index(tmp_path):
+    (tmp_path / "project_code").mkdir()
+    (tmp_path / "project_code" / "__init__.py").write_text("")
+    (tmp_path / "project_code" / "pipes.py").write_text(
+        """\
+from edsnlp.core.registries import registry
+
+
+@registry.factories.register("project_code.dummy")
+def create_component(nlp, name):
+    def pipe(doc):
+        return doc
+
+    return pipe
+"""
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        f"""\
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "project-code"
+version = "1.4.0"
+description = "A test code package"
+authors = [
+    {{name = "Test Author", email = "test.author@mail.com"}}
+]
+requires-python = ">=3.10"
+
+[project.entry-points."edsnlp_factories"]
+"project_code.dummy" = "project_code.pipes:create_component"
+
+[[tool.uv.index]]
+name = "local"
+url = "{(tmp_path / "simple").as_uri()}"
+publish-url = "{(tmp_path / "upload").as_uri()}"
+explicit = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["project_code*"]
+"""
+    )
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            str(tmp_path / "dist"),
+        ],
+        cwd=tmp_path,
+    )
+    code_wheel = next((tmp_path / "dist").glob("project_code-1.4.0-*.whl"))
+    simple_package = tmp_path / "simple" / "project-code"
+    simple_package.mkdir(parents=True)
+    (simple_package / "index.html").write_text(
+        "\n".join(
+            [
+                '<a href="not-a-wheel.txt">not-a-wheel.txt</a>',
+                '<a href="other_package-1.4.0-py3-none-any.whl">'
+                "other_package-1.4.0-py3-none-any.whl</a>",
+                f'<a href="../../dist/{code_wheel.name}">{code_wheel.name}</a>',
+            ]
+        )
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        import project_code.pipes  # noqa: F401
+
+        nlp = edsnlp.blank("eds")
+        nlp.add_pipe("project_code.dummy")
+        nlp.to_disk(tmp_path / "model", exclude=set())
+    finally:
+        sys.path.remove(str(tmp_path))
+
+    package(
+        name="project-code-model",
+        pipeline=tmp_path / "model",
+        root_dir=tmp_path,
+        version="2026.7.4",
+        distributions=["wheel"],
+        code="dependency",
+        code_check="error",
+    )
+
+    model_wheel = tmp_path / "dist" / "project_code_model-2026.7.4-py3-none-any.whl"
+    assert model_wheel.is_file()
+    with zipfile.ZipFile(model_wheel) as zf:
+        names = set(zf.namelist())
+        assert "project_code/__init__.py" not in names
+        assert "project_code/pipes.py" not in names
+        assert "project_code_model/artifacts/config.cfg" in names
+        metadata = zf.read("project_code_model-2026.7.4.dist-info/METADATA").decode()
+        assert "Requires-Dist: project-code<1.5,>=1.4" in metadata
+        meta = zf.read("project_code_model/artifacts/meta.json").decode()
+        assert '"dependency": "project-code>=1.4,<1.5"' in meta
+
+    with pytest.raises(RuntimeError, match="Could not find uv index"):
+        package(
+            name="project-code-model-missing-index",
+            pipeline=tmp_path / "model",
+            root_dir=tmp_path,
+            version="2026.7.5",
+            distributions=["wheel"],
+            code="dependency",
+            code_check="error",
+            publish_index="missing",
+        )
+
+    with pytest.raises(RuntimeError, match="Code dependency"):
+        package(
+            name="project-code-model-missing-dep",
+            pipeline=tmp_path / "model",
+            root_dir=tmp_path,
+            version="2026.7.5",
+            distributions=["wheel"],
+            code="dependency",
+            code_dependency="project-code>=2,<3",
+            code_check="error",
+            publish_index="local",
+        )
+
+    (tmp_path / "project_code" / "pipes.py").write_text(
+        (tmp_path / "project_code" / "pipes.py").read_text() + "\nVALUE = 1\n"
+    )
+    (tmp_path / "project_code" / "extra.py").write_text("VALUE = 2\n")
+    with pytest.raises(RuntimeError, match="Local project code differs"):
+        package(
+            name="project-code-model-drift",
+            pipeline=tmp_path / "model",
+            root_dir=tmp_path,
+            version="2026.7.5",
+            distributions=["wheel"],
+            code="dependency",
+            code_check="error",
+            publish_index="local",
+        )
+
+
+def test_package_none_mode_excludes_project_code(nlp, tmp_path):
+    if not isinstance(nlp, edsnlp.Pipeline):
+        pytest.skip("Only running for edsnlp.Pipeline")
+
+    nlp.to_disk(tmp_path / "model", exclude=set())
+    (tmp_path / "project_code").mkdir()
+    (tmp_path / "project_code" / "__init__.py").write_text('VALUE = "unused"\n')
+    (tmp_path / "pyproject.toml").write_text(
+        """\
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "project-code"
+version = "1.4.0"
+description = "A test code package"
+authors = [
+    {name = "Test Author", email = "test.author@mail.com"}
+]
+requires-python = ">=3.10"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["project_code*"]
+"""
+    )
+
+    with pytest.warns(UserWarning, match="code='none'"):
+        package(
+            name="artifact-only-model",
+            pipeline=tmp_path / "model",
+            root_dir=tmp_path,
+            version="2026.7.4",
+            distributions=["wheel"],
+            code="none",
+        )
+
+    model_wheel = tmp_path / "dist" / "artifact_only_model-2026.7.4-py3-none-any.whl"
+    with zipfile.ZipFile(model_wheel) as zf:
+        names = set(zf.namelist())
+        assert "project_code/__init__.py" not in names
+        assert "artifact_only_model/artifacts/config.cfg" in names

--- a/tests/utils/test_package.py
+++ b/tests/utils/test_package.py
@@ -11,7 +11,6 @@ from edsnlp.package import package
 
 
 def test_blank_package(nlp, tmp_path):
-    # Missing metadata makes poetry fail due to missing author / description
     if not isinstance(nlp, edsnlp.Pipeline):
         pytest.skip("Only running for edsnlp.Pipeline")
 
@@ -20,7 +19,6 @@ def test_blank_package(nlp, tmp_path):
         root_dir=tmp_path,
         name="test-model-fail",
         metadata={},
-        project_type="poetry",
     )
 
     nlp.package(
@@ -30,7 +28,6 @@ def test_blank_package(nlp, tmp_path):
             "description": "A test model",
             "authors": "Test Author <test.author@mail.com>",
         },
-        project_type="poetry",
         distributions=["wheel"],
     )
     assert (tmp_path / "dist").is_dir()
@@ -39,8 +36,7 @@ def test_blank_package(nlp, tmp_path):
 
 
 @pytest.mark.parametrize("package_name", ["my-test-model", None])
-@pytest.mark.parametrize("manager", ["poetry", "setuptools"])
-def test_package_with_files(nlp, tmp_path, package_name, manager):
+def test_package_with_files(nlp, tmp_path, package_name):
     if not isinstance(nlp, edsnlp.Pipeline):
         pytest.skip("Only running for edsnlp.Pipeline")
 
@@ -55,28 +51,8 @@ def test_package_with_files(nlp, tmp_path, package_name, manager):
 # Test Model
 """
     )
-    if manager == "poetry":
-        (tmp_path / "pyproject.toml").write_text(
-            """\
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.poetry]
-name = "test-model"
-version = "0.0.0"
-description = "A test model"
-authors = ["Test Author <test.author@mail.com>"]
-readme = "README.md"
-
-[tool.poetry.dependencies]
-python = ">=3.10"
-build = "*"  # sample light package to install
-"""
-        )
-    elif manager == "setuptools":
-        (tmp_path / "pyproject.toml").write_text(
-            """\
+    (tmp_path / "pyproject.toml").write_text(
+        """\
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -95,7 +71,7 @@ dependencies = [
     "build"
 ]
 """
-        )
+    )
     package(
         name=package_name,
         pipeline=tmp_path / "model",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

### Added

- `edsnlp.package` now supports `code="dependency"` and `code="none"` to build model packages without embedding project code, which is better for model finetuning with custom code, since finetuned models only require the custom code and not the original model weights. Dependency mode infers the project package requirement from `pyproject.toml` and can check the selected uv index for unreleased local code changes.

### Changed

- `edsnlp.package` now only supports PEP 621 projects, old style poetry packaging support has been removed.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
