### PR TITLE
fix: parse times with seconds correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 
 - `eds.contextual_matcher` now checks `span_getter` in span-only `include` rules instead of rejecting every anchor
 - Correctly normalize two-digit years matched by `eds.dates`, allowing at most one year after the report date
+- `eds.dates` now parses the hour correctly when a date and time include seconds and a minute from `00` to `23`
 - Restore Spark inference functions after successful and failed schema inference
 
 ## v0.22.0 (2026-06-17)

--- a/edsnlp/pipes/misc/dates/patterns/atomic/time.py
+++ b/edsnlp/pipes/misc/dates/patterns/atomic/time.py
@@ -9,7 +9,7 @@ lz_second_pattern = r"(?<!\d)(?P<second>0[0-9]|[1-5]\d)(?!\d)"
 
 # The time pattern is always optional
 time_pattern = (
-    r"(\s.{,3}"
+    r"(\s.{,3}?"
     + f"{hour_pattern}[h:]({lz_minute_pattern})?"
     + f"((:|m|min){lz_second_pattern})?"
     + ")?"

--- a/tests/pipelines/misc/test_dates.py
+++ b/tests/pipelines/misc/test_dates.py
@@ -193,6 +193,7 @@ def test_time(with_time: bool):
     if with_time:
         time_examples = [
             "Vu le <ent norm='2012-01-11 11h34m'>11/01/2012 à 11h34</ent> pour radio.",
+            "Vu le <ent norm='2012-01-11 18h'>11/01/2012 à 18:00:00</ent> pour radio.",
         ]
     else:
         time_examples = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- `eds.dates` now parses the hour correctly when a date and time include seconds and a minute from `00` to `23`

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
