### PR TITLE
fix: extract and normalize two digits years by detecting next decade

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 ### Fixed
 
 - `eds.contextual_matcher` now checks `span_getter` in span-only `include` rules instead of rejecting every anchor
+- Correctly normalize two-digit years matched by `eds.dates`, allowing at most one year after the report date
 
 ## v0.22.0 (2026-06-17)
 

--- a/edsnlp/pipes/misc/dates/models.py
+++ b/edsnlp/pipes/misc/dates/models.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 from pandas._libs.tslibs.nattype import NaTType
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 from pytz import timezone
 from spacy.tokens import Span
 
@@ -16,6 +16,24 @@ def validator(x, allow_reuse=True, pre=False):
 
 def root_validator(allow_reuse=True, pre=False):
     return model_validator(mode="before" if pre else "after")
+
+
+def normalize_year(
+    year: int,
+    reference_year: Optional[int] = None,
+    threshold: int = 1,
+) -> int:
+    """
+    Expand a two-digit year up to a threshold after the reference year
+    """
+    if year >= 100:
+        return year
+
+    if reference_year is None:
+        reference_year = datetime.date.today().year
+    max_year = reference_year + threshold
+    expanded = max_year // 100 * 100 + year
+    return expanded if expanded <= max_year else expanded - 100
 
 
 class Direction(str, Enum):
@@ -212,12 +230,18 @@ class AbsoluteDate(BaseDate):
         return norm
 
     @validator("year")
-    def validate_year(cls, v):
-        if v > 100:
-            return v
-
-        if v < 25:
-            return 2000 + v
+    def validate_year(cls, v, info: ValidationInfo):
+        """
+        Expand two-digit years relative to the document date or current date
+        """
+        doc = info.data.get("doc")
+        note_datetime = doc._.note_datetime if doc is not None else None
+        reference_year = (
+            note_datetime.year
+            if note_datetime is not None and not isinstance(note_datetime, NaTType)
+            else None
+        )
+        return normalize_year(v, reference_year)
 
 
 class Relative(BaseDate):

--- a/edsnlp/pipes/misc/dates/normalizer.py
+++ b/edsnlp/pipes/misc/dates/normalizer.py
@@ -1,3 +1,4 @@
+import datetime
 import string
 from typing import List, cast
 
@@ -7,7 +8,7 @@ from spacy.tokens import Span
 from edsnlp import registry
 from edsnlp.core import PipelineProtocol
 from edsnlp.pipes.base import BaseComponent
-from edsnlp.pipes.misc.dates.models import AbsoluteDate
+from edsnlp.pipes.misc.dates.models import AbsoluteDate, normalize_year
 from edsnlp.utils.span_getters import SpanGetterArg, get_spans, validate_span_getter
 
 noun_regex = r"""(?xi)
@@ -123,7 +124,7 @@ class DatesNormalizer(BaseComponent):
             Span.set_extension("date_format", default=None)
 
     @staticmethod
-    def extract_date(s, next_date=None, next_offsets=None):
+    def extract_date(s, next_date=None, next_offsets=None, reference_year=None):
         date_conf = {}
 
         m = regex.search(full_regex, s)
@@ -131,7 +132,10 @@ class DatesNormalizer(BaseComponent):
             date = AbsoluteDate(
                 day=int(m.group("day").replace(" ", "").replace("Û", "0")),
                 month=int(m.group("month").replace(" ", "").replace("Û", "0")),
-                year=int(m.group("year").replace(" ", "").replace("Û", "0")),
+                year=normalize_year(
+                    int(m.group("year").replace(" ", "").replace("Û", "0")),
+                    reference_year,
+                ),
             )
             return date, sorted(
                 [
@@ -167,10 +171,8 @@ class DatesNormalizer(BaseComponent):
                     matches.append((match.start(), match.end(), "dmy", value))
             elif value <= 31:
                 matches.append((match.start(), match.end(), "dy", value))
-            elif value <= 40:
-                matches.append((match.start(), match.end(), "y", 2000 + value))
-            elif 40 < value < 100:
-                matches.append((match.start(), match.end(), "y", 1900 + value))
+            elif value < 100:
+                matches.append((match.start(), match.end(), "y", value))
             elif 1900 <= value <= 2100:
                 matches.append((match.start(), match.end(), "y", value))
             elif 1900 <= int(snippet[:4]) <= 2100:
@@ -267,7 +269,7 @@ class DatesNormalizer(BaseComponent):
             elif m[2] == "m":
                 date_conf["month"] = m[3]
             elif m[2] == "y":
-                date_conf["year"] = m[3]
+                date_conf["year"] = normalize_year(m[3], reference_year)
 
         date = cast(AbsoluteDate, date_conf)
 
@@ -313,6 +315,12 @@ class DatesNormalizer(BaseComponent):
 
     def __call__(self, doc):
         spans = list(get_spans(doc, self.span_getter))
+        note_datetime = doc._.note_datetime
+        reference_year = (
+            note_datetime.year
+            if note_datetime is not None
+            else datetime.date.today().year
+        )
         last_date = None
         last_date_offsets = None
         last_span = None
@@ -326,6 +334,7 @@ class DatesNormalizer(BaseComponent):
                 text,
                 last_date,
                 last_date_offsets,
+                reference_year,
             )
             span._.date = date
             span._.datetime = date.to_datetime(doc._.note_datetime)

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -155,6 +155,19 @@ def test_dates_component(blank_nlp: PipelineProtocol):
                 assert date.to_datetime(note_datetime=note_datetime)
 
 
+def test_two_digit_year_normalization(blank_nlp: PipelineProtocol):
+    cases = [
+        (None, "24/03/25 24/03/26 24/03/27", [2025, 2026, 2027]),
+        (datetime.datetime(2029, 1, 1), "24/03/30 24/03/31", [2030, 1931]),
+        (datetime.datetime(2010, 1, 1), "24/03/11 24/03/12", [2011, 1912]),
+    ]
+    for note_datetime, text, expected in cases:
+        doc = blank_nlp.make_doc(text)
+        doc._.note_datetime = note_datetime
+        doc = blank_nlp(doc)
+        assert [span._.date.year for span in doc.spans["dates"]] == expected
+
+
 def test_periods(blank_nlp: PipelineProtocol):
     period_examples = [
         "à partir de <ent>juin 2017 pendant trois semaines</ent>",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Fixes #520 

- Normalize two-digit years relative to the report date, falling back to the current date, with the next decade as the century cutoff

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
