### PR TITLE
Change 'start' to 'begin' in converters.md

### DIFF
--- a/docs/data/converters.md
+++ b/docs/data/converters.md
@@ -165,7 +165,7 @@ the annotations should be stored in a JSON-like schema. We use the following sch
       "entity_id": 0,
       "label": "drug",
       "fragments": [{
-        "start": 0,
+        "begin": 0,
         "end": 10
       }],
       "attributes": {


### PR DESCRIPTION
Updated 'start' key to 'begin' in the converters documentation.
the standoff converter expects the "begin" key

