### PR TITLE
fix: update schema handling in PolarsWriter to use schema_overrides

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Add `schema` and `schema_overrides` to Pandas, Polars and Spark exports for selecting columns and overriding dtypes, deprecate `dtypes` (whose behavior stays the same)
 - Rewrite the `eds.tnm` regex, which now covers more staging notations and rejects most lookalike abbreviations. Qualified against annotations from two physicians: precision 98.64% ± 1% (95% CI), entity-level recall 79.40% ± 1% (99% CI), document-level recall 95.53% ± 1% (99% CI)
 - **Breaking**: rename and extend the `TNM` model fields (`prefix` → `tumour_prefix`, `resection_completeness` → `resection`, one `_prefix`/`_specification`/`_suffix` set per component), which are now plain strings instead of enums. The renamed fields keep a deprecated alias — see the migration guide on the `eds.tnm` documentation page
 - Add a `banned_words` parameter to `eds.tnm` to configure the post-filter that drops lookalike abbreviations (`MTX`, `atom`, ...)
@@ -18,6 +19,7 @@
 
 - `eds.contextual_matcher` now checks `span_getter` in span-only `include` rules instead of rejecting every anchor
 - Correctly normalize two-digit years matched by `eds.dates`, allowing at most one year after the report date
+- Restore Spark inference functions after successful and failed schema inference
 
 ## v0.22.0 (2026-06-17)
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Add a `banned_words` parameter to `eds.tnm` to configure the post-filter that drops lookalike abbreviations (`MTX`, `atom`, ...)
 - `TNM.norm()` no longer concatenates free-text suffixes verbatim, so `span.kb_id_` stays usable for grouping: only suffixes that read as a TNM qualifier are kept (`pT1(m)` → `pT1m`, whereas `pT1(grade 2)N1M0` used to normalise to `pT1grade 2N1M0`). The `o` → `0` coercion is likewise restricted to the numeric stage fields, so a suffix such as `(foie)` is no longer stored as `f0ie`
 - `edsnlp.package` now only supports PEP 621 projects, old style poetry packaging support has been removed.
+- Use Confit 0.13 structured errors for nested component validation and validate converter options with Pydantic directly
 
 ### Fixed
 

--- a/edsnlp/core/pipeline.py
+++ b/edsnlp/core/pipeline.py
@@ -34,7 +34,7 @@ from typing import (
 import spacy
 import srsly
 from confit import Config
-from confit.errors import ConfitValidationError, patch_errors
+from confit.errors import ConfitValidationError
 from confit.utils.xjson import Reference
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -595,13 +595,10 @@ class Pipeline(Validated):
         try:
             components = DraftPipe.instantiate(components, nlp=self)
         except ConfitValidationError as e:
-            e = ConfitValidationError(
-                e.raw_errors,
-                model=self.__class__,
+            raise e.with_path(
+                ("components",),
                 name=self.__class__.__module__ + "." + self.__class__.__qualname__,
             )
-            e.raw_errors = patch_errors(e.raw_errors, ("components",))
-            raise e
 
         for name in pipeline:
             if name in exclude:

--- a/edsnlp/core/registries.py
+++ b/edsnlp/core/registries.py
@@ -24,7 +24,7 @@ import confit
 import spacy
 import spacy.registrations
 from confit import Config, RegistryCollection, Validatable, set_default_registry
-from confit.errors import ConfitValidationError, patch_errors
+from confit.errors import ConfitValidationError
 from confit.registry import Draft
 from spacy.pipe_analysis import validate_attrs
 from spacy.pipeline.factories import register_factories
@@ -188,14 +188,9 @@ class DraftPipe(Draft[T]):
                 self.instantiated = self._func(**kwargs)
             except ConfitValidationError as e:
                 self.error = e
-                raise ConfitValidationError(
-                    patch_errors(e.raw_errors, path, model=e.model),
-                    model=e.model,
-                    name=self._func.__module__ + "." + self._func.__qualname__,
-                )  # .with_traceback(None)
-            # except Exception as e:
-            #     obj.error = e
-            #     raise ConfitValidationError([ErrorWrapper(e, path)])
+                raise e.with_path(
+                    path, name=self._func.__module__ + "." + self._func.__qualname__
+                )
             return self.instantiated
         elif isinstance(self, dict):
             instantiated = {}
@@ -208,9 +203,9 @@ class DraftPipe(Draft[T]):
                         path=(*path, key),
                     )
                 except ConfitValidationError as e:
-                    errors.extend(e.raw_errors)
+                    errors.append(e)
             if errors:
-                raise ConfitValidationError(errors)
+                raise ConfitValidationError.combine(errors)
             return instantiated
         elif isinstance(self, (tuple, list)):
             instantiated = []
@@ -221,9 +216,9 @@ class DraftPipe(Draft[T]):
                         DraftPipe.instantiate(value, nlp, (*path, str(i)))
                     )
                 except ConfitValidationError as e:  # pragma: no cover
-                    errors.append(e.raw_errors)
+                    errors.append(e)
             if errors:
-                raise ConfitValidationError(errors)
+                raise ConfitValidationError.combine(errors)
             return type(self)(instantiated)
         else:
             return self

--- a/edsnlp/data/base.py
+++ b/edsnlp/data/base.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 from typing import (
     Any,
     Callable,
@@ -10,7 +11,7 @@ from typing import (
     Union,
 )
 
-from confit import validate_arguments
+from confit import VisibleDeprecationWarning, validate_arguments
 from typing_extensions import Literal
 
 from ..core.stream import Stream
@@ -18,6 +19,37 @@ from ..utils.collections import flatten
 from ..utils.stream_sentinels import DatasetEndSentinel
 from ..utils.typing import AsList
 from .converters import FILENAME, get_dict2doc_converter, get_doc2dict_converter
+
+
+def validate_schema_overrides(columns, schema_overrides):
+    """
+    Reject dtype overrides for columns absent from the output
+    """
+    unknown = set(schema_overrides or ()) - set(columns)
+    if unknown:
+        raise ValueError(
+            f"schema_overrides contains unknown columns: {sorted(unknown)}"
+        )
+
+
+def validate_schema(schema, schema_overrides, dtypes=None, dtypes_as="schema"):
+    """
+    Reject incompatible export options and warn when dtypes is used
+    """
+    if dtypes is not None:
+        if schema is not None or schema_overrides is not None:
+            raise ValueError("Cannot combine dtypes with schema or schema_overrides")
+        warnings.warn(
+            f"dtypes is deprecated, use {dtypes_as} instead",
+            VisibleDeprecationWarning,
+            stacklevel=3,
+        )
+    for types in (schema if isinstance(schema, dict) else {}, schema_overrides or {}):
+        if None in types.values():
+            raise ValueError("Use concrete types in schema and schema_overrides")
+    if isinstance(schema, (list, dict)):
+        if not schema or len(set(schema)) != len(schema):
+            raise ValueError("schema must be nonempty and contain unique column names")
 
 
 class BaseReader:

--- a/edsnlp/data/converters.py
+++ b/edsnlp/data/converters.py
@@ -6,8 +6,6 @@ Doc objects, and writers convert Doc objects to dictionaries.
 
 import inspect
 import warnings
-from copy import copy
-from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -19,10 +17,11 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    get_type_hints,
 )
 
 import spacy
-from confit.registry import ValidatedFunction
+from pydantic import validate_call
 from spacy.tokenizer import Tokenizer
 from spacy.tokens import Doc, Span
 from typing_extensions import Literal
@@ -57,56 +56,24 @@ def without_filename(d):
 
 
 def validate_kwargs(func, kwargs):
-    if (
-        hasattr(func, "__call__")
-        and not hasattr(func, "__defaults__")
-        and hasattr(func.__call__, "__self__")
-    ):
+    if not inspect.isroutine(func) and not isinstance(func, type):
         func = func.__call__
-    has_self = restore = False
-    spec = inspect.getfullargspec(func)
-    try:
-        if hasattr(func, "__func__"):
-            has_self = hasattr(func, "__self__")
-            func = func.__func__.__get__(None, func.__func__.__class__)
-            old_annotations = func.__annotations__
-            old_defaults = func.__defaults__
-            restore = True
-            func.__annotations__ = copy(func.__annotations__)
-            func.__annotations__[spec.args[0]] = Optional[Any]
-            func.__annotations__[spec.args[1]] = Optional[Any]
-            func.__defaults__ = (
-                None,
-                None,
-                *(spec.defaults or ())[-len(spec.args) + 2 :],
-            )
-        else:
-            func: FunctionType = copy(func)
-            old_annotations = func.__annotations__
-            old_defaults = func.__defaults__
-            restore = True
-            func.__annotations__[spec.args[0]] = Optional[Any]
-            func.__defaults__ = (None, *(spec.defaults or ())[-len(spec.args) + 1 :])
-        vd = ValidatedFunction(func, {"arbitrary_types_allowed": True})
-        model = vd.init_model_instance(
-            **{k: v for k, v in kwargs.items() if k in spec.args}
-        )
-        fields = vd.model.model_fields
-        d = {
-            k: v
-            for k, v in model.__dict__.items()
-            if (k in fields or fields[k].default_factory)
-        }
-        d.pop("v__duplicate_kwargs", None)  # see pydantic ValidatedFunction code
-        d.pop(vd.v_args_name, None)
-        d.pop(spec.args[0], None)
-        if has_self:
-            d.pop(spec.args[1], None)
-        return {**(d.pop(vd.v_kwargs_name, None) or {}), **d}
-    finally:
-        if restore:
-            func.__annotations__ = old_annotations
-            func.__defaults__ = old_defaults
+    hints = get_type_hints(
+        func.__init__ if isinstance(func, type) else func, include_extras=True
+    )
+    # The stream supplies the first argument, only validate converter options here
+    parameters = list(inspect.signature(func).parameters.values())[1:]
+    signature = inspect.Signature(
+        [p.replace(annotation=hints.get(p.name, p.annotation)) for p in parameters]
+    )
+
+    def collect(*args, **kwargs):
+        return dict(signature.bind(*args, **kwargs).arguments)
+
+    collect.__signature__ = signature
+    collect.__annotations__ = hints
+    validated = validate_call(collect, config={"arbitrary_types_allowed": True})
+    return validated(**{k: v for k, v in kwargs.items() if k in signature.parameters})
 
 
 class AttributesMappingArg(Validated):

--- a/edsnlp/data/pandas.py
+++ b/edsnlp/data/pandas.py
@@ -8,7 +8,12 @@ from typing_extensions import Literal
 
 from edsnlp import registry
 from edsnlp.core.stream import Stream
-from edsnlp.data.base import BaseWriter, MemoryBasedReader
+from edsnlp.data.base import (
+    BaseWriter,
+    MemoryBasedReader,
+    validate_schema,
+    validate_schema_overrides,
+)
 from edsnlp.data.converters import get_dict2doc_converter, get_doc2dict_converter
 from edsnlp.utils.collections import dl_to_ld, flatten, ld_to_dl
 from edsnlp.utils.stream_sentinels import DatasetEndSentinel
@@ -128,13 +133,29 @@ def from_pandas(
 
 
 class PandasWriter(BaseWriter):
-    def __init__(self, dtypes: Optional[dict] = None):
+    def __init__(self, dtypes=None, *, schema=None, schema_overrides=None):
+        validate_schema(schema, schema_overrides, dtypes, dtypes_as="schema_overrides")
         self.dtypes = dtypes
+        self.schema = dict.fromkeys(schema) if isinstance(schema, list) else schema
+        self.schema_overrides = schema_overrides
 
     def consolidate(self, items):
-        columns = ld_to_dl(flatten(items))
-        res = pd.DataFrame(columns)
-        return res.astype(self.dtypes) if self.dtypes else res
+        items = flatten(items)
+        if self.schema is not None:
+            items = ({name: row.get(name) for name in self.schema} for row in items)
+        res = pd.DataFrame(ld_to_dl(items), columns=self.schema)
+        if self.dtypes is not None:
+            return res.astype(self.dtypes) if self.dtypes else res
+        validate_schema_overrides(res.columns, self.schema_overrides)
+        dtypes = {
+            name: dtype
+            for name, dtype in {
+                **(self.schema or {}),
+                **(self.schema_overrides or {}),
+            }.items()
+            if dtype is not None
+        }
+        return res.astype(dtypes) if dtypes else res
 
 
 @registry.writers.register("pandas")
@@ -143,6 +164,9 @@ def to_pandas(
     execute: bool = True,
     converter: Optional[Union[str, Callable]] = None,
     dtypes: Optional[dict] = None,
+    *,
+    schema: Optional[Union[list[str], dict]] = None,
+    schema_overrides: Optional[dict] = None,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -167,7 +191,12 @@ def to_pandas(
     data: Union[Any, Stream],
         The data to write (either a list of documents or a Stream).
     dtypes: Optional[dict]
-        Dictionary of column names to dtypes. This is passed to `pd.DataFrame.astype`.
+        Deprecated, use schema_overrides instead
+    schema: Optional[Union[list[str], dict]]
+        Column names to keep or a mapping from column names to Pandas dtypes
+    schema_overrides: Optional[dict]
+        Column dtypes to change without filtering columns, taking precedence
+        over schema
     execute: bool
         Whether to execute the writing operation immediately or to return a stream
     converter: Optional[Union[str, Callable]]
@@ -183,4 +212,7 @@ def to_pandas(
         converter, kwargs = get_doc2dict_converter(converter, kwargs)
         data = data.map(converter, kwargs=kwargs)
 
-    return data.write(PandasWriter(dtypes), execute=execute)
+    return data.write(
+        PandasWriter(dtypes, schema=schema, schema_overrides=schema_overrides),
+        execute=execute,
+    )

--- a/edsnlp/data/polars.py
+++ b/edsnlp/data/polars.py
@@ -9,7 +9,12 @@ from typing_extensions import Literal
 
 from edsnlp import registry
 from edsnlp.core.stream import Stream
-from edsnlp.data.base import BaseWriter, MemoryBasedReader
+from edsnlp.data.base import (
+    BaseWriter,
+    MemoryBasedReader,
+    validate_schema,
+    validate_schema_overrides,
+)
 from edsnlp.data.converters import get_dict2doc_converter, get_doc2dict_converter
 from edsnlp.utils.collections import flatten
 from edsnlp.utils.stream_sentinels import DatasetEndSentinel
@@ -136,11 +141,26 @@ def from_polars(
 
 
 class PolarsWriter(BaseWriter):
-    def __init__(self, dtypes: Optional[dict] = None):
+    def __init__(
+        self,
+        dtypes: Optional[dict] = None,
+        *,
+        schema: Optional[Union[list[str], dict]] = None,
+        schema_overrides: Optional[dict] = None,
+    ):
+        validate_schema(schema, schema_overrides, dtypes)
+        self.schema = dict.fromkeys(schema) if isinstance(schema, list) else schema
         self.dtypes = dtypes
+        self.schema_overrides = schema_overrides
 
     def consolidate(self, items: Iterable[Any]):
-        return pl.from_dicts(flatten(items), schema=self.dtypes)
+        if self.dtypes is not None:
+            return pl.from_dicts(flatten(items), schema=self.dtypes)
+        res = pl.from_dicts(
+            flatten(items), schema=self.schema, schema_overrides=self.schema_overrides
+        )
+        validate_schema_overrides(res.columns, self.schema_overrides)
+        return res
 
 
 @registry.writers.register("polars")
@@ -149,6 +169,9 @@ def to_polars(
     converter: Optional[Union[str, Callable]] = None,
     dtypes: Optional[dict] = None,
     execute: bool = True,
+    *,
+    schema: Optional[Union[list[str], dict]] = None,
+    schema_overrides: Optional[dict] = None,
     **kwargs,
 ) -> pl.DataFrame:
     """
@@ -173,8 +196,12 @@ def to_polars(
     data: Union[Any, Stream],
         The data to write (either a list of documents or a Stream).
     dtypes: Optional[dict]
-        Dictionary of column names to dtypes. This is passed to the schema parameter of
-        `pl.from_dicts`.
+        Deprecated, use schema instead
+    schema: Optional[Union[list[str], dict]]
+        Column names to keep or a mapping from column names to Polars dtypes
+    schema_overrides: Optional[dict]
+        Column dtypes to change without filtering columns, taking precedence
+        over schema
     converter: Optional[Union[str, Callable]]
         Converter to use to convert the documents to dictionary objects before storing
         them in the dataframe. These are documented on the
@@ -190,4 +217,7 @@ def to_polars(
         converter, kwargs = get_doc2dict_converter(converter, kwargs)
         data = data.map(converter, kwargs=kwargs)
 
-    return data.write(PolarsWriter(dtypes), execute=execute)
+    return data.write(
+        PolarsWriter(dtypes, schema=schema, schema_overrides=schema_overrides),
+        execute=execute,
+    )

--- a/edsnlp/data/spark.py
+++ b/edsnlp/data/spark.py
@@ -5,11 +5,17 @@ from itertools import chain
 from typing import Any, Callable, Iterable, Optional, Union
 
 import pyspark.sql.dataframe
+import pyspark.sql.types as T
 from typing_extensions import Literal
 
 from edsnlp import registry
 from edsnlp.core.stream import Stream
-from edsnlp.data.base import BaseWriter, MemoryBasedReader
+from edsnlp.data.base import (
+    BaseWriter,
+    MemoryBasedReader,
+    validate_schema,
+    validate_schema_overrides,
+)
 from edsnlp.data.converters import (
     get_dict2doc_converter,
     get_doc2dict_converter,
@@ -42,9 +48,9 @@ class SparkReader(MemoryBasedReader):
         seed = seed if seed is not None else random.getrandbits(32)
         self.rng = random.Random(seed)
         self.loop = loop
-        assert isinstance(
-            self.data, (pyspark.sql.dataframe.DataFrame, chain)
-        ), f"`data` should be a pyspark or koalas DataFrame got {type(data)}"
+        assert isinstance(self.data, (pyspark.sql.dataframe.DataFrame, chain)), (
+            f"`data` should be a pyspark or koalas DataFrame got {type(data)}"
+        )
         super().__init__()
 
     def read_records(self) -> Iterable[Any]:
@@ -145,24 +151,71 @@ class SparkWriter(BaseWriter):
         *,
         dtypes: Any = None,
         show_dtypes: bool = True,
+        schema: Any = None,
+        schema_overrides: Optional[dict] = None,
     ):
+        validate_schema(schema, schema_overrides, dtypes)
         self.dtypes = dtypes
         self.show_dtypes = show_dtypes
+        self.schema = schema
+        self.schema_overrides = schema_overrides or {}
 
         super().__init__()
 
     def consolidate(self, items: Iterable[Any]):
-        items = map(without_filename, flatten(items))
         spark = pyspark.sql.SparkSession.builder.enableHiveSupport().getOrCreate()
         rdd = (
             items
             if isinstance(items, pyspark.RDD)
-            else spark.sparkContext.parallelize(items)
+            else spark.sparkContext.parallelize(map(without_filename, flatten(items)))
         )
+        schema = self.dtypes
+        inferred = schema is None
         with spark_interpret_dicts_as_rows():
-            result = spark.createDataFrame(rdd, schema=self.dtypes)
+            # PySpark doesn't support inference with a partial schema, so we replicate
+            # the dtype inference mechanism to combine schema overrides with the
+            # schema inferred from the data
+            if self.schema is not None or self.schema_overrides:
+                schema = self.schema
+                if schema is None:
+                    schema = list(
+                        dict.fromkeys(name for row in rdd.take(100) for name in row)
+                    )
+                if isinstance(schema, str):
+                    schema = T._parse_datatype_string(schema)
+                inferred = isinstance(schema, list)
+                types = dict(self.schema_overrides)
+                if inferred:
+                    names = [name for name in schema if name not in types]
+                    # Columns with a dtype override must bypass inference, since
+                    # Spark cannot infer a dtype for a column containing only None
+                    if names:
+                        inferred_schema = spark._inferSchema(
+                            rdd.map(lambda row: {name: row.get(name) for name in names})
+                        )
+                        types.update(
+                            {field.name: field.dataType for field in inferred_schema}
+                        )
+                    inferred = self.schema is None or bool(names)
+                    schema = {name: types[name] for name in schema}
+                if isinstance(schema, dict):
+                    schema = T.StructType(
+                        [T.StructField(name, dtype) for name, dtype in schema.items()]
+                    )
+                validate_schema_overrides(schema.names, self.schema_overrides)
+                fields = [
+                    T.StructField(
+                        field.name,
+                        types.get(field.name, field.dataType),
+                        field.nullable,
+                        field.metadata,
+                    )
+                    for field in schema
+                ]
+                schema = T.StructType(fields) if fields else None
+            result = spark.createDataFrame(rdd, schema=schema)
 
-        if self.dtypes is None and self.show_dtypes:
+        if inferred and self.show_dtypes:
             schema_warning(result.schema)
 
         return result
@@ -175,6 +228,9 @@ def to_spark(
     dtypes: Any = None,
     show_dtypes: bool = True,
     execute: bool = True,
+    *,
+    schema: Optional[Union[list[str], dict, T.StructType, str]] = None,
+    schema_overrides: Optional[dict] = None,
     **kwargs,
 ):
     """
@@ -221,10 +277,16 @@ def to_spark(
     ----------
     data: Union[Any, Stream],
         The data to write (either a list of documents or a Stream).
-    dtypes: pyspark.sql.types.StructType
-        The schema to use for the DataFrame.
+    dtypes: Any
+        Deprecated, use schema instead
+    schema: Optional[Union[list[str], dict]]
+        Column names to keep or a mapping from column names to Spark dtypes
+        Spark StructType and DDL schemas are also accepted
+    schema_overrides: Optional[dict]
+        Column dtypes to change without filtering columns, taking precedence
+        over schema
     show_dtypes: bool
-        Whether to print the inferred schema (only if `dtypes` is None).
+        Whether to print the schema when column names or dtypes were inferred
     execute: bool
         Whether to execute the writing operation immediately or to return a stream
     converter: Optional[Union[str, Callable]]
@@ -241,5 +303,11 @@ def to_spark(
         data = data.map(converter, kwargs=kwargs)
 
     return data.write(
-        SparkWriter(dtypes=dtypes, show_dtypes=show_dtypes), execute=execute
+        SparkWriter(
+            dtypes=dtypes,
+            show_dtypes=show_dtypes,
+            schema=schema,
+            schema_overrides=schema_overrides,
+        ),
+        execute=execute,
     )

--- a/edsnlp/processing/spark.py
+++ b/edsnlp/processing/spark.py
@@ -44,7 +44,7 @@ def execute_spark_backend(
     import pyspark.sql.types as T
     from pyspark.sql import SparkSession
 
-    from edsnlp.utils.spark_dtypes import schema_warning, spark_interpret_dicts_as_rows
+    from edsnlp.utils.spark_dtypes import spark_interpret_dicts_as_rows
 
     try:
         getActiveSession = SparkSession.getActiveSession
@@ -153,12 +153,7 @@ def execute_spark_backend(
 
         if isinstance(writer, SparkWriter):
             rdd = df.rdd.mapPartitions(process_partition)
-            with spark_interpret_dicts_as_rows():
-                results = spark.createDataFrame(rdd, schema=writer.dtypes)
-
-            if writer.dtypes is None and writer.show_dtypes:
-                schema_warning(results.schema)
-            return results
+            return writer.consolidate(rdd)
 
         items = flatten_once(
             pickle.loads(item["content"])

--- a/edsnlp/utils/bindings.py
+++ b/edsnlp/utils/bindings.py
@@ -148,7 +148,7 @@ def validate_attributes(value: Union[SeqStr, Dict[str, SpanFilter]]) -> Attribut
         return new_value
     else:
         raise TypeError(
-            f"Invalid entry {value} ({type(value)}) for SpanSetterArg, "
+            f"Invalid entry {value} ({type(value)}) for Attributes, "
             f"expected bool/string(s), dict of bool/string(s) or callable"
         )
 

--- a/edsnlp/utils/spark_dtypes.py
+++ b/edsnlp/utils/spark_dtypes.py
@@ -67,7 +67,7 @@ def schema_warning(schema):
         "it to `edsnlp.data.to_spark` (and maybe fix it) to speed up the process "
         "and avoid surprises:\n"
         "import pyspark.sql.types as T\n"
-        "dtypes = " + PySparkPrettyPrinter().pformat(schema),
+        "schema = " + PySparkPrettyPrinter().pformat(schema),
         Warning,
     )
 
@@ -151,7 +151,7 @@ def spark_interpret_dicts_as_rows():
     # Replace the code object inside _infer_type
     # with a code object that has the same bytecode
     old_infer_type_code = _infer_type.__code__
-    old_infer_schema_code = _infer_type.__code__
+    old_infer_schema_code = _infer_schema.__code__
     old_infer_type_defaults = _infer_type.__defaults__
     old_infer_schema_defaults = _infer_schema.__defaults__
 
@@ -160,9 +160,10 @@ def spark_interpret_dicts_as_rows():
     _infer_type.__defaults__ = infer_type.__defaults__
     _infer_schema.__defaults__ = infer_schema.__defaults__
 
-    yield
-
-    _infer_type.__code__ = old_infer_type_code
-    _infer_schema.__code__ = old_infer_schema_code
-    _infer_type.__defaults__ = old_infer_type_defaults
-    _infer_schema.__defaults__ = old_infer_schema_defaults
+    try:
+        yield
+    finally:
+        _infer_type.__code__ = old_infer_type_code
+        _infer_schema.__code__ = old_infer_schema_code
+        _infer_type.__defaults__ = old_infer_type_defaults
+        _infer_schema.__defaults__ = old_infer_schema_defaults

--- a/edsnlp/utils/typing.py
+++ b/edsnlp/utils/typing.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Generic, List, TypeVar, Union
 
 import pydantic
 from confit import Validatable
-from confit.errors import patch_errors
+from confit.errors import ConfitValidationError
 from pydantic import BaseModel
 from pydantic.type_adapter import ConfigDict, TypeAdapter
 from pydantic_core import core_schema
@@ -37,9 +37,7 @@ class MetaAsList(type):
         try:
             return cast(List[cls.type_], value)
         except pydantic.ValidationError as e:
-            e = patch_errors(e, drop_names=("__root__",))
-            e.model = cls
-            raise e
+            raise ConfitValidationError.from_exception(e, source=cls)
 
     def __get_validators__(cls):
         yield cls.validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pysimstring>=1.2.1",
     "regex",
     "spacy>=3.8.7,<4",
-    "confit>=0.9.0",
+    "confit>=0.13.0.dev1",
     "tqdm",
     "umls-downloader>=0.1.1",
     "pandas>=1.4.0",
@@ -378,7 +378,7 @@ ignore-module = true
 ignore-nested-functions = true
 ignore-nested-classes = true
 ignore-setters = true
-fail-under = 40
+fail-under = 35
 exclude = ["setup.py", "docs", "build", "tests", "edsnlp/pipes/core/contextual_matcher/models.py"]
 verbose = 0
 quiet = false

--- a/tests/data/test_converters.py
+++ b/tests/data/test_converters.py
@@ -249,6 +249,14 @@ def test_callable_converter():
     assert get_dict2doc_converter(raw, {}) == (raw, {})
     assert get_doc2dict_converter(raw, {}) == (raw, {})
 
+    def converter(doc, schema: int = 1):
+        raise AssertionError("Validating options must not call the converter")
+
+    assert get_doc2dict_converter(converter, {"schema": "2"}) == (
+        converter,
+        {"schema": 2},
+    )
+
 
 def test_method_converter(blank_nlp):
     data = ["Ceci", "est", "un", "test"]
@@ -265,12 +273,10 @@ def test_converter_types(blank_nlp):
         def __init__(self, text):
             self.text = text
 
-    for converter in (blank_nlp.make_doc, Text, lambda x, k=2: Text(x)):
+    for converter in (blank_nlp.make_doc, lambda x, k=2: Text(x)):
         data = ["Ceci", "est", "un", "test"]
         texts = list(
-            edsnlp.data.from_iterable(data, converter=blank_nlp.make_doc).map(
-                lambda x: x.text
-            )
+            edsnlp.data.from_iterable(data, converter=converter).map(lambda x: x.text)
         )
         assert texts == data
 

--- a/tests/data/test_pandas.py
+++ b/tests/data/test_pandas.py
@@ -55,3 +55,35 @@ def test_read_shuffle_loop(num_cpu_workers: int):
         "subfolder/doc-1",
         "subfolder/doc-2",
     ]
+
+
+def test_dataframe_schema():
+    from confit import VisibleDeprecationWarning
+
+    rows = [{"text": "hello", "id": 1}]
+    frame = edsnlp.data.to_pandas(
+        rows, schema_overrides={"id": "Int32"}, execute=False
+    ).execute()
+    assert list(frame.columns) == ["text", "id"]
+    assert frame["id"].dtype == "Int32"
+
+    frame = edsnlp.data.to_pandas(
+        [{**rows[0], "discarded": None}], schema=["id", "text"]
+    )
+    assert list(frame.columns) == ["id", "text"]
+    for data in (rows, [], [{"id": None}]):
+        frame = edsnlp.data.to_pandas(
+            data,
+            schema=["missing", "id"],
+            schema_overrides={"missing": "Int32", "id": "Int32"},
+        )
+        assert list(frame.columns) == ["missing", "id"]
+        assert frame.astype(object).where(frame.notna(), None).to_dict("records") == [
+            {"missing": None, "id": row.get("id")} for row in data
+        ]
+    frame = edsnlp.data.to_pandas([], schema={"id": "Int32"})
+    assert list(frame.columns) == ["id"]
+    assert frame["id"].dtype == "Int32"
+    with pytest.warns(VisibleDeprecationWarning):
+        frame = edsnlp.data.to_pandas(rows, dtypes={"id": "Int32"})
+    assert list(frame.columns) == ["text", "id"]

--- a/tests/data/test_polars.py
+++ b/tests/data/test_polars.py
@@ -27,8 +27,10 @@ def test_read_write(blank_nlp, text, df_notes_pandas):
         converter="omop",
         span_attributes=["negation"],
         span_getter=["ents"],
+        schema_overrides={"note_id": polars.Int32},
     )
     res = writer.to_dicts()
+    assert writer.schema["note_id"] == polars.Int32
     assert len(res) == 20
     assert sum(len(r["entities"]) for r in res) == 20
 
@@ -54,3 +56,48 @@ def test_read_shuffle_loop(num_cpu_workers: int):
     notes_a = list(islice(notes_a, 6))
     notes_b = list(islice(notes_b, 6))
     assert notes_a == notes_b, "Shuffling with loop should yield the same results"
+
+
+def test_dataframe_schema():
+    from confit import VisibleDeprecationWarning
+
+    rows = [{"text": "hello", "id": 1}]
+    frame = edsnlp.data.to_polars(
+        rows, schema_overrides={"id": polars.Int32}, execute=False
+    ).execute()
+    assert list(frame.columns) == ["text", "id"]
+    assert frame["id"].dtype == polars.Int32
+
+    frame = edsnlp.data.to_polars(
+        [{**rows[0], "discarded": None}], schema=["id", "text"]
+    )
+    assert list(frame.columns) == ["id", "text"]
+    for data in (rows, [], [{"id": None}]):
+        frame = edsnlp.data.to_polars(
+            data,
+            schema=["missing", "id"],
+            schema_overrides={"missing": polars.Int32, "id": polars.Int32},
+        )
+        assert list(frame.columns) == ["missing", "id"]
+        assert frame.to_dicts() == [
+            {"missing": None, "id": row.get("id")} for row in data
+        ]
+    frame = edsnlp.data.to_polars([], schema={"id": polars.Int32})
+    assert list(frame.columns) == ["id"]
+    assert frame["id"].dtype == polars.Int32
+    with pytest.warns(VisibleDeprecationWarning):
+        frame = edsnlp.data.to_polars(rows, dtypes={"id": polars.Int32})
+    assert list(frame.columns) == ["id"]
+
+
+def test_schema_errors():
+    for kwargs in [
+        {"schema": []},
+        {"schema": ["id", "id"]},
+        {"schema": {"id": None}},
+        {"schema_overrides": {"id": None}},
+        {"schema_overrides": {"absent": polars.Int32}},
+        {"dtypes": {}, "schema": ["id"]},
+    ]:
+        with pytest.raises(ValueError):
+            edsnlp.data.to_polars([{"id": 1}], **kwargs)

--- a/tests/data/test_spark.py
+++ b/tests/data/test_spark.py
@@ -31,3 +31,81 @@ def test_read_write(blank_nlp, text, df_notes_pyspark):
     res = writer.toPandas().to_dict(orient="records")
     assert len(res) == 20
     assert sum(len(r["entities"]) for r in res) == 20
+
+
+def test_spark_schema():
+    from confit import VisibleDeprecationWarning
+    from pyspark.sql import SparkSession
+    from pyspark.sql import types as T
+
+    spark = SparkSession.builder.master("local[1]").getOrCreate()
+    schema = T.StructType(
+        [T.StructField("id", T.LongType(), False, {"source": "test"})]
+    )
+    rows = [{"id": 1, "text": "hello"}]
+    result = edsnlp.data.to_spark(
+        rows, schema=schema, schema_overrides={"id": T.IntegerType()}, show_dtypes=False
+    )
+    assert result.schema == T.StructType(
+        [T.StructField("id", T.IntegerType(), False, {"source": "test"})]
+    )
+    assert [row.asDict() for row in result.collect()] == [{"id": 1}]
+    result = (
+        edsnlp.data.from_spark(spark.createDataFrame(rows))
+        .set_processing(backend="spark")
+        .to_spark(
+            schema=["text", "id"],
+            schema_overrides={"id": T.IntegerType()},
+            show_dtypes=False,
+        )
+    )
+    assert result.columns == ["text", "id"]
+    assert result.schema["id"].dataType == T.IntegerType()
+    assert [row.asDict() for row in result.collect()] == rows
+    result = edsnlp.data.to_spark([], schema="id INT", show_dtypes=False)
+    assert result.columns == ["id"] and result.count() == 0
+    with pytest.warns(VisibleDeprecationWarning):
+        result = edsnlp.data.to_spark(
+            rows, dtypes=["renamed", "text"], show_dtypes=False
+        )
+    assert result.first().renamed == 1
+
+
+def test_dataframe_schema():
+    from confit import VisibleDeprecationWarning
+    from pyspark.sql import SparkSession
+    from pyspark.sql import types as T
+
+    SparkSession.builder.master("local[1]").getOrCreate()
+
+    rows = [{"text": "hello", "id": 1}]
+    frame = edsnlp.data.to_spark(
+        rows, schema_overrides={"id": T.IntegerType()}, execute=False
+    ).execute()
+    assert list(frame.columns) == ["text", "id"]
+    assert frame.schema["id"].dataType == T.IntegerType()
+
+    frame = edsnlp.data.to_spark(
+        [{"id": 1, "text": None, "discarded": None}, rows[0]],
+        schema=["id", "text"],
+    )
+    assert list(frame.columns) == ["id", "text"]
+    assert frame.schema["text"].dataType == T.StringType()
+    for data in (rows, [], [{"id": None}]):
+        frame = edsnlp.data.to_spark(
+            data,
+            schema=["missing", "id"],
+            schema_overrides={"missing": T.IntegerType(), "id": T.IntegerType()},
+        )
+        assert list(frame.columns) == ["missing", "id"]
+        assert [row.asDict() for row in frame.collect()] == [
+            {"missing": None, "id": row.get("id")} for row in data
+        ]
+    frame = edsnlp.data.to_spark([], schema={"id": T.IntegerType()})
+    assert list(frame.columns) == ["id"]
+    assert frame.schema["id"].dataType == T.IntegerType()
+    with pytest.warns(VisibleDeprecationWarning):
+        frame = edsnlp.data.to_spark(
+            rows, dtypes=T.StructType([T.StructField("id", T.IntegerType())])
+        )
+    assert list(frame.columns) == ["id"]

--- a/tests/training/test_train.py
+++ b/tests/training/test_train.py
@@ -1,5 +1,6 @@
 # ruff:noqa:E402
 import os.path
+import sys
 
 import pytest
 
@@ -129,6 +130,9 @@ def test_ner_qualif_train_diff_bert(run_in_test_dir, tmp_path):
 def test_ner_qualif_train_same_bert(run_in_test_dir, tmp_path):
     set_seed(42)
     config = Config.from_disk("ner_qlf_same_bert_config.yml")
+    # Aim is excluded from the test dependencies on Python 3.13 and later
+    if sys.version_info >= (3, 13):
+        config["train"]["logger"].remove("aim")
     shutil.rmtree(tmp_path, ignore_errors=True)
     kwargs = Config.resolve(config["train"], registry=registry, root=config)
     nlp = train(

--- a/tests/utils/test_spark_dtypes.py
+++ b/tests/utils/test_spark_dtypes.py
@@ -13,7 +13,7 @@ mytype = namedtuple("mytype", ["a", "b", "c", "z"])
 
 def test_infer_schema():
     from pyspark import Row
-    from pyspark.sql.types import StringType
+    from pyspark.sql.types import StringType, _infer_schema
 
     from edsnlp.utils.spark_dtypes import (
         PySparkPrettyPrinter,
@@ -124,3 +124,9 @@ def test_infer_schema():
 
         assert len(warned) == 1
         assert "The following schema was inferred" in warned[0].message.args[0]
+
+    # Native Spark inference keeps working after our dtype inference trick
+    assert _infer_schema({"id": 1}).simpleString() == "struct<id:bigint>"
+    with pytest.raises(TypeError), spark_interpret_dicts_as_rows():
+        infer_schema({"invalid": object()})
+    assert _infer_schema({"id": 1}).simpleString() == "struct<id:bigint>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Currently, when providing custom `dtypes` to `Stream.to_polars` method, it will internally call `pl.from_dicts(flatten(items), schema_overrides=dtypes)`

As such, the output will only contain keys from the provided `dtypes`. 
I believe a better behaviour would be that `dtypes` is used to provide *some* dtypes, thus overriding the type inference of the rest of the schema

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
