### PR TITLE
fix: contextual_span_getter can now use both span_getter and regex in include/exclude

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@
 - Add a `banned_words` parameter to `eds.tnm` to configure the post-filter that drops lookalike abbreviations (`MTX`, `atom`, ...)
 - `TNM.norm()` no longer concatenates free-text suffixes verbatim, so `span.kb_id_` stays usable for grouping: only suffixes that read as a TNM qualifier are kept (`pT1(m)` → `pT1m`, whereas `pT1(grade 2)N1M0` used to normalise to `pT1grade 2N1M0`). The `o` → `0` coercion is likewise restricted to the numeric stage fields, so a suffix such as `(foie)` is no longer stored as `f0ie`
 
+### Fixed
+
+- `eds.contextual_matcher` now checks `span_getter` in span-only `include` rules instead of rejecting every anchor
+
 ## v0.22.0 (2026-06-17)
 
 ### Added

--- a/edsnlp/pipes/core/contextual_matcher/contextual_matcher.py
+++ b/edsnlp/pipes/core/contextual_matcher/contextual_matcher.py
@@ -133,7 +133,7 @@ class ContextualMatcher(BaseNERComponent):
             pattern.regex_matcher = regex_matcher
 
             for exclude in pattern.exclude:
-                if exclude.regex is not None:
+                if exclude.regex:
                     matcher = RegexMatcher(
                         attr=exclude.regex_attr or pattern.regex_attr or self.attr,
                         flags=exclude.regex_flags
@@ -147,7 +147,7 @@ class ContextualMatcher(BaseNERComponent):
                     exclude.regex_matcher = matcher
 
             for include in pattern.include:
-                if include.regex is not None:
+                if include.regex:
                     matcher = RegexMatcher(
                         attr=include.regex_attr or pattern.regex_attr or self.attr,
                         flags=include.regex_flags

--- a/tests/pipelines/core/test_contextual_matcher.py
+++ b/tests/pipelines/core/test_contextual_matcher.py
@@ -278,6 +278,47 @@ Tumeur mammaire benigne.
     assert ent._.assigned["size"]._.value.cm == 3
 
 
+@pytest.mark.parametrize(
+    "filter_name,filter_config,expected",
+    [
+        ("include", dict(span_getter="dates"), [["cancer"], [], ["cancer"]]),
+        ("exclude", dict(span_getter="dates"), [[], ["cancer"], []]),
+        (
+            "include",
+            dict(regex="patient", span_getter="dates"),
+            [["cancer"], [], []],
+        ),
+        (
+            "exclude",
+            dict(regex="patient", span_getter="dates"),
+            [[], [], []],
+        ),
+    ],
+)
+def test_contextual_matcher_filter_span_getter(filter_name, filter_config, expected):
+    nlp = edsnlp.blank("eds")
+    nlp.add_pipe(eds.sentences())
+    nlp.add_pipe(eds.dates())
+    nlp.add_pipe(
+        eds.contextual_matcher(
+            patterns=[
+                dict(
+                    regex="cancer",
+                    **{filter_name: filter_config},
+                )
+            ],
+            label="cancer",
+        )
+    )
+
+    texts = [
+        "Le patient a eu un cancer le 26/05/23",
+        "Le patient a eu un cancer sans date",
+        "cancer le 26/05/23",
+    ]
+    assert [[ent.text for ent in nlp(text).ents] for text in texts] == expected
+
+
 # Checks https://github.com/aphp/edsnlp/issues/394
 def test_contextual_matcher_exclude_outside():
     import edsnlp


### PR DESCRIPTION
## Description

- `eds.contextual_matcher` now checks `span_getter` in span-only `include` rules instead of rejecting every anchor

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
