### PR TITLE
Avoid backtracking in normalizer regexps, with large speedups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 - Correctly normalize two-digit years matched by `eds.dates`, allowing at most one year after the report date
 - `eds.dates` now parses the hour correctly when a date and time include seconds and a minute from `00` to `23`
 - Restore Spark inference functions after successful and failed schema inference
+- Reduce normalizer pollution regex backtracking on long lines, namely for information notices, biology tables, coding sections, footers and web addresses
 
 ## v0.22.0 (2026-06-17)
 

--- a/edsnlp/pipes/core/normalizer/pollution/patterns.py
+++ b/edsnlp/pipes/core/normalizer/pollution/patterns.py
@@ -1,7 +1,8 @@
 # noinspection SpellCheckingInspection
 information = [
     (
-        r"(?s)(=====+\s*)?(L\s*e\s*s\sdonnées\s*administratives,\s*sociales\s*|"
+        # Avoid retrying the optional separator from inside the same equals run
+        r"(?s)((?<![=])=====+\s*)?(L\s*e\s*s\sdonnées\s*administratives,\s*sociales\s*|"
         r"I?nfo\s*rmation\s*aux?\s*patients?|"
         r"L[’']AP-HP\s*collecte\s*vos\s*données\s*administratives|"
         r"L[’']Assistance\s*Publique\s*-\s*Hôpitaux\s*de\s*Paris\s*"
@@ -17,7 +18,10 @@ information = [
 bars = r"(?i)([nbw]|_|-|=){5,}"
 
 # Biology tables: Prone to false positive with disease names
-biology = r"(\b.*[|¦].*\n)+"
+# Word characters include superscript numbers and exclude combining marks
+word = r"[\p{L}\p{N}_]"
+# Scan each line once and exclude leading punctuation from the pollution span
+biology = rf"^[^\p{{L}}\p{{N}}_\n]*\K({word}[^\n|¦]*[|¦][^\n]*\n)+"
 
 # Leftside note with doctor names
 doctors = r"(?mi)(^((dr)|(pr))(\.|\s|of).*)+"
@@ -25,20 +29,30 @@ doctors = r"(?mi)(^((dr)|(pr))(\.|\s|of).*)+"
 # Mails or websites
 web = [
     r"(www\.\S*)",
-    r"(\S*@\S*)",
-    r"\S*\.(?:fr|com|net|org)",
+    r"(?<!\S)(\S*@\S*)",
+    r"(?<!\S)\S*\.(?:fr|com|net|org)",
 ]
 
 # Subsection with ICD-10 Codes
-coding = r".*? \(\d+\) [a-zA-Z]\d{2,4}.*?(\n|[a-zA-Z]\d{2,4})"
+# Resume at the previous match end for multiple coding sections on one line
+coding = r"(?:^|\G).*? \(\d+\) [a-zA-Z]\d{2,4}.*?(\n|[a-zA-Z]\d{2,4})"
 
 
 # New page
-date = r"\b\d\d/\d\d/\d\d\d\d\b"
+date = rf"(?<!{word})\d\d/\d\d/\d\d\d\d(?!{word})"
 ipp = r"80\d{8}"
-page = r"((^\d\/\d\s?)|(^\d\d?\/\d\d\?))"
-footer = rf"(?i)({page}.*\n?pat.*(ipp)?.*\n?(courrier valid.*)?)"
-footer += rf"|(.*{date}.*{ipp}.*)|(imprim.\sle\s{date}.*\d/\d.*\n?pat.*{date})"
+# Notice separators include Unicode whitespace and control separators
+space = r"[\s\x1c-\x1f]"
+page = rf"((^\d\/\d{space}?)|(^\d\d?\/\d\d\?))"
+# Footer words accept dotless i as a case variant
+footer = rf"(?i)({page}.*\n?pat.*\n?(courr[iı]er val[iı]d.*)?)"
+# The first date is sufficient to find an IPP later on the same line
+footer += rf"|((?:^|\G)(?>.*?{date}).*{ipp}.*)"
+# Commit to the first page number and prefer a patient line after the newline
+footer += (
+    rf"|((?:^|\G)(?>.*?\K[iı]mpr[iı]m.{space}le{space}{date})"
+    rf"(?>.*?\d/\d)(?:.*\npat.*{date}|(?>.*?pat).*{date}))"
+)
 
 # Word split in the middle due to line break
 intraword_split = r"(?<![\W\d_])-\n"

--- a/tests/pipelines/core/test_normalisation.py
+++ b/tests/pipelines/core/test_normalisation.py
@@ -1,10 +1,14 @@
+import re
+
 import pytest
 from pytest import fixture
+from spacy.tokens import Doc
 
 from edsnlp.matchers.utils import get_text
 from edsnlp.pipelines.core.normalizer.accents.patterns import accents
 from edsnlp.pipelines.core.normalizer.pollution.patterns import pollution
 from edsnlp.pipelines.core.normalizer.quotes.patterns import quotes_and_apostrophes
+from edsnlp.utils.regex_utils import compile_regex
 
 
 @fixture
@@ -123,3 +127,125 @@ def test_normalization_intraword_breaks(nlp_factory, lang):
     if lang != "eds":
         pytest.xfail("This test is expected to fail when EDS's language isn't used")
     assert norm == expected
+
+
+@pytest.mark.parametrize(
+    "name,text,expected",
+    [
+        (
+            "information",
+            "=====\nInformation aux patients https://recherche.aphp.fr/eds/droit-opposition",
+            [
+                "=====\nInformation aux patients https://recherche.aphp.fr/eds/droit-opposition"
+            ],
+        ),
+        (
+            "information",
+            "=== Information aux patients https://recherche.aphp.fr/eds/droit-opposition",
+            ["Information aux patients https://recherche.aphp.fr/eds/droit-opposition"],
+        ),
+        (
+            "biology",
+            "  !!!Na | 140\nK ¦ 4\n  CRP | 2\nConclusion",
+            ["Na | 140\nK ¦ 4\n", "CRP | 2\n"],
+        ),
+        ("biology", "|| Na\nNa | 140", []),
+        ("biology", "Na | 140\r\nK | 4\r\n", ["Na | 140\r\nK | 4\r\n"]),
+        ("biology", "¹ Na | 140\n\u0301K | 4\n", ["¹ Na | 140\n", "K | 4\n"]),
+        (
+            "coding",
+            "head (1) A12 x B34 tail (2) C56 x D78",
+            ["head (1) A12 x B34", " tail (2) C56 x D78"],
+        ),
+        (
+            "coding",
+            "head (1) A12\nNext (2) C56\n",
+            ["head (1) A12\n", "Next (2) C56\n"],
+        ),
+        ("coding", "head (1) A12", []),
+        (
+            "footer",
+            "1/2 heading\nPat exemple\nCourrier valide\nSuite",
+            ["1/2 heading\nPat exemple\nCourrier valide"],
+        ),
+        (
+            "footer",
+            "prefix 01/02/2020 x 03/04/2020 8012345678 suffix\nSuite",
+            ["prefix 01/02/2020 x 03/04/2020 8012345678 suffix"],
+        ),
+        ("footer", "8012345678 01/02/2020", []),
+        ("footer", "²01/02/2020 8012345678", []),
+        (
+            "footer",
+            "\u030101/02/2020\u0301 8012345678",
+            ["\u030101/02/2020\u0301 8012345678"],
+        ),
+        (
+            "footer",
+            "ımprımé\x1cle\x1f01/02/2020 1/2 pat 03/04/2020",
+            ["ımprımé\x1cle\x1f01/02/2020 1/2 pat 03/04/2020"],
+        ),
+        (
+            "footer",
+            "prefix imprimé le 01/02/2020 1/2\npat 03/04/2020 suffix",
+            ["imprimé le 01/02/2020 1/2\npat 03/04/2020"],
+        ),
+        (
+            "footer",
+            "imprimé le 01/02/2020 1/2 pat 03/04/2020\npat 05/06/2020",
+            ["imprimé le 01/02/2020 1/2 pat 03/04/2020\npat 05/06/2020"],
+        ),
+        (
+            "footer",
+            "imprimé le 01/02/2020 1/2 pat 03/04/2020\npat sans date",
+            ["imprimé le 01/02/2020 1/2 pat 03/04/2020"],
+        ),
+        (
+            "footer",
+            "prefix imprimé\nle\n01/02/2020 1/2 pat 03/04/2020 suffix",
+            ["imprimé\nle\n01/02/2020 1/2 pat 03/04/2020"],
+        ),
+        (
+            "web",
+            "x@y@z.fr next user@example.org",
+            ["x@y@z.fr", "user@example.org", "x@y@z.fr", "user@example.org"],
+        ),
+        ("web", "x.fr.comsuffix\nexample.org", ["x.fr.com", "example.org"]),
+    ],
+)
+def test_pollution_spans(name, text, expected):
+    patterns = pollution[name]
+    patterns = patterns if isinstance(patterns, list) else [patterns]
+    assert [
+        match.group()
+        for pattern in patterns
+        for match in compile_regex(pattern, re.MULTILINE).finditer(text)
+    ] == expected
+
+
+@pytest.mark.timeout(10)
+@pytest.mark.parametrize(
+    "text",
+    [
+        pytest.param("Ò** lmÍ6AÓ" * 10000, id="reported"),
+        pytest.param("X" * 100000, id="no-spaces"),
+        pytest.param("8012345678 " + "01/02/2020 " * 10000, id="dates-after-ipp"),
+        pytest.param("imprimé le 01/02/2020 " * 5000, id="incomplete-footers"),
+    ],
+)
+def test_normalization_long_line(nlp_factory, text):
+    nlp = nlp_factory(p=True)
+    doc = nlp(text)
+    assert not doc.spans["pollutions"]
+    assert not any(token._.excluded for token in doc)
+
+
+@pytest.mark.timeout(10)
+def test_normalization_separator_line(nlp_factory):
+    # Use a tokenized document to isolate pollution matching from tokenization
+    nlp = nlp_factory(p=True)
+    doc = nlp(Doc(nlp.vocab, words=["=" * 100000], spaces=[False]))
+    assert [(span.label_, span.text) for span in doc.spans["pollutions"]] == [
+        ("bars", doc.text)
+    ]
+    assert all(token._.excluded for token in doc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Reduce normalizer pollution regex backtracking on long lines, namely for information notices, biology tables, coding sections, footers and web addresses

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
